### PR TITLE
Show pneumothorax duplicate option

### DIFF
--- a/addons/airway/functions/fnc_updateInjuryList.sqf
+++ b/addons/airway/functions/fnc_updateInjuryList.sqf
@@ -151,7 +151,7 @@ if (_target getVariable [QGVAR(overstretch), false] && _selectionN isEqualTo 0) 
 };
 
 private _tensionhemothorax = false;
-if (!(kat_breathing_showPneumothorax_dupe)) {
+if (!(kat_breathing_showPneumothorax_dupe)) then {
     if ((_target getVariable ["KAT_medical_tensionpneumothorax", false]) || (_target getVariable ["KAT_medical_hemopneumothorax", false])) then {
             _tensionhemothorax = true;
     };

--- a/addons/airway/functions/fnc_updateInjuryList.sqf
+++ b/addons/airway/functions/fnc_updateInjuryList.sqf
@@ -151,10 +151,11 @@ if (_target getVariable [QGVAR(overstretch), false] && _selectionN isEqualTo 0) 
 };
 
 private _tensionhemothorax = false;
-
-if ((_target getVariable ["KAT_medical_tensionpneumothorax", false]) || (_target getVariable ["KAT_medical_hemopneumothorax", false])) then {
-        _tensionhemothorax = true;
-};
+if (!(kat_breathing_showPneumothorax_dupe)) {
+    if ((_target getVariable ["KAT_medical_tensionpneumothorax", false]) || (_target getVariable ["KAT_medical_hemopneumothorax", false])) then {
+            _tensionhemothorax = true;
+    };
+}
 
 if (_target getVariable ["KAT_medical_pneumothorax", false] && _selectionN isEqualTo 1 && !(kat_breathing_pneumothorax_hardcore) && !(_tensionhemothorax)) then {
     _woundEntries pushback [localize ELSTRING(breathing,pneumothorax_mm), [1,1,1,1]];

--- a/addons/airway/functions/fnc_updateInjuryList.sqf
+++ b/addons/airway/functions/fnc_updateInjuryList.sqf
@@ -155,7 +155,7 @@ if (!(kat_breathing_showPneumothorax_dupe)) {
     if ((_target getVariable ["KAT_medical_tensionpneumothorax", false]) || (_target getVariable ["KAT_medical_hemopneumothorax", false])) then {
             _tensionhemothorax = true;
     };
-}
+};
 
 if (_target getVariable ["KAT_medical_pneumothorax", false] && _selectionN isEqualTo 1 && !(kat_breathing_pneumothorax_hardcore) && !(_tensionhemothorax)) then {
     _woundEntries pushback [localize ELSTRING(breathing,pneumothorax_mm), [1,1,1,1]];

--- a/addons/breathing/XEH_preInit.sqf
+++ b/addons/breathing/XEH_preInit.sqf
@@ -191,4 +191,14 @@ PREP_RECOMPILE_END;
 ] call CBA_Settings_fnc_init;
 */
 
+// Default is disabled. If enabled, units with tension pneumothorax or hemopneumothorax will also have pneumothorax injury displayed in medical menu.
+[
+    QGVAR(showPneumothorax_dupe),
+    "CHECKBOX",
+    [LLSTRING(showPneumothorax_dupe),LLSTRING(showPneumothorax_dupe_DESC)],
+    CBA_SETTINGS_CAT,
+    [false],
+    true
+] call CBA_Settings_fnc_init;
+
 ADDON = true;

--- a/addons/breathing/stringtable.xml
+++ b/addons/breathing/stringtable.xml
@@ -755,6 +755,7 @@
         <Key ID="STR_kat_breathing_showPneumothorax_dupe">
             <English>Show pneumothorax duplicate</English>
             <Czech>Ukázat duplikát pneumotoraxu</Czech>
+            <German>Pneumothorax dupliziert anzeigen</German>
         </Key>
         <Key ID="STR_kat_breathing_showPneumothorax_dupe_DESC">
             <English>Default is disabled. If enabled, units with tension pneumothorax or hemopneumothorax will also have pneumothorax injury displayed in medical menu.</English>

--- a/addons/breathing/stringtable.xml
+++ b/addons/breathing/stringtable.xml
@@ -752,5 +752,13 @@
             <Italian>Valore di SpO2 sotto il quale causa la perdita di coscienza</Italian>
             <Japanese>SpO2(血中酸素濃度)が設定した値を下回ると気絶し、無意識状態に陥ります。</Japanese>
         </Key>
+        <Key ID="STR_kat_breathing_showPneumothorax_dupe">
+            <English>Show pneumothorax duplicate</English>
+            <Czech>Ukázat duplikát pneumotoraxu</Czech>
+        </Key>
+        <Key ID="STR_kat_breathing_showPneumothorax_dupe_DESC">
+            <English>Default is disabled. If enabled, units with tension pneumothorax or hemopneumothorax will also have pneumothorax injury displayed in medical menu.</English>
+            <Czech>Výchozí nastavení zakázáno. Pokud povoleno, jednotky s tenzním pneumotoraxem a nebo hemopneumotoraxem budou mít též zranění pneumotorax ukázán ve zdravotnické nabídce.</Czech>
+        </Key>
     </Package>
 </Project>

--- a/addons/breathing/stringtable.xml
+++ b/addons/breathing/stringtable.xml
@@ -760,6 +760,7 @@
         <Key ID="STR_kat_breathing_showPneumothorax_dupe_DESC">
             <English>Default is disabled. If enabled, units with tension pneumothorax or hemopneumothorax will also have pneumothorax injury displayed in medical menu.</English>
             <Czech>Výchozí nastavení zakázáno. Pokud povoleno, jednotky s tenzním pneumotoraxem a nebo hemopneumotoraxem budou mít též zranění pneumotorax ukázán ve zdravotnické nabídce.</Czech>
+            <German>Standardmäßig ist diese Option deaktiviert. Wenn aktiviert, wird bei Einheiten mit Spannungspneumothorax oder Hämopneumothorax auch die Pneumothorax-Verletzung im medizinischen Menü angezeigt.</German>
         </Key>
     </Package>
 </Project>


### PR DESCRIPTION
-adds Show pneumothorax duplicate. Default is disabled. If enabled, units with tension pneumothorax or hemopneumothorax will also have pneumothorax injury displayed in medical menu. Some people requested this option when I have fixed this "bug", but apparently it was a feature.