### PR TITLE
change shockable state - removed check for ACE_isUnconscious

### DIFF
--- a/addons/zeus/functions/fnc_ui_changeAsystole.sqf
+++ b/addons/zeus/functions/fnc_ui_changeAsystole.sqf
@@ -42,9 +42,6 @@ switch (false) do {
     case (_unit isKindOf "CAManBase"): {
         [LSTRING(OnlyInfantry)] call _fnc_error;
     };
-    case !(_unit getVariable ["ACE_isUnconscious", false]): {
-        [LSTRING(NotUnconscious)] call _fnc_error;
-    };
 };
 
 private _fnc_onUnload = {


### PR DESCRIPTION
-removed check for ACE_isUnconscious due to sometimes ACE is handling unconsciousness in a strange way and when using this module on the conscious unit it has no effect anyway, so it will resolve the issue of sometimes being unable to use it.
