### PR TITLE
Remove time and distance limits on AED-X

### DIFF
--- a/addons/circulation/functions/fnc_treatmentAdvanced_X.sqf
+++ b/addons/circulation/functions/fnc_treatmentAdvanced_X.sqf
@@ -61,28 +61,6 @@ private _string = "HR: %1 RR: %2/%3 SpO2: %4";
 
 }, 1, [_string, _target]] call CBA_fnc_addPerFrameHandler;
 
-// 300 sec is maximum for monitoring, then you have to connect it again. It's more something that you can't forget to remove it.
-// disconnect the x-series
-[{
-    params ["_player", "_target"];
-    (_target distance2D _player) > 30;
-}, {
-    params ["_player", "_target"];
-    _target setVariable [QGVAR(X), false, true];
-    private _output = localize LSTRING(X_Action_Remove);
-    [_output, 1.5, _player] call ace_common_fnc_displayTextStructured;
-    _target setVariable [QGVAR(X), false, true];
-    _player setVariable [QGVAR(use), false, true];
-    [_player, _target] call FUNC(returnAED_X);
-}, [_player, _target], 300, {
-    params ["_player", "_target"];
-    _target setVariable [QGVAR(X), false, true];
-    private _output = localize LSTRING(X_Action_Remove);
-    [_output, 1.5, _player] call ace_common_fnc_displayTextStructured;
-    _target setVariable [QGVAR(X), false, true];
-    _player setVariable [QGVAR(use), false, true];
-    [_player, _target] call FUNC(returnAED_X);
-}] call CBA_fnc_waitUntilAndExecute;
 
 // spawns the heart rate beep.
 [_target, _player] spawn {


### PR DESCRIPTION
Given that we now remove the AED-X from the medic's inventory it shouldn't be necessary to set a timeout for the AED-X or a distance limit.