### PR TITLE
Changed medical level requiered to None for IV

### DIFF
--- a/addons/pharma/XEH_preInit.sqf
+++ b/addons/pharma/XEH_preInit.sqf
@@ -61,7 +61,7 @@ PREP_RECOMPILE_END;
     "LIST",
     [LLSTRING(IV_MEDIC)],
     "KAT - ADV Medical: Pharmacy",
-    [[0, 1, 2], ["Anyone", "Medics", "Doctors"], 2],
+    [[0, 1, 2], ["Anyone", "Medics", "Doctors"], 0],
     true
 ] call CBA_Settings_fnc_init;
 


### PR DESCRIPTION
The default value should be None so people won't be false-reporting issues where it is not working for them due to the wrong medical settings. Units that want to increase the medical level will have an option to do so.