### PR TITLE
Add Require inserted IV/IO addon option

### DIFF
--- a/addons/pharma/ACE_Medical_Treatment_Actions.hpp
+++ b/addons/pharma/ACE_Medical_Treatment_Actions.hpp
@@ -10,7 +10,7 @@ class ACE_Medical_Treatment_Actions {
     class BloodIV: BasicBandage {
         allowedSelections[] = {"Body", "LeftArm", "RightArm", "LeftLeg", "RightLeg"};
         medicRequired = QUOTE(ace_medical_medicIV);
-        condition = QUOTE((_patient getVariable [ARR_2(QQGVAR(IVplaced), true)]) && FUNC(removeIV));
+        condition = QUOTE(((_patient getVariable [ARR_2(QQGVAR(IVplaced), true)]) && FUNC(removeIV)) || !(GVAR(RequireInsIV)));
     };
     class Painkillers: Morphine {
         displayName = CSTRING(Inject_Box_Painkillers);

--- a/addons/pharma/XEH_preInit.sqf
+++ b/addons/pharma/XEH_preInit.sqf
@@ -47,6 +47,16 @@ PREP_RECOMPILE_END;
     true
 ] call CBA_Settings_fnc_init;
 
+//Require inserted IV for using saline/blood/plasma?
+[
+    QGVAR(RequireInsIV),
+    "CHECKBOX",
+    [LLSTRING(SETTING_REQUIRE_INS_IV),LLSTRING(SETTING_REQUIRE_INS_IV_DESC)],
+    "KAT - ADV Medical: Pharmacy",
+    [true],
+    true
+] call CBA_Settings_fnc_init;
+
 [
     QGVAR(IVreuse),
     "CHECKBOX",

--- a/addons/pharma/stringtable.xml
+++ b/addons/pharma/stringtable.xml
@@ -916,7 +916,7 @@
             <Polish>Wymagaj włożonego IV/IO</Polish>
             <French>Exiger l'insertion d'IV/IO</French>
             <Chinese>需要插入 IV/IO</Chinese>
-            <Italian>Richiede inserito IV/IO</Italian>
+            <Italian>Richiesto inserimento IV/IO</Italian>
             <Spanish>Requiere inserción IV/IO</Spanish>
             <Korean>삽입된 IV/IO 필요</Korean>
             <Turkish>Takılı IV/IO gerektir</Turkish>
@@ -930,7 +930,7 @@
             <Spanish>Verdadero predeterminado. Si es verdadero, primero deberá insertar IV/IO antes de poder administrarle a alguien solución salina/sangre/plasma.\n Si es falso, conserva el comportamiento estándar de ACE para usar solución salina/sangre/plasma.</Spanish>
             <French>Vrai par défaut. Si vrai, vous devrez d'abord insérer IV/IO avant de pouvoir donner à quelqu'un une solution saline/sang/plasma.\n Si faux, il conserve le comportement ACE standard pour l'utilisation de solution saline/sang/plasma.</French>
             <Turkish>Varsayılan doğru. Doğruysa, birine salin/kan/plazma vermeden önce IV/IO eklemeniz gerekir.\n Yanlışsa, salin/kan/plazma kullanımı için standart ACE davranışını korur.</Turkish>
-            <Italian>Predefinito vero. Se vero, dovrai prima inserire IV/IO prima di poter somministrare a qualcuno soluzione salina/sangue/plasma.\n Se falso, mantiene il comportamento ACE standard per l'uso di soluzione salina/sangue/plasma.</Italian>
+            <Italian>Predefinito vero. Se è vero, dovrai prima inserire l'IV/IO per poter somministrare a qualcuno soluzione salina/sangue/plasma. \nSe falso, mantiene il comportamento ACE standard per l'utilizzo di soluzione salina/sangue/plasma.</Italian>
             <Chinese>默认为真。 如果为 true，您需要先插入 IV/IO，然后才能给某人注射盐水/血液/血浆。\n 如果为 false，它保留使用盐水/血液/血浆的标准 ACE 行为。</Chinese>
             <Korean>기본값은 참입니다. 참이면 염수/혈액/혈장을 제공하기 전에 먼저 IV/IO를 삽입해야 합니다.\n 거짓이면 염수/혈액/혈장 사용에 대한 표준 ACE 동작을 유지합니다.</Korean>
             <Czech>Výchozí povoleno. Pokud je povoleno, budete muset nejprve vložit IV/IO, než budete moci někomu podat fyziologický roztok/krev/plazmu.\n Pokud je zakázano, zachová standardní chování ACE pro použití fyziologického roztoku/krve/plazmy.</Czech>

--- a/addons/pharma/stringtable.xml
+++ b/addons/pharma/stringtable.xml
@@ -914,7 +914,7 @@
             <English>Require inserted IV/IO</English>
 			<German>Erfordert eingefügtes IV/IO</German>
             <Polish>Wymagaj włożonego IV/IO</Polish>
-            <French>Exiger l'insertion d'IV/IO</French>
+            <French>IV/IO posée requise</French>
             <Chinese>需要插入 IV/IO</Chinese>
             <Italian>Richiesto inserimento IV/IO</Italian>
             <Spanish>Requiere inserción IV/IO</Spanish>
@@ -928,7 +928,7 @@
 			<German>Standardeinstellung wahr. Wenn wahr, müssen Sie zuerst eine IV/IO einführen, bevor Sie jemandem Kochsalzlösung/Blut/Plasma geben können.\n Wenn falsch, behält es das Standard-ACE-Verhalten für die Verwendung von Kochsalzlösung/Blut/Plasma bei.</German>
             <Polish>Domyślnie włączone. Jeśli włączone, należy najpierw umieścić IV/IO przed podaniem płynów. \nJeśli wyłączone, mechanika będzie taka sama jak w ACE przy podawaniu soli fizjologicznej/krwi/osocza.</Polish>
             <Spanish>Verdadero predeterminado. Si es verdadero, primero deberá insertar IV/IO antes de poder administrarle a alguien solución salina/sangre/plasma.\n Si es falso, conserva el comportamiento estándar de ACE para usar solución salina/sangre/plasma.</Spanish>
-            <French>Vrai par défaut. Si vrai, vous devrez d'abord insérer IV/IO avant de pouvoir donner à quelqu'un une solution saline/sang/plasma.\n Si faux, il conserve le comportement ACE standard pour l'utilisation de solution saline/sang/plasma.</French>
+            <French>Par défaut activé. Si activé, vous avez besoin de poser une IV/IO avant de pouvoir administrer de la saline/sang/plasma.\n Si désactivé, le comportement standard de ACE pour l'usage de saline/sang plasma est utilisé.</French>
             <Turkish>Varsayılan doğru. Doğruysa, birine salin/kan/plazma vermeden önce IV/IO eklemeniz gerekir.\n Yanlışsa, salin/kan/plazma kullanımı için standart ACE davranışını korur.</Turkish>
             <Italian>Predefinito vero. Se è vero, dovrai prima inserire l'IV/IO per poter somministrare a qualcuno soluzione salina/sangue/plasma. \nSe falso, mantiene il comportamento ACE standard per l'utilizzo di soluzione salina/sangue/plasma.</Italian>
             <Chinese>默认为真。 如果为 true，您需要先插入 IV/IO，然后才能给某人注射盐水/血液/血浆。\n 如果为 false，它保留使用盐水/血液/血浆的标准 ACE 行为。</Chinese>

--- a/addons/pharma/stringtable.xml
+++ b/addons/pharma/stringtable.xml
@@ -917,7 +917,7 @@
             <French>IV/IO posée requise</French>
             <Chinese>需要插入 IV/IO</Chinese>
             <Italian>Richiesto inserimento IV/IO</Italian>
-            <Spanish>Requiere inserción IV/IO</Spanish>
+            <Spanish>Requiere poner un IV/IO</Spanish>
             <Korean>삽입된 IV/IO 필요</Korean>
             <Turkish>Takılı IV/IO gerektir</Turkish>
             <Czech>Vyžadování vložení IV/IO</Czech>
@@ -927,7 +927,7 @@
             <English>Default true. If true, you will need to insert IV/IO first before being able to give someone saline/blood/plasma.\n If false, it retains standard ACE behaviour for using saline/blood/plasma.</English>
 			<German>Standardeinstellung wahr. Wenn wahr, müssen Sie zuerst eine IV/IO einführen, bevor Sie jemandem Kochsalzlösung/Blut/Plasma geben können.\n Wenn falsch, behält es das Standard-ACE-Verhalten für die Verwendung von Kochsalzlösung/Blut/Plasma bei.</German>
             <Polish>Domyślnie włączone. Jeśli włączone, należy najpierw umieścić IV/IO przed podaniem płynów. \nJeśli wyłączone, mechanika będzie taka sama jak w ACE przy podawaniu soli fizjologicznej/krwi/osocza.</Polish>
-            <Spanish>Verdadero predeterminado. Si es verdadero, primero deberá insertar IV/IO antes de poder administrarle a alguien solución salina/sangre/plasma.\n Si es falso, conserva el comportamiento estándar de ACE para usar solución salina/sangre/plasma.</Spanish>
+            <Spanish>True como valor por defecto. Si es true se necesitará poner un IV/IO primero antes de poder aplicar salino/sangre/plasma. \n Si es falso, se mantiene el funcionamiento de ACE para aplicar salino/sangre/plasma.</Spanish>
             <French>Par défaut activé. Si activé, vous avez besoin de poser une IV/IO avant de pouvoir administrer de la saline/sang/plasma.\n Si désactivé, le comportement standard de ACE pour l'usage de saline/sang plasma est utilisé.</French>
             <Turkish>Varsayılan doğru. Doğruysa, birine salin/kan/plazma vermeden önce IV/IO eklemeniz gerekir.\n Yanlışsa, salin/kan/plazma kullanımı için standart ACE davranışını korur.</Turkish>
             <Italian>Predefinito vero. Se è vero, dovrai prima inserire l'IV/IO per poter somministrare a qualcuno soluzione salina/sangue/plasma. \nSe falso, mantiene il comportamento ACE standard per l'utilizzo di soluzione salina/sangue/plasma.</Italian>

--- a/addons/pharma/stringtable.xml
+++ b/addons/pharma/stringtable.xml
@@ -910,6 +910,31 @@
             <Turkish>% 1 artık boş</Turkish>
             <Italian>%1 è vuota</Italian>
             <Japanese>%1は空になりました</Japanese>
+			<Key ID="STR_kat_pharma_SETTING_REQUIRE_INS_IV">
+            <English>Require inserted IV/IO</English>
+			<German>Erfordert eingefügtes IV/IO</German>
+            <Polish>Wymagaj włożonego IV/IO</Polish>
+            <French>Exiger l'insertion d'IV/IO</French>
+            <Chinese>需要插入 IV/IO</Chinese>
+            <Italian>Richiede inserito IV/IO</Italian>
+            <Spanish>Requiere inserción IV/IO</Spanish>
+            <Korean>삽입된 IV/IO 필요</Korean>
+            <Turkish>Takılı IV/IO gerektir</Turkish>
+            <Czech>Vyžadování vložení IV/IO</Czech>
+            <Japanese>輸液にIV/IO挿管を要求しますか</Japanese>
+        </Key>
+        <Key ID="STR_kat_pharma_SETTING_REQUIRE_INS_IV_DESC">
+            <English>Default true. If true, you will need to insert IV/IO first before being able to give someone saline/blood/plasma.\n If false, it retains standard ACE behaviour for using saline/blood/plasma.</English>
+			<German>Standardeinstellung wahr. Wenn wahr, müssen Sie zuerst eine IV/IO einführen, bevor Sie jemandem Kochsalzlösung/Blut/Plasma geben können.\n Wenn falsch, behält es das Standard-ACE-Verhalten für die Verwendung von Kochsalzlösung/Blut/Plasma bei.</German>
+            <Polish>Domyślnie włączone. Jeśli włączone, należy najpierw umieścić IV/IO przed podaniem płynów. \nJeśli wyłączone, mechanika będzie taka sama jak w ACE przy podawaniu soli fizjologicznej/krwi/osocza.</Polish>
+            <Spanish>Verdadero predeterminado. Si es verdadero, primero deberá insertar IV/IO antes de poder administrarle a alguien solución salina/sangre/plasma.\n Si es falso, conserva el comportamiento estándar de ACE para usar solución salina/sangre/plasma.</Spanish>
+            <French>Vrai par défaut. Si vrai, vous devrez d'abord insérer IV/IO avant de pouvoir donner à quelqu'un une solution saline/sang/plasma.\n Si faux, il conserve le comportement ACE standard pour l'utilisation de solution saline/sang/plasma.</French>
+            <Turkish>Varsayılan doğru. Doğruysa, birine salin/kan/plazma vermeden önce IV/IO eklemeniz gerekir.\n Yanlışsa, salin/kan/plazma kullanımı için standart ACE davranışını korur.</Turkish>
+            <Italian>Predefinito vero. Se vero, dovrai prima inserire IV/IO prima di poter somministrare a qualcuno soluzione salina/sangue/plasma.\n Se falso, mantiene il comportamento ACE standard per l'uso di soluzione salina/sangue/plasma.</Italian>
+            <Chinese>默认为真。 如果为 true，您需要先插入 IV/IO，然后才能给某人注射盐水/血液/血浆。\n 如果为 false，它保留使用盐水/血液/血浆的标准 ACE 行为。</Chinese>
+            <Korean>기본값은 참입니다. 참이면 염수/혈액/혈장을 제공하기 전에 먼저 IV/IO를 삽입해야 합니다.\n 거짓이면 염수/혈액/혈장 사용에 대한 표준 ACE 동작을 유지합니다.</Korean>
+            <Czech>Výchozí povoleno. Pokud je povoleno, budete muset nejprve vložit IV/IO, než budete moci někomu podat fyziologický roztok/krev/plazmu.\n Pokud je zakázano, zachová standardní chování ACE pro použití fyziologického roztoku/krve/plazmy.</Czech>
+            <Japanese>KATデフォルトではtrueです。trueの場合、輸液を行う前にIV/IOを挿管する必要があります。\nfalseの場合はACEデフォルトの動作を保持します。つまり、生理食塩水/血液/血しょうパックだけで輸液可能になります。</Japanese>
         </Key>
     </Package>
 </Project>


### PR DESCRIPTION
Adds Require inserted IV/IO addon option.

Default true. If true, you will need to insert IV/IO first before being able to give someone saline/blood/plasma.\n If false, it retains standard ACE behaviour for using saline/blood/plasma.