### PR TITLE
Change default medical level requirement to Anyone

### DIFF
--- a/addons/airway/XEH_preInit.sqf
+++ b/addons/airway/XEH_preInit.sqf
@@ -84,7 +84,7 @@ In real life, this will happen sometimes, not quiet often.
     "LIST",
     [LLSTRING(ALLOW_LARYNXTUBUS),LLSTRING(ALLOW_LARYNXTUBUS_DESC)],
     CBA_SETTINGS_CAT,
-    [[0, 1, 2], ["Anyone", "Medics", "Doctors"], 1],
+    [[0, 1, 2], ["Anyone", "Medics", "Doctors"], 0],
     true
 ] call CBA_settings_fnc_init;
 
@@ -104,7 +104,7 @@ In real life, this will happen sometimes, not quiet often.
     "LIST",
     [LLSTRING(ALLOW_ACCUVAC),LLSTRING(ALLOW_ACCUVAC_DESC)],
     CBA_SETTINGS_CAT,
-    [[0, 1, 2], ["Anyone", "Medics", "Doctors"], 1],
+    [[0, 1, 2], ["Anyone", "Medics", "Doctors"], 0],
     true
 ] call CBA_settings_fnc_init;
 

--- a/addons/breathing/XEH_preInit.sqf
+++ b/addons/breathing/XEH_preInit.sqf
@@ -115,7 +115,7 @@ PREP_RECOMPILE_END;
     "LIST",
     [LLSTRING(ALLOW_CHESTSEAL), LLSTRING(TRAININGLEVEL_CHESTSEAL)],
     CBA_SETTINGS_CAT,
-    [[0, 1, 2], ["Anyone", "Medics", "Doctors"], 1],
+    [[0, 1, 2], ["Anyone", "Medics", "Doctors"], 0],
     true
 ] call CBA_settings_fnc_init;
 
@@ -145,7 +145,7 @@ PREP_RECOMPILE_END;
     "LIST",
     [LLSTRING(HEMOPNEUMOTHORAX_TREATMENT_LEVEL), LLSTRING(HEMOPNEUMOTHORAX_TREATMENT_LEVEL_DESCRIPTION)],
     CBA_SETTINGS_CAT,
-    [[0, 1, 2], ["Anyone", "Medics", "Doctors"], 1],
+    [[0, 1, 2], ["Anyone", "Medics", "Doctors"], 0],
     true
 ] call CBA_settings_fnc_init;
 
@@ -195,7 +195,7 @@ PREP_RECOMPILE_END;
     "LIST",
     [LLSTRING(CYANOSIS_TREATMENT_LEVEL), LLSTRING(CYANOSIS_TREATMENT_LEVEL_DESCRIPTION)],
     CBA_SETTINGS_CAT,
-    [[0, 1, 2], ["Anyone", "Medics", "Doctors"], 1],
+    [[0, 1, 2], ["Anyone", "Medics", "Doctors"], 0],
     true
 ] call CBA_settings_fnc_init;
 


### PR DESCRIPTION
- Change default medical level requirement to Anyone to avoid unnecessary questions, false bug reports and so on.
