### PR TITLE
Translation - Japanese Translation Recovery Position Update

### DIFF
--- a/addons/airway/stringtable.xml
+++ b/addons/airway/stringtable.xml
@@ -27,7 +27,7 @@
             <Turkish>ACE-Havayolu yaralanmaları aktive edildi mi?</Turkish>
             <Italian>Attivare ACE-Lesioni Respiratorie?</Italian>
             <Russian>Активированы травмы ACE-Airway?</Russian>
-            <Japanese>ACE-Airway injuries を有効化しますか?</Japanese>
+            <Japanese>KAM-Airway を有効化しますか?</Japanese>
         </Key>
         <Key ID="STR_kat_airway_SETTING_collapsed">
             <English>Probability for airway collapsing</English>
@@ -125,7 +125,7 @@
             <Turkish>%1 kontrol edilmiş havayolları: %2 %3, %4 %5</Turkish>
             <Italian>%1 ha controllato le vie aeree: %2 %3 %4 %5</Italian>
             <Russian>%1 проверены дыхательные пути: %2 %3, %4 %5</Russian>
-            <Japanese>%1 が気道を確認しました: %2 %3, %4 %5</Japanese>
+            <Japanese>%1 が気道を確認しました: %3%2, %5%4</Japanese>
         </Key>
         <Key ID="STR_kat_airway_airway_log">
             <English>%1 inserted a %2</English>
@@ -153,7 +153,7 @@
             <Turkish>Tıkalı</Turkish>
             <Italian>Occlusa</Italian>
             <Russian>Окклюзия</Russian>
-            <Japanese>異物</Japanese>
+            <Japanese>異物発生</Japanese>
         </Key>
         <Key ID="STR_kat_airway_Collapsed">
             <English>Collapsed</English>
@@ -167,7 +167,7 @@
             <Turkish>Çökmüş</Turkish>
             <Italian>Collassata</Italian>
             <Russian>Свернуто</Russian>
-            <Japanese>崩壊</Japanese>
+            <Japanese>崩壊発生</Japanese>
         </Key>
         <Key ID="STR_kat_airway_obstruction">
             <English>Obstruction</English>
@@ -181,7 +181,7 @@
             <Turkish>Kapanma</Turkish>
             <Italian>Ostruita</Italian>
             <Russian>Обструкция</Russian>
-            <Japanese>閉塞</Japanese>
+            <Japanese>閉塞発生</Japanese>
         </Key>
         <Key ID="STR_kat_airway_N">
             <English>Not</English>
@@ -195,7 +195,7 @@
             <Turkish>Değil</Turkish>
             <Italian>No</Italian>
             <Russian>Нет</Russian>
-            <Japanese>非</Japanese>
+            <Japanese>無し</Japanese>
         </Key>
         <Key ID="STR_kat_airway_message_obstruction_no">
             <English>Airways are clear</English>
@@ -237,7 +237,7 @@
             <Turkish>Havayolu yönetimi gerekli</Turkish>
             <Italian>Gestione delle vie aeree necessaria</Italian>
             <Russian>Необходимо управление дыхательными путями</Russian>
-            <Japanese>気道管理が必要</Japanese>
+            <Japanese>気道管理が必要です</Japanese>
         </Key>
         <Key ID="STR_kat_airway_message_Occluded_yes">
             <English>Medical suction needed</English>
@@ -251,7 +251,7 @@
             <Turkish>Tıbbi aspirasyon gerekli</Turkish>
             <Italian>Aspirazione medica necessaria</Italian>
             <Russian>всасывание необходимо</Russian>
-            <Japanese>医療吸引が必要</Japanese>
+            <Japanese>医療吸引が必要です</Japanese>
         </Key>
         <Key ID="STR_kat_airway_Airway_already">
             <English>Airway management has already been performed</English>
@@ -335,7 +335,7 @@
             <Turkish>Hyperextension Gerçekleştir</Turkish>
             <Italian>Iperestensione della testa</Italian>
             <Russian>Гиперэкстензия головы</Russian>
-            <Japanese>気道の確保</Japanese>
+            <Japanese>気道確保 (頭部後屈あご先挙上法)</Japanese>
         </Key>
         <Key ID="STR_kat_airway_overstretched">
             <English>Hyperextended Head</English>
@@ -349,7 +349,7 @@
             <Turkish>Hyperextension Gerçekleşmiş Kafa</Turkish>
             <Italian>Testa iperestesa</Italian>
             <Russian>перетянутый голова</Russian>
-            <Japanese>気道を確保中 (頭部後屈あご先挙上法)</Japanese>
+            <Japanese>気道確保中 (頭部後屈あご先挙上法)</Japanese>
         </Key>
         <Key ID="STR_kat_airway_overstretching">
             <English>Extending</English>
@@ -363,7 +363,7 @@
             <Turkish>Uzatılmış</Turkish>
             <Italian>Estendendo</Italian>
             <Russian>Гиперэкстензия головы</Russian>
-            <Japanese>気道を確保中</Japanese>
+            <Japanese>気道確保中</Japanese>
         </Key>
         <Key ID="STR_kat_airway_overstretch_cancel">
             <English>Hyperextending Head canceled</English>
@@ -377,7 +377,7 @@
             <Turkish>Hyperextension İptal Edildi</Turkish>
             <Italian>Iperestensione della testa annullata</Italian>
             <Russian>Гиперэкстензия головы отменена</Russian>
-            <Japanese>気道の確保がキャンセルされました</Japanese>
+            <Japanese>気道確保が中止されました</Japanese>
         </Key>
         <Key ID="STR_kat_airway_overstretch_info">
             <English>Don't run away, you're saving a life!</English>
@@ -405,7 +405,7 @@
             <Turkish>Baş dönüşü yapıldı, hava yolları hala net değil</Turkish>
             <Italian>Rotazione della testa eseguita, le vie aeree non sono ancora libere</Italian>
             <Russian>Выполнен поворот головы, дыхательные пути еще не очистились</Russian>
-            <Japanese>回復体位を取っていますが、まだ気道は詰まっています</Japanese>
+            <Japanese>試みましたが、まだ異物が残っています。</Japanese>
         </Key>
         <Key ID="STR_kat_airway_turnaround">
             <English>Head turning</English>
@@ -419,7 +419,7 @@
             <Turkish>Baş döndürme</Turkish>
             <Italian>Rotazione testa</Italian>
             <Russian>Повернуть голову в сторону</Russian>
-            <Japanese>気道異物の除去</Japanese>
+            <Japanese>異物の除去</Japanese>
         </Key>
         <Key ID="STR_kat_airway_turnaround_action">
             <English>Turning the head</English>
@@ -475,7 +475,7 @@
             <Turkish>Yerleştiriliyor</Turkish>
             <Italian>Posizionando</Italian>
             <Russian>Размещение</Russian>
-            <Japanese>実行中</Japanese>
+            <Japanese>装着中</Japanese>
         </Key>
         <Key ID="STR_kat_airway_Larynx_Display">
             <English>King LT</English>
@@ -671,7 +671,7 @@
             <Turkish>Baş döndürme başarı olasılığı</Turkish>
             <Italian>Probabilità di successo della rotazione della testa</Italian>
             <Russian>Вероятность успеха для поворота головы</Russian>
-            <Japanese>気道異物の除去の成功確率</Japanese>
+            <Japanese>異物の除去の成功確率</Japanese>
         </Key>
         <Key ID="STR_kat_airway_SUCCES_HEADTURNING_DESC">
             <English>Higher, the better the probability of success</English>
@@ -699,7 +699,7 @@
             <Turkish>Laringeal Tüp'e izin ver</Turkish>
             <Italian>Permetti il tubo laringeo</Italian>
             <Russian>Разрешить гортанную трубку</Russian>
-            <Japanese>King LTを許可する</Japanese>
+            <Japanese>King LTの許可</Japanese>
         </Key>
         <Key ID="STR_kat_airway_ALLOW_LARYNXTUBUS_DESC">
             <English>Training level required to use a Larynxtubus - KingLT</English>
@@ -713,7 +713,7 @@
             <Turkish>Laringeal Tüp'ü kullanmak için gerekli eğitim seviyesi</Turkish>
             <Italian>Livello d'addestramento richiesto per utilizzare il tubo laringeo</Italian>
             <Russian>Уровень подготовки, необходимый для использования гортанной трубки</Russian>
-            <Japanese>King LTを使用するために必要な訓練レベル</Japanese>
+            <Japanese>King LTの使用に訓練レベルを必要とさせます。</Japanese>
         </Key>
         <Key ID="STR_kat_airway_ALLOW_GUEDELTUBUS">
             <English>Allow Guedeltubus</English>
@@ -727,7 +727,7 @@
             <Turkish>Guedel Tüp'e izin ver</Turkish>
             <Italian>Permetti la canula di Guedel</Italian>
             <Russian>Разрешить гедельтубус</Russian>
-            <Japanese>Guedelチューブを許可する</Japanese>
+            <Japanese>Guedelチューブの許可</Japanese>
         </Key>
         <Key ID="STR_kat_airway_ALLOW_GUEDELTUBUS_DESC">
             <English>Training level required to use a Guedeltubus</English>
@@ -741,7 +741,7 @@
             <Turkish>Guedel Tüp'ü kullanmak için gerekli eğitim seviyesi</Turkish>
             <Italian>Livello d'addestramento richiesto per utilizzare la canula di Guedel</Italian>
             <Russian>Уровень подготовки, необходимый для использования тубуса Геделя.</Russian>
-            <Japanese>Guedelチューブを使用するために必要な訓練レベル</Japanese>
+            <Japanese>Guedelチューブの使用に訓練レベルを必要とさせます。</Japanese>
         </Key>
         <Key ID="STR_kat_airway_ALLOW_ACCUVAC">
             <English>Allow Accuvac</English>
@@ -755,7 +755,7 @@
             <Turkish>Accuvac'a izin ver</Turkish>
             <Italian>Permetti l'ACCUVAC</Italian>
             <Russian>Разрешить Аккувак</Russian>
-            <Japanese>Accuvacを許可する</Japanese>
+            <Japanese>Accuvacの許可</Japanese>
         </Key>
         <Key ID="STR_kat_airway_ALLOW_ACCUVAC_DESC">
             <English>Training level required to use an Accuvac</English>
@@ -769,7 +769,7 @@
             <Turkish>Acuvvac'ı kullanmak için gerekli eğitim seviyesi</Turkish>
             <Italian>Livello d'addestramento richiesto per utilizzare l'ACCUVAC</Italian>
             <Russian>Уровень подготовки, необходимый для использования Accuvac</Russian>
-            <Japanese>Accuvacを使用するために必要な訓練レベル</Japanese>
+            <Japanese>Accuvacの使用に訓練レベルを必要とさせます。</Japanese>
         </Key>
         <Key ID="STR_kat_airway_TIME_CHECKAIRWAY">
             <English>Time to check Airways</English>
@@ -783,7 +783,7 @@
             <Turkish>Havayollarını kontrol etme zamanı</Turkish>
             <Italian>Tempo per controllare le vie aeree</Italian>
             <Russian>Время проверить дыхательные пути</Russian>
-            <Japanese>気道を確認する時間</Japanese>
+            <Japanese>気道の確認にかかる時間</Japanese>
         </Key>
         <Key ID="STR_kat_airway_TIME_CHECKAIRWAY_DESC">
             <English>How long it will take to check Airways</English>
@@ -797,7 +797,7 @@
             <Turkish>Havayollarını kontrol etmek ne kadar sürecek</Turkish>
             <Italian>Quanto tempo si impiega per controllare le vie aeree</Italian>
             <Russian>Сколько времени займет проверка дыхательных путей</Russian>
-            <Japanese>気道の確認にかかる時間</Japanese>
+            <Japanese>気道の確認を完了するのにどのくらい時間がかかるか設定します</Japanese>
         </Key>
         <Key ID="STR_kat_airway_TIME_HEADTURNING">
             <English>Time for head turning</English>
@@ -811,7 +811,7 @@
             <Turkish>Baş döndürme zamanı</Turkish>
             <Italian>Tempo per ruotare la testa</Italian>
             <Russian>Время для поворота головы</Russian>
-            <Japanese>回復体位にかかる時間</Japanese>
+            <Japanese>異物の除去にかかる時間</Japanese>
         </Key>
         <Key ID="STR_kat_airway_TIME_OVERSTRETCH">
             <English>Time for overstretch the head</English>
@@ -825,7 +825,7 @@
             <Turkish>Kafayı aşırı germe zamanı</Turkish>
             <Italian>Tempo per iperestendere la testa</Italian>
             <Russian>Время перенапрягать голову</Russian>
-            <Japanese>頭部後屈あご先挙上法にかかる時間</Japanese>
+            <Japanese>気道確保にかかる時間</Japanese>
         </Key>
         <Key ID="STR_kat_airway_TIME_OVERSTRETCH_DESC">
             <English>How long it will take to overstretch the head</English>
@@ -839,7 +839,7 @@
             <Turkish>Kafanın aşırı gerilmesi ne kadar sürecek</Turkish>
             <Italian>Quanto tempo si impiega per iperestendere la testa</Italian>
             <Russian>Сколько времени потребуется, чтобы перетянуть голову</Russian>
-            <Japanese>気道の確保(頭部後屈あご先挙上法)にかかる時間</Japanese>
+            <Japanese>気道確保 (頭部後屈あご先挙上法) を完了するのにどのくらい時間がかかるか設定します</Japanese>
         </Key>
         <Key ID="STR_kat_airway_TIME_HEADTURNING_DESC">
             <English>How long it will take to turn head</English>
@@ -853,7 +853,7 @@
             <Turkish>Kafayı çevirmek ne kadar sürecek</Turkish>
             <Italian>Quanto tempo si impiega per ruotare la testa</Italian>
             <Russian>Сколько времени потребуется, чтобы повернуть голову</Russian>
-            <Japanese>気道異物の除去にかかる時間</Japanese>
+            <Japanese>異物の除去を完了するのにどのくらい時間がかかるか設定します</Japanese>
         </Key>
         <Key ID="STR_kat_airway_TIME_ACCUVAC">
             <English>Time for Accuvac</English>
@@ -881,7 +881,7 @@
             <Turkish>Accuvac'ı kullanmak ne kadar sürecek</Turkish>
             <Italian>Quanto tempo si impiega per usare l'ACCUVAC</Italian>
             <Russian>Сколько времени потребуется, чтобы использовать Аккувака</Russian>
-            <Japanese>Accuvacの使用にかかる時間</Japanese>
+            <Japanese>Accuvacを使用するのにどのくらい時間がかかるか設定します</Japanese>
         </Key>
         <Key ID="STR_kat_airway_TIME_LARYNXTUBUS">
             <English>Time for Larynxtubus</English>
@@ -909,7 +909,7 @@
             <Turkish>Laringeal Tüp'ü kullanmak ne kadar sürecek</Turkish>
             <Italian>Quanto tempo si impiega per posizionare il tubo laringeo</Italian>
             <Russian>Сколько времени потребуется, чтобы использовать гортанную трубку</Russian>
-            <Japanese>King LTの使用にかかる時間</Japanese>
+            <Japanese>King LTを使用するのにどのくらい時間がかかるか設定します</Japanese>
         </Key>
         <Key ID="STR_kat_airway_TIME_GUEDELTUBUS">
             <English>Time for Geudeltubus</English>
@@ -937,7 +937,7 @@
             <Turkish>Guedel Tüp'ü kullanmak ne kadar sürecek</Turkish>
             <Italian>Quanto tempo si impiega per posizionare una canula di Guedel</Italian>
             <Russian>Сколько времени потребуется, чтобы использовать Гедель Тубус</Russian>
-            <Japanese>Guedelチューブの使用にかかる時間</Japanese>
+            <Japanese>Guedelチューブを使用するのにどのくらい時間がかかるか設定します</Japanese>
         </Key>
         <Key ID="STR_kat_airway_COLORED_LOGS">
             <English>Colored activitylogs (AED-X/Pulseoximeter)</English>
@@ -971,61 +971,73 @@
             <English>Established in recovery position</English>
             <German>In die stabile Seitenlage gebracht</German>
             <Polish>Ułożony w pozycji bezpiecznej</Polish>
+            <Japanese>回復体位をとっています</Japanese>
         </Key>
         <Key ID="STR_kat_airway_RecoveryPosition_displayName">
             <English>Establish recovery position</English>
             <German>In die stabile Seitenlage legen</German>
             <Polish>Ułóż w pozycji bezpiecznej</Polish>
+            <Japanese>回復体位をとらせる</Japanese>
         </Key>
         <Key ID="STR_kat_airway_RecoveryPosition_displayNameProgress">
             <English>Establishing recovery position</English>
             <German>In die stabile Seitenlage legen</German>
             <Polish>Układanie w pozycji</Polish>
+            <Japanese>回復体位をとらせています</Japanese>
         </Key>
         <Key ID="STR_kat_airway_Recovery_Info">
             <English>Recovery position established successfully</English>
             <German>Erfolgreich in die stabile Seitenlage gelegt</German>
             <Polish>Pomyślnie ułożono w pozycji bezpiecznej</Polish>
+            <Japanese>回復体位をとりました</Japanese>
         </Key>
         <Key ID="STR_kat_airway_Recovery_Cancel">
             <English>Recovery position cancelled</English>
             <German>Stabile Seitenlage abgebrochen</German>
             <Polish>Przerwano pozycję bezpieczną</Polish>
+            <Japanese>回復体位が崩されました</Japanese>
         </Key>
         <Key ID="STR_kat_airway_RecoveryPosition_Log">
             <English>%1 established recovery position</English>
             <German>%1 hat die stabile Seitenlage durchgeführt</German>
             <Polish>%1 ułożył w pozycji bezpiecznej</Polish>
+            <Japanese>%1 が回復体位にしました</Japanese>
         </Key>
         <Key ID="STR_kat_airway_TIME_RECOVERY">
             <English>Time for recovery position</English>
             <German>Zeit für die stabile Seitenlage</German>
             <Polish>Czas na ułożenie w pozycji bezpiecznej</Polish>
+            <Japanese>回復体位にかかる時間</Japanese>
         </Key>
         <Key ID="STR_kat_airway_TIME_RECOVERY_DESC">
             <English>How long it will take to establish recovery position</English>
             <German>Die Zeit, wie lange es dauert eine erfolgreiche stabile Seitenlage durchzuführen</German>
             <Polish>Jak długo potrwa ułożenie w pozycji bocznej bezpiecznej</Polish>
+            <Japanese>回復体位を完了するのにどのくらい時間がかかるか設定します</Japanese>
         </Key>
         <Key ID="STR_kat_airway_CancelRecoveryPosition_displayName">
             <English>Cancel recovery position</English>
             <German>Stabile Seitenlage abbrechen</German>
             <Polish>Przerwij pozycję bezpieczną</Polish>
+            <Japanese>回復体位をやめる</Japanese>
         </Key>
         <Key ID="STR_kat_airway_CancelRecoveryPosition_displayNameProgress">
             <English>Cancelling recovery position</English>
             <German>Stabile Seitenlage abbrechen</German>
             <Polish>Przerywanie pozycji bezpiecznej</Polish>
+            <Japanese>回復体位を崩しています</Japanese>
         </Key>
         <Key ID="STR_kat_airway_TIME_CANCELRECOVERY">
             <English>Time for cancelling recovery position</English>
             <German>Die Zeit, wie lange es dauert eine stabile Seitenlage abzubrechen</German>
             <Polish>Czas na przerwanie pozycji bezpiecznej</Polish>
+            <Japanese>回復体位をやめるのにかかる時間</Japanese>
         </Key>
         <Key ID="STR_kat_airway_TIME_CANCELRECOVERY_DESC">
             <English>How long it will take to establish recovery position</English>
             <German>Die Zeit, wie lange es dauert eine stabile Seitenlage abzubrechen</German>
             <Polish>Jak długo potrwa przerwanie pozycji bocznej bezpiecznej</Polish>
+            <Japanese>回復体位をやめさせるのにどのくらい時間がかかるか設定します</Japanese>
         </Key>
     </Package>
 </Project>

--- a/addons/breathing/stringtable.xml
+++ b/addons/breathing/stringtable.xml
@@ -13,7 +13,7 @@
             <Turkish>ACE-Nefes etkinleştirildi mi?</Turkish>
             <Italian>Attivare ACE-Respirazione?</Italian>
             <Russian>ACE-дыхание активировано?</Russian>
-            <Japanese>ACE-Breathing を有効化しますか?</Japanese>
+            <Japanese>KAM-Breathing を有効化しますか?</Japanese>
         </Key>
         <Key ID="STR_kat_breathing_SETTING_SpO2_dieValue">
             <English>Lethal SpO2 value</English>
@@ -55,7 +55,7 @@
             <Turkish>Sp02 eklemek / çıkarmak için küçük değer (daha küçük tedavi veya yaralanmalar)</Turkish>
             <Italian>Piccolo valore da aggiungere/rimuovere Sp02 (trattamento minore o lesioni)</Italian>
             <Russian>Небольшое значение для добавления/удаления Sp02 (меньшее лечение или травмы)</Russian>
-            <Japanese>小さいSpO2値の上下変動(軽症時)</Japanese>
+            <Japanese>小さいSpO2値の上下変動 (軽症時)</Japanese>
         </Key>
         <Key ID="STR_kat_breathing_SETTING_Value_After">
             <English>Big value to add / remove Sp02 (bigger treatment or injuries)</English>
@@ -69,7 +69,7 @@
             <Turkish>Sp02 eklemek / çıkarmak için büyük değer (daha büyük tedavi veya yaralanmalar)</Turkish>
             <Italian>Grande valore da aggiungere / rimuovere Sp02 (trattamento più grande o lesioni)</Italian>
             <Russian>Большое значение для добавления/удаления Sp02 (более серьезное лечение или травмы)</Russian>
-            <Japanese>大きいSpO2値の上下変動(重症時)</Japanese>
+            <Japanese>大きいSpO2値の上下変動 (重症時)</Japanese>
         </Key>
         <Key ID="STR_kat_breathing_SETTING_MultiplyPositive">
             <English>SpO2 positive multiplier</English>
@@ -83,7 +83,7 @@
         </Key>
         <Key ID="STR_kat_breathing_SETTING_SpO2_Perfusion">
             <English>Enable cardiac arrest SpO2 reduction</English>
-            <Japanese>心停止のSpO2低下を可能にする</Japanese>
+            <Japanese>心停止時のSpO2低下を有効化</Japanese>
             <Russian>Включить снижение SpO2 при остановке сердца</Russian>
         </Key>
         <Key ID="STR_kat_breathing_SETTING_pneumothorax">
@@ -285,10 +285,10 @@
                  %1достаточно вентилируется?
                  %1Sp02 более 70% -&gt; Да
                  %1Sp02 ниже 70% -&gt; Нет -&gt; зад. Дыхание</Russian>
-            <Japanese>呼吸
-                %1十分に吸気していますか?
-                %1Sp02 70%以上 -&gt; はい
-                %1Sp02 70%以下 -&gt; いいえ -&gt; 呼吸を助けてください</Japanese>
+            <Japanese>"呼吸
+ %1十分に吸気していますか?
+ %1Sp02 70%以上 -&gt; はい
+ %1Sp02 70%以下 -&gt; いいえ -&gt; 呼吸を助けてください"</Japanese>
         </Key>
         <Key ID="STR_kat_breathing_hint_tip">
             <English>If you saved the airway with a larynxtube skip this</English>
@@ -400,7 +400,7 @@
             <Turkish>Nabız Oksimetresine izin ver</Turkish>
             <Italian>Permetti pulsossimetro</Italian>
             <Russian>Разрешить пульсоксиметр</Russian>
-            <Japanese>パルスオキシメータを許可する</Japanese>
+            <Japanese>パルスオキシメータの許可</Japanese>
         </Key>
         <Key ID="STR_kat_breathing_TRAININGLEVEL_PULSEOXIMETER">
             <English>Training level required to use a Pulseoximeter</English>
@@ -414,7 +414,7 @@
             <Turkish>Nabız Oksimetresi kullanmak için gerekli eğitim seviyesi</Turkish>
             <Italian>Livello d'addestramento rischiesto per utilizzare il pulsossimetro</Italian>
             <Russian>Уровень подготовки, необходимый для использования пульсоксиметра</Russian>
-            <Japanese>パルスオキシメータを使用するために必要な訓練レベル</Japanese>
+            <Japanese>パルスオキシメータの使用に訓練レベルを必要とさせます。</Japanese>
         </Key>
         <Key ID="STR_kat_breathing_ALLOW_CHESTSEAL">
             <English>Allow Chest Seal</English>
@@ -428,7 +428,7 @@
             <Turkish>Chest Seal'a izin ver</Turkish>
             <Italian>Permetti Chest Seal</Italian>
             <Russian>Разрешить Чест Сеал </Russian>
-            <Japanese>チェストシールを許可する</Japanese>
+            <Japanese>チェストシールの許可</Japanese>
         </Key>
         <Key ID="STR_kat_breathing_TRAININGLEVEL_CHESTSEAL">
             <English>Training level required to use a Chest Seal</English>
@@ -442,11 +442,11 @@
             <Turkish>Chest Seal kullanmak için gerekli eğitim seviyesi</Turkish>
             <Italian>Livello d'addestramento rischiesto per utilizzare il Chest Seal</Italian>
             <Russian>Уровень подготовки, необходимый для использования Чест Сеал </Russian>
-            <Japanese>チェストシールを使用するために必要な訓練レベル</Japanese>
+            <Japanese>チェストシールの使用に訓練レベルを必要とさせます。</Japanese>
         </Key>
         <Key ID="STR_kat_breathing_SETTING_SELF_CHESTSEAL">
             <English>Allow Chest Seal self treatment</English>
-            <Japanese>チェストシールでの自己治療を許可する</Japanese>
+            <Japanese>チェストシールでの自己治療を許可</Japanese>
             <Russian>Разрешить самолечение Чест Сеал </Russian>
         </Key>
         <Key ID="STR_kat_breathing_SETTING_STABLE_SPO2">
@@ -489,7 +489,7 @@
             <Turkish>Sıvıyı Boşaltın</Turkish>
             <Italian>Drenare il liquido</Italian>
             <Russian>Слить жидкость</Russian>
-            <Japanese>液体を排出する</Japanese>
+            <Japanese>胸腔排液治療</Japanese>
         </Key>
         <Key ID="STR_kat_breathing_hemopneumothorax">
             <English>%1 treated a Hemopneumothorax</English>
@@ -587,7 +587,7 @@
             <Turkish>Gelişmiş Hava Yolu Tedavi Kiti, hemopnömotoraks gibi gelişmiş hava yolu koşullarını tedavi etmek için tasarlanmış tek kullanımlık bir kittir.</Turkish>
             <Italian>Il kit per il Trattamento Avanzato delle vie Aeree è un kit ad uso singolo per il trattamento avanzato di condizioni alle vie aeree, come l'emopneumotorace</Italian>
             <Russian>Набор ААТ</Russian>
-            <Japanese>Advanced Airway Treatment Kitは、血気胸などの高度な気道の状態を治療するために設計された使い捨てキットです。</Japanese>
+            <Japanese>AATキットは、血気胸などの高度な呼吸器の状態を治療するために設計された使い捨てキットです。</Japanese>
         </Key>
         <Key ID="STR_kat_breathing_HEMOPNEUMOTHORAX_CHANCE_OPTION">
             <English>Hemothorax / Tension Pneumothorax Chance</English>
@@ -601,7 +601,7 @@
             <Turkish>Hemotoraks / Gerilim Pnömotoraks Şansı</Turkish>
             <Italian>Probabilità di un emo/pneumotorace iperteso</Italian>
             <Russian>Гемоторакс / Напряженный пневмоторакс Вероятность</Russian>
-            <Japanese>血胸/緊張性気胸の可能性</Japanese>
+            <Japanese>血気胸/緊張性気胸の可能性</Japanese>
         </Key>
         <Key ID="STR_kat_breathing_DESCRIPTION_HEMOPNEUMOTHORAX_CHANCE_OPTION">
             <English>The percentage chance that a patient will suffer from a hemopneumotorax or tension pneumothorax after they are treated for a pneumothorax. Treatment requires the draining of fluids with the use of an AAT Kit.</English>
@@ -615,7 +615,7 @@
             <Turkish>Bir hastanın pnömotoraks tedavisi gördükten sonra hemotoraks veya tansiyon pnömotorakstan muzdarip olma şansı yüzdesi. Tedavi, sıvıların bir AAT Kiti kullanılarak boşaltılmasını gerektirir.</Turkish>
             <Italian>La probabilità percentuale che un paziente soffra di un emopneumotorace o pneumotorace iperteso in seguito al trattamento di uno pneumotorace. Il trattamento richiede un drenaggio con l'AAT Kit.</Italian>
             <Russian>Процентная вероятность того, что пациент будет страдать гемопневмотораксом или напряженным пневмотораксом после лечения пневмоторакса. Лечение требует дренирования жидкости с использованием набора ААТ.</Russian>
-            <Japanese>気胸の治療を受けた後、患者が気胸または緊張性気胸に苦しむ可能性の割合。治療には、AATキットを使用して水分を排出する必要があります。</Japanese>
+            <Japanese>気胸の治療を受けた後、患者が血気胸または緊張性気胸に苦しむ可能性の割合。治療には、AATキットを使用して体液を排出する必要があります。</Japanese>
         </Key>
         <Key ID="STR_kat_breathing_HEMOPNEUMOTHORAX_TREATMENT_LEVEL">
             <English>Hemothorax / Tension Pnuemothorax Treament Minimum Level</English>
@@ -629,7 +629,7 @@
             <Turkish>Hemotoraks / Gerilim Pnömotoraks Tedavisi Minimum Seviye</Turkish>
             <Italian>Livello minimo per il trattamento di un emo/pneumotorace iperteso</Italian>
             <Russian>Лечение гемоторакса/напряженного пневмоторакса Минимальный уровень</Russian>
-            <Japanese>血胸/緊張性気胸治療最低レベル</Japanese>
+            <Japanese>血気胸/緊張性気胸治療の許可</Japanese>
         </Key>
         <Key ID="STR_kat_breathing_HEMOPNEUMOTHORAX_TREATMENT_LEVEL_DESCRIPTION">
             <English>The minimum medical level required for someone to be able to perform the Needle Decompression and Drain Fluids treatment actions, used to treat Hemothorax or Tension Pneumothorax.</English>
@@ -643,7 +643,7 @@
             <Turkish>Hemotoraks veya Tansiyon Pnömotoraksı tedavi etmek için kullanılan İğne Dekompresyonu ve Boşaltma Sıvıları tedavi eylemlerini gerçekleştirebilmek için gerekli minimum tıbbi seviye.</Turkish>
             <Italian>Il livello medico minimo richiesto per eseguire la decompressione con ago e il drenaggio dei fluidi, necessari per il trattamento di un emotorace o pneumotorace iperteso</Italian>
             <Russian>Минимальный медицинский уровень, необходимый для того, чтобы кто-то мог выполнять лечебные действия «Декомпрессия иглой» и «Дренаж жидкости», используемые для лечения гемоторакса или напряженного пневмоторакса.</Russian>
-            <Japanese>血胸または緊張性気胸の治療に使用される、針減圧および排液治療アクションを実行できるようにするために必要な最小医療レベル。</Japanese>
+            <Japanese>胸腔穿刺減圧および胸腔排液治療に訓練レベルを必要とさせます。</Japanese>
         </Key>
         <Key ID="STR_kat_breathing_PNEUMOTHORAX_DAMAGE_THRESHOLD">
             <English>Pneumothorax Damage Threshold</English>
@@ -685,7 +685,7 @@
             <Turkish>sert pnömotoraks </Turkish>
             <Italian>Pneumotorace estremo </Italian>
             <Russian>Система расширенного пневмоторакса</Russian>
-            <Japanese>ハードコア気胸</Japanese>
+            <Japanese>高度な気胸診断を有効化</Japanese>
         </Key>
         <Key ID="STR_kat_breathing_SETTING_pneumothorax_hardcore_DESC">
             <English>Enables hardcore mod for pneumothorax by not making it appear in medical menu - Stethoscope might be helpful</English>
@@ -699,7 +699,7 @@
             <Turkish>Tıbbi menüde görünmesini sağlamayarak pnömotoraks için hardcore modunu etkinleştirir - Stetoskop yardımcı olabilir </Turkish>
             <Italian>Abilita la mod hardcore per il pneumotorace non facendola apparire nel menu medico - Lo stetoscopio potrebbe essere utile </Italian>
             <Russian>Активирует расширенную систему пневмоторакса, не показывая пневмоторакс в медицинском меню — может помочь стетоскоп.</Russian>
-            <Japanese>気胸のハードコアmodを有効にします。気胸が発生しても医療メニューに表示しません。-聴診器が役立つ場合があります</Japanese>
+            <Japanese>気胸診断のハードコアモードを有効にします。気胸が発生しても医療メニューに表示しません。-聴診器が役立つ場合があります</Japanese>
         </Key>
         <Key ID="STR_kat_breathing_SETTING_tensionhemothorax_hardcore">
             <English>Hardcore tension pneumothorax and hemothorax</English>
@@ -713,7 +713,7 @@
             <Turkish>Sert tansiyon pnömotoraks ve hemotoraks</Turkish>
             <Italian>Pneumotorace da tensione hardcore ed emotorace</Italian>
             <Russian>Усовершенствованная система для напряженного пневмоторакса/гемопневмоторакса</Russian>
-            <Japanese>ハードコア緊張性気胸と血胸</Japanese>
+            <Japanese>高度な緊張性気胸と血気胸診断を有効化</Japanese>
         </Key>
         <Key ID="STR_kat_breathing_SETTING_tensionhemothorax_hardcore_DESC">
             <English>Enables hardcore mod for tension and hemothorax by not making it appear in medical menu - Stethoscope might be helpful</English>
@@ -727,7 +727,7 @@
             <Turkish>Medikal menüde görünmeyerek tansiyon ve hemotoraks için hardcore modu etkinleştirir - Stetoskop yardımcı olabilir</Turkish>
             <Italian>Abilita la mod hardcore per la tensione e l'emotorace non facendola apparire nel menu medico - Lo stetoscopio potrebbe essere utile</Italian>
             <Russian>Активирует расширенную систему для напряженного пневмоторакса / гемопневмоторакса, не отображая напряженный пневмоторакс / гемопневмоторакс в медицинском меню - может помочь стетоскоп</Russian>
-            <Japanese>緊張性気胸と血気胸のハードコアmodを有効にします。気胸が発生しても医療メニューに表示しません。-聴診器が役立つ場合があります</Japanese>
+            <Japanese>緊張性気胸診断と血気胸診断のハードコアモードを有効にします。それらが発生しても医療メニューに表示しません。-聴診器が役立つ場合があります</Japanese>
         </Key>
         <Key ID="STR_kat_breathing_Stethoscope_display">
             <English>Stethoscope</English>
@@ -811,7 +811,7 @@
             <Turkish>Stetoskop kullanırken toraks seslerinin ne kadar yüksek olduğunu belirler</Turkish>
             <Italian>Determina quanto sono forti i suoni del torace quando si utilizza lo stetoscopio</Italian>
             <Russian>Определяет громкость звуков грудной клетки при использовании стетоскопа.</Russian>
-            <Japanese>聴診器を使用したときの胸の音の大きさを設定します</Japanese>
+            <Japanese>聴診器を使用した際の呼吸音の音の大きさを設定します</Japanese>
         </Key>
         <Key ID="STR_kat_breathing_SETTING_SpO2_unconscious">
             <English>Unconscious SpO2 value</English>
@@ -858,56 +858,56 @@
             <German>Zyanose überprüfen</German>
             <Polish>Sprawdź sinicę</Polish>
             <Russian>Проверить цианоз</Russian>
-            <Japanese>チアノーゼをチェック</Japanese>
+            <Japanese>チアノーゼの確認</Japanese>
         </Key>
         <Key ID="STR_kat_breathing_CheckCyanosis_Progress">
             <English>Checking Cyanosis</English>
             <German>Zyanose prüfen</German>
             <Polish>Sprawdzanie sinicy</Polish>
             <Russian>Проверка цианоза</Russian>
-            <Japanese>チアノーゼの確認</Japanese>
+            <Japanese>チアノーゼを確認中</Japanese>
         </Key>
         <Key ID="STR_kat_breathing_CheckCyanosis_Log">
             <English>Cyanosis Status: %1</English>
             <German>Status der Zyanose: %1</German>
             <Polish>Status sinicy: %1</Polish>
             <Russian>Статус цианоза: %1</Russian>
-            <Japanese>チアノーゼ状態: %1</Japanese>
+            <Japanese>チアノーゼの症状: %1</Japanese>
         </Key>
         <Key ID="STR_kat_breathing_CyanosisStatus_N">
             <English>No Cyanosis</English>
             <German>Keine Zyanose</German>
             <Polish>Brak sinicy</Polish>
             <Russian>Нет цианоза</Russian>
-            <Japanese>チアノーゼなし</Japanese>
+            <Japanese>なし</Japanese>
         </Key>
         <Key ID="STR_kat_breathing_CyanosisStatus_Slight">
             <English>Slight Cyanosis</English>
             <German>Leichte Zyanose</German>
             <Polish>Lekka sinica</Polish>
             <Russian>Легкий цианоз</Russian>
-            <Japanese>わずかなチアノーゼ</Japanese>
+            <Japanese>わずか</Japanese>
         </Key>
         <Key ID="STR_kat_breathing_CyanosisStatus_Mild">
             <English>Mild Cyanosis</English>
             <German>Mittelschwere Zyanose</German>
             <Polish>Umiarkowana sinica</Polish>
             <Russian>средний цианоз</Russian>
-            <Japanese>軽度のチアノーゼ</Japanese>
+            <Japanese>軽度</Japanese>
         </Key>
         <Key ID="STR_kat_breathing_CyanosisStatus_Severe">
             <English>Severe Cyanosis</English>
             <German>Schwere Zyanose</German>
             <Polish>Ciężka sinica</Polish>
             <Russian>Тяжелый цианоз</Russian>
-            <Japanese>重度のチアノーゼ</Japanese>
+            <Japanese>重度</Japanese>
         </Key>
         <Key ID="STR_kat_breathing_SETTING_Cyanosis">
             <English>Enable cyanosis diagnose</English>
             <German>Zyanose-Diagnose aktivieren</German>
             <Polish>Włącz diagnozę sinicy</Polish>
             <Russian>Включить диагностику цианоза</Russian>
-            <Japanese>チアノーゼ診断を有効にする</Japanese>
+            <Japanese>チアノーゼ診断を有効化</Japanese>
         </Key>
         <Key ID="STR_kat_breathing_SETTING_Cyanosis_DESC">
             <English>Enables cyanosis diagnose</English>
@@ -921,54 +921,54 @@
             <German>Leichter Zyanose SpO2-Wert</German>
             <Polish>Poziom SpO2 dla lekkiej sinicy</Polish>
             <Russian>Легкий цианоз Значение SpO2</Russian>
-            <Japanese>わずかなチアノーゼSpO2値</Japanese>
+            <Japanese>わずかなチアノーゼが発症するSpO2値</Japanese>
         </Key>
         <Key ID="STR_kat_breathing_SETTING_slightValue_DESC">
             <English>Slight cyanosis value - default 90 SpO2</English>
             <German>Leichte Zyanose - Standardwert 90 SpO2</German>
             <Polish>Poziom SpO2 dla lekkiej sinicy - domyślnie 90 SpO2</Polish>
             <Russian>Значение легкого цианоза - по умолчанию 90 SpO2</Russian>
-            <Japanese>わずかなチアノーゼ値 - デフォルトはSpO2 90</Japanese>
+            <Japanese>わずかなチアノーゼが発症するSpO2の値 - デフォルトはSpO2 90</Japanese>
         </Key>
         <Key ID="STR_kat_breathing_SETTING_mildValue">
             <English>Mild cyanosis SpO2 value</English>
             <German>Mittelschwere Zyanose SpO2-Wert</German>
             <Polish>Poziom SpO2 dla umiarkowanej sinicy</Polish>
             <Russian>Средний значение цианоза SpO2</Russian>
-            <Japanese>軽度のチアノーゼSpO2値</Japanese>
+            <Japanese>軽度のチアノーゼが発症するSpO2値</Japanese>
         </Key>
         <Key ID="STR_kat_breathing_SETTING_mildValue_DESC">
             <English>Mild cyanosis value - default 75 SpO2</English>
             <German>Mittelschwere Zyanose - Standardwert 75 SpO2</German>
             <Polish>Poziom SpO2 dla umiarkowanej sinicy - domyślnie 75 SpO2</Polish>
             <Russian>Значение Средней цианоза — по умолчанию 75 SpO2</Russian>
-            <Japanese>軽度のチアノーゼ値 - デフォルトはSpO2 75</Japanese>
+            <Japanese>軽度のチアノーゼが発症するSpO2の値 - デフォルトはSpO2 75</Japanese>
         </Key>
         <Key ID="STR_kat_breathing_SETTING_severeValue">
             <English>Severe cyanosis SpO2 value</English>
             <German>Schwere Zyanose SpO2-Wert</German>
             <Polish>Poziom SpO2 dla ciężkiej sinicy</Polish>
             <Russian>Тяжелый цианоз Значение SpO2</Russian>
-            <Japanese>重度のチアノーゼSpO2値</Japanese>
+            <Japanese>重度のチアノーゼが発症するSpO2値</Japanese>
         </Key>
         <Key ID="STR_kat_breathing_SETTING_severeValue_DESC">
             <English>Severe cyanosis value - default 66 SpO2 \nShould be little bit higher than lethal SpO2 value</English>
             <German>Schwere Zyanose - Standardwert 66 SpO2 \nSollte etwas höher sein als der tödliche SpO2-Wert</German>
             <Polish>Poziom SpO2 dla ciężkiej sinicy - domyślnie 66 SpO2 \nPowinien być minimalnie wyższy niż wartość śmiertelna SpO2</Polish>
             <Russian>Значение Тяжелый цианоза - по умолчанию 66 SpO2 \nДолжно быть немного выше летального значения SpO2</Russian>
-            <Japanese>重度のチアノーゼ値 - デフォルトSpO2 66\n致命的なSpO2値より少し高く設定する必要があります</Japanese>
+            <Japanese>重度のチアノーゼが発症するSpO2の値 - デフォルトSpO2 66\n致命的なSpO2値より少し高く設定する必要があります</Japanese>
         </Key>
         <Key ID="STR_kat_breathing_CYANOSIS_TREATMENT_LEVEL">
             <English>Check Cyanosis Minimum Level</English>
             <German>Zyanose prüfen Medic Level</German>
             <Polish>Minimalny poziom wyszkolenia do sprawdzenia sinicy</Polish>
-            <Japanese>チアノーゼを確認出来る医療レベル</Japanese>
+            <Japanese>チアノーゼの確認の許可</Japanese>
         </Key>
         <Key ID="STR_kat_breathing_CYANOSIS_TREATMENT_LEVEL_DESCRIPTION">
             <English>The minimum medical level required for someone to be able to check cyanosis.</English>
             <German>Das Medic Level, das erforderlich ist, damit jemand eine Zyanose feststellen kann.</German>
             <Polish>Minimalny poziom wyszkolenia medycznego wymagany, aby ktoś był w stanie sprawdzić sinicę.</Polish>
-            <Japanese>誰かがチアノーゼをチェックできるようにするために必要な最低医療レベル。</Japanese>
+            <Japanese>チアノーゼの確認に訓練レベルを必要とさせます。</Japanese>
         </Key>
     </Package>
 </Project>

--- a/addons/circulation/CfgVehicles.hpp
+++ b/addons/circulation/CfgVehicles.hpp
@@ -42,6 +42,8 @@ class CfgVehicles {
         class TransportItems: TransportItems {
             MACRO_ADDITEM(kat_X_AED,1);
 			MACRO_ADDITEM(kat_AED,1);
+            MACRO_ADDITEM(KAT_Empty_bloodIV_250,10);
+            MACRO_ADDITEM(KAT_Empty_bloodIV_500,10);
         };
         class TransportMagazines: TransportMagazines {
             MACRO_ADDMAGAZINE(kat_Painkiller,10);
@@ -75,6 +77,8 @@ class CfgVehicles {
             MACRO_ADDITEM(kat_bloodIV_B_250_N,10);
             MACRO_ADDITEM(kat_bloodIV_AB_250,10);
             MACRO_ADDITEM(kat_bloodIV_AB_250_N,10);
+            MACRO_ADDITEM(KAT_Empty_bloodIV_250,10);
+            MACRO_ADDITEM(KAT_Empty_bloodIV_500,10);
         };
     };
 

--- a/addons/circulation/CfgVehicles.hpp
+++ b/addons/circulation/CfgVehicles.hpp
@@ -42,8 +42,6 @@ class CfgVehicles {
         class TransportItems: TransportItems {
             MACRO_ADDITEM(kat_X_AED,1);
 			MACRO_ADDITEM(kat_AED,1);
-            MACRO_ADDITEM(KAT_Empty_bloodIV_250,10);
-            MACRO_ADDITEM(KAT_Empty_bloodIV_500,10);
         };
         class TransportMagazines: TransportMagazines {
             MACRO_ADDMAGAZINE(kat_Painkiller,10);
@@ -77,8 +75,6 @@ class CfgVehicles {
             MACRO_ADDITEM(kat_bloodIV_B_250_N,10);
             MACRO_ADDITEM(kat_bloodIV_AB_250,10);
             MACRO_ADDITEM(kat_bloodIV_AB_250_N,10);
-            MACRO_ADDITEM(KAT_Empty_bloodIV_250,10);
-            MACRO_ADDITEM(KAT_Empty_bloodIV_500,10);
         };
     };
 

--- a/addons/circulation/stringtable.xml
+++ b/addons/circulation/stringtable.xml
@@ -13,7 +13,7 @@
             <Turkish>ACE-Sirkülasyon etkinleştirildi mi?</Turkish>
             <Italian>Attivare ACE-Circolazione?</Italian>
             <Russian>ACE-циркуляция активирована?</Russian>
-            <Japanese>ACE-Circulation を有効化しますか?</Japanese>
+            <Japanese>KAM-Circulation を有効化しますか?</Japanese>
         </Key>
         <Key ID="STR_kat_circulation_RHYTHM_ENABLE">
             <English>Advanced Rhythm activated?</English>
@@ -26,7 +26,7 @@
             <Italian>Ritmo avanzato attivato?</Italian>
             <Spanish>¿Ritmo avanzado activado?</Spanish>
             <Czech>Pokročilý rytmus aktivován?</Czech>
-            <Japanese>Advanced Rhythm を有効化しますか?</Japanese>
+            <Japanese>高度な心房細動 を有効化しますか?</Japanese>
             <Russian>Продвинутый ритм активирован?</Russian>
         </Key>
         <Key ID="STR_kat_circulation_SETTING_variableHR_ENABLE">
@@ -69,7 +69,7 @@
             <Turkish>Kan IV (1000ml) KG: 0+</Turkish>
             <Italian>Sangue EV (1000ml) GS: 0+</Italian>
             <Russian>Кровь IV (1000 мл) Гk : 0+</Russian>
-            <Japanese>血液IV (1000ml) O+型</Japanese>
+            <Japanese>血液 IV (1000ml) O+型</Japanese>
         </Key>
         <Key ID="STR_KAT_circulation_BloodIV_O_N">
             <English>Blood IV (1000ml) BT: 0-</English>
@@ -83,7 +83,7 @@
             <Turkish>Kan IV (1000ml) KG: 0-</Turkish>
             <Italian>Sangue EV (1000ml) GS: 0-</Italian>
             <Russian>Кровь IV (1000 мл) Гk : 0-</Russian>
-            <Japanese>血液IV (1000ml) O-型</Japanese>
+            <Japanese>血液 IV (1000ml) O-型</Japanese>
         </Key>
         <Key ID="STR_KAT_circulation_BloodIV_A">
             <English>Blood IV (1000ml) BT: A+</English>
@@ -97,7 +97,7 @@
             <Turkish>Kan IV (1000ml) KG: A+</Turkish>
             <Italian>Sangue EV (1000ml) GS: A+</Italian>
             <Russian>Кровь IV (1000 мл) Гk : А+</Russian>
-            <Japanese>血液IV (1000ml) A+型</Japanese>
+            <Japanese>血液 IV (1000ml) A+型</Japanese>
         </Key>
         <Key ID="STR_KAT_circulation_BloodIV_A_N">
             <English>Blood IV (1000ml) BT: A-</English>
@@ -111,7 +111,7 @@
             <Turkish>Kan IV (1000ml) KG: A-</Turkish>
             <Italian>Sangue EV (1000ml) GS: A-</Italian>
             <Russian>Кровь IV (1000 мл) Гk : А-</Russian>
-            <Japanese>血液IV (1000ml) A-型</Japanese>
+            <Japanese>血液 IV (1000ml) A-型</Japanese>
         </Key>
         <Key ID="STR_KAT_circulation_BloodIV_B">
             <English>Blood IV (1000ml) BT: B+</English>
@@ -125,7 +125,7 @@
             <Turkish>Kan IV (1000ml) KG: B+</Turkish>
             <Italian>Sangue EV (1000ml) GS: B+</Italian>
             <Russian>Кровь IV (1000 мл) Гk : B+</Russian>
-            <Japanese>血液IV (1000ml) B+型</Japanese>
+            <Japanese>血液 IV (1000ml) B+型</Japanese>
         </Key>
         <Key ID="STR_KAT_circulation_BloodIV_B_N">
             <English>Blood IV (1000ml) BT: B-</English>
@@ -139,7 +139,7 @@
             <Turkish>Kan IV (1000ml) KG: B-</Turkish>
             <Italian>Sangue EV (1000ml) GS: B-</Italian>
             <Russian>Кровь IV (1000 мл) Гk : B-</Russian>
-            <Japanese>血液IV (1000ml) B-型</Japanese>
+            <Japanese>血液 IV (1000ml) B-型</Japanese>
         </Key>
         <Key ID="STR_KAT_circulation_BloodIV_AB">
             <English>Blood IV (1000ml) BT: AB+</English>
@@ -153,7 +153,7 @@
             <Turkish>Kan IV (1000ml) KG: AB+</Turkish>
             <Italian>Sangue EV (1000ml) GS: AB+</Italian>
             <Russian>Кровь IV (1000 мл) Гk : AB+</Russian>
-            <Japanese>血液IV (1000ml) AB+型</Japanese>
+            <Japanese>血液 IV (1000ml) AB+型</Japanese>
         </Key>
         <Key ID="STR_KAT_circulation_BloodIV_AB_N">
             <English>Blood IV (1000ml) BT: AB-</English>
@@ -167,7 +167,7 @@
             <Turkish>Kan IV (1000ml) KG: AB-</Turkish>
             <Italian>Sangue EV (1000ml) GS: AB-</Italian>
             <Russian>Кровь IV (1000 мл) Гk : АB-</Russian>
-            <Japanese>血液IV (1000ml) AB-型</Japanese>
+            <Japanese>血液 IV (1000ml) AB-型</Japanese>
         </Key>
         <Key ID="STR_KAT_circulation_BloodIV_O_500">
             <English>Blood IV (500ml) BT: 0+</English>
@@ -181,7 +181,7 @@
             <Turkish>Kan IV (500ml) KG: 0+</Turkish>
             <Italian>Sangue EV (500ml) GS: 0+</Italian>
             <Russian>Кровь IV (500 мл) Гk : 0+</Russian>
-            <Japanese>血液IV (500ml) O+型</Japanese>
+            <Japanese>血液 IV (500ml) O+型</Japanese>
         </Key>
         <Key ID="STR_KAT_circulation_BloodIV_O_500_N">
             <English>Blood IV (500ml) BT: 0-</English>
@@ -195,7 +195,7 @@
             <Turkish>Kan IV (500ml) KG: 0-</Turkish>
             <Italian>Sangue EV (500ml) GS: 0-</Italian>
             <Russian>Кровь IV (500 мл) Гk : 0-</Russian>
-            <Japanese>血液IV (500ml) O-型</Japanese>
+            <Japanese>血液 IV (500ml) O-型</Japanese>
         </Key>
         <Key ID="STR_KAT_circulation_BloodIV_A_500">
             <English>Blood IV (500ml) BT: A+</English>
@@ -209,7 +209,7 @@
             <Turkish>Kan IV (500ml) KG: A+</Turkish>
             <Italian>Sangue EV (500ml) GS: A+</Italian>
             <Russian>Кровь IV (500 мл) Гk : A+</Russian>
-            <Japanese>血液IV (500ml) A+型</Japanese>
+            <Japanese>血液 IV (500ml) A+型</Japanese>
         </Key>
         <Key ID="STR_KAT_circulation_BloodIV_A_500_N">
             <English>Blood IV (500ml) BT: A-</English>
@@ -223,7 +223,7 @@
             <Turkish>Kan IV (500ml) KG: A-</Turkish>
             <Italian>Sangue EV (500ml) GS: A-</Italian>
             <Russian>Кровь IV (500 мл) Гk : A-</Russian>
-            <Japanese>血液IV (500ml) A-型</Japanese>
+            <Japanese>血液 IV (500ml) A-型</Japanese>
         </Key>
         <Key ID="STR_KAT_circulation_BloodIV_B_500">
             <English>Blood IV (500ml) BT: B+</English>
@@ -237,7 +237,7 @@
             <Turkish>Kan IV (500ml) KG: B+</Turkish>
             <Italian>Sangue EV (500ml) GS: B+</Italian>
             <Russian>Кровь IV (500 мл) Гk : B+</Russian>
-            <Japanese>血液IV (500ml) B+型</Japanese>
+            <Japanese>血液 IV (500ml) B+型</Japanese>
         </Key>
         <Key ID="STR_KAT_circulation_BloodIV_B_500_N">
             <English>Blood IV (500ml) BT: B-</English>
@@ -251,7 +251,7 @@
             <Turkish>Kan IV (500ml) KG: B-</Turkish>
             <Italian>Sangue EV (500ml) GS: B-</Italian>
             <Russian>Кровь IV (500 мл) Гk : B-</Russian>
-            <Japanese>血液IV (500ml) B-型</Japanese>
+            <Japanese>血液 IV (500ml) B-型</Japanese>
         </Key>
         <Key ID="STR_KAT_circulation_BloodIV_AB_500">
             <English>Blood IV (500ml) BT: AB+</English>
@@ -265,7 +265,7 @@
             <Turkish>Kan IV (500ml) KG: AB+</Turkish>
             <Italian>Sangue EV (500ml) GS: AB+</Italian>
             <Russian>Кровь IV (500 мл) Гk : AB+</Russian>
-            <Japanese>血液IV (500ml) AB+型</Japanese>
+            <Japanese>血液 IV (500ml) AB+型</Japanese>
         </Key>
         <Key ID="STR_KAT_circulation_BloodIV_AB_500_N">
             <English>Blood IV (500ml) BT: AB-</English>
@@ -279,7 +279,7 @@
             <Turkish>Kan IV (500ml) KG: AB-</Turkish>
             <Italian>Sangue EV (500ml) GS: AB-</Italian>
             <Russian>Кровь IV (500 мл) Гk : AB-</Russian>
-            <Japanese>血液IV (500ml) AB-型</Japanese>
+            <Japanese>血液 IV (500ml) AB-型</Japanese>
         </Key>
         <Key ID="STR_KAT_circulation_BloodIV_O_250">
             <English>Blood IV (250ml) BT: 0+</English>
@@ -293,7 +293,7 @@
             <Turkish>Kan IV (250ml) KG: 0+</Turkish>
             <Italian>Sangue EV (250ml) GS: 0+</Italian>
             <Russian>Кровь IV (250 мл) Гk : 0+</Russian>
-            <Japanese>血液IV (250ml) O+型</Japanese>
+            <Japanese>血液 IV (250ml) O+型</Japanese>
         </Key>
         <Key ID="STR_KAT_circulation_BloodIV_O_250_N">
             <English>Blood IV (250ml) BT: 0-</English>
@@ -307,7 +307,7 @@
             <Turkish>Kan IV (250ml) KG: 0-</Turkish>
             <Italian>Sangue EV (250ml) GS: 0-</Italian>
             <Russian>Кровь IV (250 мл) Гk : 0-</Russian>
-            <Japanese>血液IV (250ml) O-型</Japanese>
+            <Japanese>血液 IV (250ml) O-型</Japanese>
         </Key>
         <Key ID="STR_KAT_circulation_BloodIV_A_250">
             <English>Blood IV (250ml) BT: A+</English>
@@ -321,7 +321,7 @@
             <Turkish>Kan IV (250ml) KG: A+</Turkish>
             <Italian>Sangue EV (250ml) GS: A+</Italian>
             <Russian>Кровь IV (250 мл) Гk : A+</Russian>
-            <Japanese>血液IV (250ml) A+型</Japanese>
+            <Japanese>血液 IV (250ml) A+型</Japanese>
         </Key>
         <Key ID="STR_KAT_circulation_BloodIV_A_250_N">
             <English>Blood IV (250ml) BT: A-</English>
@@ -335,7 +335,7 @@
             <Turkish>Kan IV (250ml) KG: A-</Turkish>
             <Italian>Sangue EV (250ml) GS: A-</Italian>
             <Russian>Кровь IV (250 мл) Гk : A-</Russian>
-            <Japanese>血液IV (250ml) A-型</Japanese>
+            <Japanese>血液 IV (250ml) A-型</Japanese>
         </Key>
         <Key ID="STR_KAT_circulation_BloodIV_B_250">
             <English>Blood IV (250ml) BT: B+</English>
@@ -349,7 +349,7 @@
             <Turkish>Kan IV (250ml) KG: B+</Turkish>
             <Italian>Sangue EV (250ml) GS: B+</Italian>
             <Russian>Кровь IV (250 мл) Гk : B+</Russian>
-            <Japanese>血液IV (250ml) B+型</Japanese>
+            <Japanese>血液 IV (250ml) B+型</Japanese>
         </Key>
         <Key ID="STR_KAT_circulation_BloodIV_B_250_N">
             <English>Blood IV (250ml) BT: B-</English>
@@ -363,7 +363,7 @@
             <Turkish>Kan IV (250ml) KG: B-</Turkish>
             <Italian>Sangue EV (250ml) GS: B-</Italian>
             <Russian>Кровь IV (250 мл) Гk : B-</Russian>
-            <Japanese>血液IV (250ml) B-型</Japanese>
+            <Japanese>血液 IV (250ml) B-型</Japanese>
         </Key>
         <Key ID="STR_KAT_circulation_BloodIV_AB_250">
             <English>Blood IV (250ml) BT: AB+</English>
@@ -377,7 +377,7 @@
             <Turkish>Kan IV (250ml) KG: AB+</Turkish>
             <Italian>Sangue EV (250ml) GS: AB+</Italian>
             <Russian>Кровь IV (250 мл) Гk : AB+</Russian>
-            <Japanese>血液IV (250ml) AB+型</Japanese>
+            <Japanese>血液 IV (250ml) AB+型</Japanese>
         </Key>
         <Key ID="STR_KAT_circulation_BloodIV_AB_250_N">
             <English>Blood IV (250ml) BT: AB-</English>
@@ -391,7 +391,7 @@
             <Turkish>Kan IV (250ml) KG: AB-</Turkish>
             <Italian>Sangue EV (250ml) GS: AB-</Italian>
             <Russian>Кровь IV (250 мл) Гk : AB-</Russian>
-            <Japanese>血液IV (250ml) AB-型</Japanese>
+            <Japanese>血液 IV (250ml) AB-型</Japanese>
         </Key>
         <Key ID="STR_KAT_circulation_Action_BloodIV_O">
             <English>Give Blood IV (1000ml) BT: 0+</English>
@@ -405,7 +405,7 @@
             <Turkish>Kan IV (1000ml) KG: 0+ Ver</Turkish>
             <Italian>Somministrare Sangue EV (1000ml) GS: 0+</Italian>
             <Russian>Переливание крови IV (1000 мл) Гk : 0+</Russian>
-            <Japanese>血液IV (1000ml) O+型 を投与</Japanese>
+            <Japanese>血液 IV (1000ml) O+型 を投与</Japanese>
         </Key>
         <Key ID="STR_KAT_circulation_Action_BloodIV_O_N">
             <English>Give Blood IV (1000ml) BT: 0-</English>
@@ -419,7 +419,7 @@
             <Turkish>Kan IV (1000ml) KG: 0- Ver</Turkish>
             <Italian>Somministrare Sangue EV (1000ml) GS: 0-</Italian>
             <Russian>Переливание крови IV (1000 мл) Гk : 0-</Russian>
-            <Japanese>血液IV (1000ml) O-型 を投与</Japanese>
+            <Japanese>血液 IV (1000ml) O-型 を投与</Japanese>
         </Key>
         <Key ID="STR_KAT_circulation_Action_BloodIV_A">
             <English>Give Blood IV (1000ml) BT: A+</English>
@@ -433,7 +433,7 @@
             <Turkish>Kan IV (1000ml) KG: A+ Ver</Turkish>
             <Italian>Somministrare Sangue EV (1000ml) GS: A+</Italian>
             <Russian>Переливание крови IV (1000 мл) Гk : А+</Russian>
-            <Japanese>血液IV (1000ml) A+型 を投与</Japanese>
+            <Japanese>血液 IV (1000ml) A+型 を投与</Japanese>
         </Key>
         <Key ID="STR_KAT_circulation_Action_BloodIV_A_N">
             <English>Give Blood IV (1000ml) BT: A-</English>
@@ -447,7 +447,7 @@
             <Turkish>Kan IV (1000ml) KG: A- Ver</Turkish>
             <Italian>Somministrare Sangue EV (1000ml) GS: A-</Italian>
             <Russian>Переливание крови IV (1000 мл) Гk : А-</Russian>
-            <Japanese>血液IV (1000ml) A-型 を投与</Japanese>
+            <Japanese>血液 IV (1000ml) A-型 を投与</Japanese>
         </Key>
         <Key ID="STR_KAT_circulation_Action_BloodIV_B">
             <English>Give Blood IV (1000ml) BT: B+</English>
@@ -461,7 +461,7 @@
             <Turkish>Kan IV (1000ml) KG: B+ Ver</Turkish>
             <Italian>Somministrare Sangue EV (1000ml) GS: B+</Italian>
             <Russian>Переливание крови IV (1000 мл) Гk : B+</Russian>
-            <Japanese>血液IV (1000ml) B+型 を投与</Japanese>
+            <Japanese>血液 IV (1000ml) B+型 を投与</Japanese>
         </Key>
         <Key ID="STR_KAT_circulation_Action_BloodIV_B_N">
             <English>Give Blood IV (1000ml) BT: B-</English>
@@ -475,7 +475,7 @@
             <Turkish>Kan IV (1000ml) KG: B- Ver</Turkish>
             <Italian>Somministrare Sangue EV (1000ml) GS: B-</Italian>
             <Russian>Переливание крови IV (1000 мл) Гk : B-</Russian>
-            <Japanese>血液IV (1000ml) B-型 を投与</Japanese>
+            <Japanese>血液 IV (1000ml) B-型 を投与</Japanese>
         </Key>
         <Key ID="STR_KAT_circulation_Action_BloodIV_AB">
             <English>Give Blood IV (1000ml) BT: AB+</English>
@@ -489,7 +489,7 @@
             <Turkish>Kan IV (1000ml) KG: AB+ Ver</Turkish>
             <Italian>Somministrare Sangue EV (1000ml) GS: AB+</Italian>
             <Russian>Переливание крови IV (1000 мл) Гk : АB+</Russian>
-            <Japanese>血液IV (1000ml) AB+型 を投与</Japanese>
+            <Japanese>血液 IV (1000ml) AB+型 を投与</Japanese>
         </Key>
         <Key ID="STR_KAT_circulation_Action_BloodIV_AB_N">
             <English>Give Blood IV (1000ml) BT: AB-</English>
@@ -503,7 +503,7 @@
             <Turkish>Kan IV (1000ml) KG: AB- Ver</Turkish>
             <Italian>Somministrare Sangue EV (1000ml) GS: AB-</Italian>
             <Russian>Переливание крови IV (1000 мл) Гk : АB-</Russian>
-            <Japanese>血液IV (1000ml) AB-型 を投与</Japanese>
+            <Japanese>血液 IV (1000ml) AB-型 を投与</Japanese>
         </Key>
         <Key ID="STR_KAT_circulation_Action_500_BloodIV_O">
             <English>Give Blood IV (500ml) BT: 0+</English>
@@ -517,7 +517,7 @@
             <Turkish>Kan IV (500ml) KG: 0+ Ver</Turkish>
             <Italian>Somministrare Sangue EV (500ml) GS: 0+</Italian>
             <Russian>Переливание крови IV (500 мл) Гk : 0+</Russian>
-            <Japanese>血液IV (500ml) O+型 を投与</Japanese>
+            <Japanese>血液 IV (500ml) O+型 を投与</Japanese>
         </Key>
         <Key ID="STR_KAT_circulation_Action_500_BloodIV_O_N">
             <English>Give Blood IV (500ml) BT: 0-</English>
@@ -531,7 +531,7 @@
             <Turkish>Kan IV (500ml) KG: 0- Ver</Turkish>
             <Italian>Somministrare Sangue EV (500ml) GS: 0-</Italian>
             <Russian>Переливание крови IV (500 мл) Гk : 0-</Russian>
-            <Japanese>血液IV (500ml) O-型 を投与</Japanese>
+            <Japanese>血液 IV (500ml) O-型 を投与</Japanese>
         </Key>
         <Key ID="STR_KAT_circulation_Action_500_BloodIV_A">
             <English>Give Blood IV (500ml) BT: A+</English>
@@ -545,7 +545,7 @@
             <Turkish>Kan IV (500ml) KG: A+ Ver</Turkish>
             <Italian>Somministrare Sangue EV (500ml) GS: A+</Italian>
             <Russian>Переливание крови IV (500 мл) Гk : A+</Russian>
-            <Japanese>血液IV (500ml) A+型 を投与</Japanese>
+            <Japanese>血液 IV (500ml) A+型 を投与</Japanese>
         </Key>
         <Key ID="STR_KAT_circulation_Action_500_BloodIV_A_N">
             <English>Give Blood IV (500ml) BT: A-</English>
@@ -559,7 +559,7 @@
             <Turkish>Kan IV (500ml) KG: A- Ver</Turkish>
             <Italian>Somministrare Sangue EV (500ml) GS: A-</Italian>
             <Russian>Переливание крови IV (500 мл) Гk : A-</Russian>
-            <Japanese>血液IV (500ml) A-型 を投与</Japanese>
+            <Japanese>血液 IV (500ml) A-型 を投与</Japanese>
         </Key>
         <Key ID="STR_KAT_circulation_Action_500_BloodIV_B">
             <English>Give Blood IV (500ml) BT: B+</English>
@@ -573,7 +573,7 @@
             <Turkish>Kan IV (500ml) KG: B+ Ver</Turkish>
             <Italian>Somministrare Sangue EV (500ml) GS: B+</Italian>
             <Russian>Переливание крови IV (500 мл) Гk : B+</Russian>
-            <Japanese>血液IV (500ml) B+型 を投与</Japanese>
+            <Japanese>血液 IV (500ml) B+型 を投与</Japanese>
         </Key>
         <Key ID="STR_KAT_circulation_Action_500_BloodIV_B_N">
             <English>Give Blood IV (500ml) BT: B-</English>
@@ -587,7 +587,7 @@
             <Turkish>Kan IV (500ml) KG: B- Ver</Turkish>
             <Italian>Somministrare Sangue EV (500ml) GS: B-</Italian>
             <Russian>Переливание крови IV (500 мл) Гk : B-</Russian>
-            <Japanese>血液IV (500ml) B-型 を投与</Japanese>
+            <Japanese>血液 IV (500ml) B-型 を投与</Japanese>
         </Key>
         <Key ID="STR_KAT_circulation_Action_500_BloodIV_AB">
             <English>Give Blood IV (500ml) BT: AB+</English>
@@ -601,7 +601,7 @@
             <Turkish>Kan IV (500ml) KG: AB+ Ver</Turkish>
             <Italian>Somministrare Sangue EV (500ml) GS: AB+</Italian>
             <Russian>Переливание крови IV (500 мл) Гk : AB+</Russian>
-            <Japanese>血液IV (500ml) AB+型 を投与</Japanese>
+            <Japanese>血液 IV (500ml) AB+型 を投与</Japanese>
         </Key>
         <Key ID="STR_KAT_circulation_Action_500_BloodIV_AB_N">
             <English>Give Blood IV (500ml) BT: AB-</English>
@@ -615,7 +615,7 @@
             <Turkish>Kan IV (500ml) KG: AB- Ver</Turkish>
             <Italian>Somministrare Sangue EV (500ml) GS: AB-</Italian>
             <Russian>Переливание крови IV (500 мл) Гk : AB-</Russian>
-            <Japanese>血液IV (500ml) AB-型 を投与</Japanese>
+            <Japanese>血液 IV (500ml) AB-型 を投与</Japanese>
         </Key>
         <Key ID="STR_KAT_circulation_Action_250_BloodIV_O">
             <English>Give Blood IV (250ml) BT: 0+</English>
@@ -629,7 +629,7 @@
             <Turkish>Kan IV (250ml) KG: 0+ Ver</Turkish>
             <Italian>Somministrare Sangue EV (250ml) GS: 0+</Italian>
             <Russian>Переливание крови IV (250 мл) Гk : 0+</Russian>
-            <Japanese>血液IV (250ml) O+型 を投与</Japanese>
+            <Japanese>血液 IV (250ml) O+型 を投与</Japanese>
         </Key>
         <Key ID="STR_KAT_circulation_Action_250_BloodIV_O_N">
             <English>Give Blood IV (250ml) BT: 0-</English>
@@ -643,7 +643,7 @@
             <Turkish>Kan IV (250ml) KG: 0- Ver</Turkish>
             <Italian>Somministrare Sangue EV (250ml) GS: 0-</Italian>
             <Russian>Переливание крови IV (250 мл) Гk : 0-</Russian>
-            <Japanese>血液IV (250ml) O-型 を投与</Japanese>
+            <Japanese>血液 IV (250ml) O-型 を投与</Japanese>
         </Key>
         <Key ID="STR_KAT_circulation_Action_250_BloodIV_A">
             <English>Give Blood IV (250ml) BT: A+</English>
@@ -657,7 +657,7 @@
             <Turkish>Kan IV (250ml) KG: A+ Ver</Turkish>
             <Italian>Somministrare Sangue EV (250ml) GS: A+</Italian>
             <Russian>Переливание крови IV (250 мл) Гk : A+</Russian>
-            <Japanese>血液IV (250ml) A+型 を投与</Japanese>
+            <Japanese>血液 IV (250ml) A+型 を投与</Japanese>
         </Key>
         <Key ID="STR_KAT_circulation_Action_250_BloodIV_A_N">
             <English>Give Blood IV (250ml) BT: A-</English>
@@ -671,7 +671,7 @@
             <Turkish>Kan IV (250ml) KG: A- Ver</Turkish>
             <Italian>Somministrare Sangue EV (250ml) GS: A-</Italian>
             <Russian>Переливание крови IV (250 мл) Гk : A-</Russian>
-            <Japanese>血液IV (250ml) A-型 を投与</Japanese>
+            <Japanese>血液 IV (250ml) A-型 を投与</Japanese>
         </Key>
         <Key ID="STR_KAT_circulation_Action_250_BloodIV_B">
             <English>Give Blood IV (250ml) BT: B+</English>
@@ -685,7 +685,7 @@
             <Turkish>Kan IV (250ml) KG: B+ Ver</Turkish>
             <Italian>Somministrare Sangue EV (250ml) GS: B+</Italian>
             <Russian>Переливание крови IV (250 мл) Гk : B+</Russian>
-            <Japanese>血液IV (250ml) B+型 を投与</Japanese>
+            <Japanese>血液 IV (250ml) B+型 を投与</Japanese>
         </Key>
         <Key ID="STR_KAT_circulation_Action_250_BloodIV_B_N">
             <English>Give Blood IV (250ml) BT: B-</English>
@@ -699,7 +699,7 @@
             <Turkish>Kan IV (250ml) KG: B- Ver</Turkish>
             <Italian>Somministrare Sangue EV (250ml) GS: B-</Italian>
             <Russian>Переливание крови IV (250 мл) Гk : B-</Russian>
-            <Japanese>血液IV (250ml) B-型 を投与</Japanese>
+            <Japanese>血液 IV (250ml) B-型 を投与</Japanese>
         </Key>
         <Key ID="STR_KAT_circulation_Action_250_BloodIV_AB">
             <English>Give Blood IV (250ml) BT: AB+</English>
@@ -713,7 +713,7 @@
             <Turkish>Kan IV (250ml) KG: AB+ Ver</Turkish>
             <Italian>Somministrare Sangue EV (250ml) GS: AB+</Italian>
             <Russian>Переливание крови IV (250 мл) Гk : AB+</Russian>
-            <Japanese>血液IV (250ml) AB+型 を投与</Japanese>
+            <Japanese>血液 IV (250ml) AB+型 を投与</Japanese>
         </Key>
         <Key ID="STR_KAT_circulation_Action_250_BloodIV_AB_N">
             <English>Give Blood IV (250ml) BT: AB-</English>
@@ -727,7 +727,7 @@
             <Turkish>Kan IV (250ml) KG: AB- Ver</Turkish>
             <Italian>Somministrare Sangue EV (250ml) GS: AB-</Italian>
             <Russian>Переливание крови IV (250 мл) Гk : AB-</Russian>
-            <Japanese>血液IV (250ml) AB-型 を投与</Japanese>
+            <Japanese>血液 IV (250ml) AB-型 を投与</Japanese>
         </Key>
         <Key ID="STR_KAT_circulation_Using">
             <English>Using</English>
@@ -1063,7 +1063,7 @@
             <Turkish>Kan Grubu Tablosunu Açın</Turkish>
             <Italian>Apri tavola dei gruppi sanguigni</Italian>
             <Russian>Открытая шпаргалка по группам крови</Russian>
-            <Japanese>血液型適合性チャートシートを開く</Japanese>
+            <Japanese>血液型適合確認シートを開く</Japanese>
         </Key>
         <Key ID="STR_KAT_circulation_place_AED">
             <English>Place AED</English>
@@ -1189,7 +1189,7 @@
             <Turkish>Oyuncuyu canlandırmak için kullanın</Turkish>
             <Italian>Utilizzato per resuscitare un giocatore</Italian>
             <Russian>Используйте, чтобы реанимировать игрока</Russian>
-            <Japanese>プレーヤーを蘇生させるために使用する</Japanese>
+            <Japanese>人を蘇生させるために使用されます</Japanese>
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_Activity_AED">
             <English>%1 performed AED</English>
@@ -1245,7 +1245,7 @@
             <Turkish>AED-X için başarı şansı</Turkish>
             <Russian>Шанс на успех для AED-X</Russian>
             <Italian>Probabilità di successo del DAE-X</Italian>
-            <Japanese>AED-Xの成功チャンス</Japanese>
+            <Japanese>AED-Xの蘇生成功率</Japanese>
         </Key>
         <Key ID="STR_KAT_circulation_SUCESSCHANCE_AED">
             <English>Success chance for AED</English>
@@ -1259,7 +1259,7 @@
             <Turkish>AED için başarı şansı</Turkish>
             <Russian>Шанс успеха для AED</Russian>
             <Italian>Probabilità di successo del DAE</Italian>
-            <Japanese>AEDの成功チャンス</Japanese>
+            <Japanese>AEDの蘇生成功率</Japanese>
         </Key>
         <Key ID="STR_KAT_circulation_ALLOW_AED">
             <English>Allow AED</English>
@@ -1273,7 +1273,7 @@
             <Turkish>AED'e izin ver</Turkish>
             <Russian>Разрешить AED</Russian>
             <Italian>Permetti il DAE</Italian>
-            <Japanese>AEDを許可する</Japanese>
+            <Japanese>AEDの許可</Japanese>
         </Key>
         <Key ID="STR_KAT_circulation_TRAINING_LEVEL_AED">
             <English>Training level required to use an AED</English>
@@ -1287,7 +1287,7 @@
             <Turkish>AED kullanmak için gerekli eğitim seviyesi</Turkish>
             <Russian>Уровень подготовки, необходимый для использования AED</Russian>
             <Italian>Livello d'addestramento richiesto per usare il DAE</Italian>
-            <Japanese>AEDを使用するために必要な訓練レベル</Japanese>
+            <Japanese>AEDの使用に訓練レベルを必要とさせます。</Japanese>
         </Key>
         <Key ID="STR_KAT_circulation_ALLOW_AED_X">
             <English>Allow AED-X</English>
@@ -1301,7 +1301,7 @@
             <Turkish>AED-X'e izin ver</Turkish>
             <Russian>Разрешить AED-X</Russian>
             <Italian>Permetti il DAE-X</Italian>
-            <Japanese>AED-Xを許可する</Japanese>
+            <Japanese>AED-Xの許可</Japanese>
         </Key>
         <Key ID="STR_KAT_circulation_TRAINING_LEVEL_AED_X">
             <English>Training level required to use an AED-X</English>
@@ -1315,7 +1315,7 @@
             <Turkish>AED-X kullanmak için gerekli eğitim seviyesi</Turkish>
             <Russian>Уровень подготовки, необходимый для использования AED-X</Russian>
             <Italian>Livello d'addestramento richiesto per usare il DAE-X</Italian>
-            <Japanese>AED-Xを使用するために必要な訓練レベル</Japanese>
+            <Japanese>AED-Xの使用に訓練レベルを必要とさせます。</Japanese>
         </Key>
         <Key ID="STR_KAT_circulation_DISTANCELIMIT_AED_X">
             <English>Distance limit for AED-X in meters</English>
@@ -1371,7 +1371,7 @@
             <Turkish>Tıbbi eğitim seviyesi başına farklı CPR şansı sağlayın</Turkish>
             <Italian>Attivare diverse possibilità di riuscita della RCP per livello medico</Italian>
             <Russian>Включить разные шансы СЛР для каждого медицинского уровня</Russian>
-            <Japanese>医療レベルごとにCPRの成功チャンスを変更する</Japanese>
+            <Japanese>医療レベルごとにCPRの成功率を変更する</Japanese>
         </Key>
         <Key ID="STR_KAT_circulation_SETTING_CPR_CHANCE_DOCTOR">
             <English>CPR Chance for Doctors</English>
@@ -1385,7 +1385,7 @@
             <Turkish>Doktorlar için CPR Şansı</Turkish>
             <Italian>Probabilità di RCP per i dottori</Italian>
             <Russian>Шанс СЛР для врачей</Russian>
-            <Japanese>医師のCPRチャンス</Japanese>
+            <Japanese>医師のCPR蘇生成功率</Japanese>
         </Key>
         <Key ID="STR_KAT_circulation_SETTING_CPR_CHANCE_REGULARMEDIC">
             <English>CPR Chance for Regular medics</English>
@@ -1399,7 +1399,7 @@
             <Turkish>İlk yardım uzmanları için CPR Şansı</Turkish>
             <Italian>Probabilità di RCP per i medici</Italian>
             <Russian>Шанс СЛР для обычных медиков</Russian>
-            <Japanese>衛生兵のCPRチャンス</Japanese>
+            <Japanese>衛生兵のCPR蘇生成功率</Japanese>
         </Key>
         <Key ID="STR_KAT_circulation_SETTING_CPR_CHANCE_DEFAULT">
             <English>CPR Chance for Default</English>
@@ -1413,7 +1413,7 @@
             <Turkish>Varsayılan CPR Şansı</Turkish>
             <Italian>Probabilità di RCP per default</Italian>
             <Russian>Шанс СЛР по умолчанию</Russian>
-            <Japanese>デフォルトのCPRチャンス</Japanese>
+            <Japanese>デフォルトのCPR蘇生成功率</Japanese>
         </Key>
         <Key ID="STR_KAT_circulation_FieldBloodTK500_Display">
             <English>Field Blood Transfusion Kit (500ml)</English>
@@ -1469,7 +1469,7 @@
             <Turkish>Kan Al (500ml) </Turkish>
             <Italian>Disegna sangue (500 ml) </Italian>
             <Russian>Взять кровь (500 мл)</Russian>
-            <Japanese>採血 (500ml)</Japanese>
+            <Japanese>採血する (500ml)</Japanese>
         </Key>
         <Key ID="STR_KAT_circulation_DrawBlood250_Action_Use">
             <English>Draw Blood (250ml)</English>
@@ -1483,7 +1483,7 @@
             <Turkish>Kan Al (250ml) </Turkish>
             <Italian>Disegna sangue (250 ml) </Italian>
             <Russian>Взять кровь (250 мл)</Russian>
-            <Japanese>採血 (250ml)</Japanese>
+            <Japanese>採血する (250ml)</Japanese>
         </Key>
         <Key ID="STR_KAT_circulation_DrawBlood_Action_Progress">
             <English>Drawing Blood</English>
@@ -1497,7 +1497,7 @@
             <Turkish>Kan Alma </Turkish>
             <Italian>Prelevare sangue</Italian>
             <Russian>Рисование крови</Russian>
-            <Japanese>採血</Japanese>
+            <Japanese>採血中</Japanese>
         </Key>
         <Key ID="STR_kat_circulation_SETTING_DRAW_BLOODGROUPS">
             <English>Use Bloodgroups for drawing blood?</English>

--- a/addons/misc/stringtable.xml
+++ b/addons/misc/stringtable.xml
@@ -13,7 +13,7 @@
             <Turkish>ACE-Misc activated?</Turkish>
             <Italian>Attivare ACE-Misc?</Italian>
             <Russian>ACE-Misc активирован?</Russian>
-            <Japanese>ACE-Misc を有効化しますか?</Japanese>
+            <Japanese>KAM-Misc を有効化しますか?</Japanese>
         </Key>
         <Key ID="STR_kat_misc_Action_add_IV">
             <English>Attaching IV</English>
@@ -41,7 +41,7 @@
             <Turkish>IV (1000ml) Bağla</Turkish>
             <Italian>Somministrare EV (1000ml)</Italian>
             <Russian>Присоединить IV  (1000 мл)</Russian>
-            <Japanese>IVを取り付ける(1000ml)</Japanese>
+            <Japanese>IVを取り付ける (1000ml)</Japanese>
         </Key>
         <Key ID="STR_kat_misc_Action_add_IV_Display_500">
             <English>Attach IV (500ml)</English>
@@ -55,7 +55,7 @@
             <Turkish>IV (500ml) Bağla</Turkish>
             <Italian>Somministrare EV (500ml)</Italian>
             <Russian>Прикрепить IV (500 мл)</Russian>
-            <Japanese>IVを取り付ける(500ml)</Japanese>
+            <Japanese>IVを取り付ける (500ml)</Japanese>
         </Key>
         <Key ID="STR_kat_misc_Action_add_IV_Display_250">
             <English>Attach IV (250ml)</English>
@@ -69,7 +69,7 @@
             <Turkish>IV (250ml) Bağla</Turkish>
             <Italian>Somministrare EV (250ml)</Italian>
             <Russian>Прикрепить IV (250 мл)</Russian>
-            <Japanese>IVを取り付ける(250ml)</Japanese>
+            <Japanese>IVを取り付ける (250ml)</Japanese>
         </Key>
         <Key ID="STR_kat_misc_Display_IVStand">
             <English>Stand: Saline IV (1000ml)</English>
@@ -83,7 +83,7 @@
             <Turkish>Stant: Seruym IV (1000ml)</Turkish>
             <Italian>Supporto: Fisiologica EV (1000ml)</Italian>
             <Russian>Подставка: Физиологический раствор IV (1000 мл)</Russian>
-            <Japanese>スタンド: 生理食塩水IV(1000ml)</Japanese>
+            <Japanese>スタンド: 生理食塩水IV (1000ml)</Japanese>
         </Key>
         <Key ID="STR_kat_misc_Display_IVStand_500">
             <English>Stand: Saline IV (500ml)</English>
@@ -97,7 +97,7 @@
             <Turkish>Stant: Seruym IV (500ml)</Turkish>
             <Italian>Supporto: Fisiologica EV (500ml)</Italian>
             <Russian>Подставка: Физиологический раствор IV (500 мл)</Russian>
-            <Japanese>スタンド: 生理食塩水IV(500ml)</Japanese>
+            <Japanese>スタンド: 生理食塩水IV (500ml)</Japanese>
         </Key>
         <Key ID="STR_kat_misc_Display_IVStand_250">
             <English>Stand: Saline IV (250ml)</English>
@@ -111,7 +111,7 @@
             <Turkish>Stant: Seruym IV (250ml)</Turkish>
             <Italian>Supporto: Fisiologica EV (250ml)</Italian>
             <Russian>Подставка: Физиологический раствор IV (250 мл)</Russian>
-            <Japanese>スタンド: 生理食塩水IV(250ml)</Japanese>
+            <Japanese>スタンド: 生理食塩水IV (250ml)</Japanese>
         </Key>
         <Key ID="STR_kat_misc_SETTING_LIMITWOUNDS_ENABLE">
             <English>Enable limited wounds</English>
@@ -265,7 +265,7 @@
             <Turkish>Flip Sedye</Turkish>
             <Italian>Flip Barella</Italian>
             <Russian>Флип носилки</Russian>
-            <Japanese>担架を回転させる</Japanese>
+            <Japanese>担架をひっくり返す</Japanese>
         </Key>
         <Key ID="STR_kat_misc_helistretcher_attention1">
             <English>The vehicle you are looking at is not a helicopter!</English>

--- a/addons/pharma/stringtable.xml
+++ b/addons/pharma/stringtable.xml
@@ -12,7 +12,7 @@
             <French>Autoriser Naloxone?</French>
             <Turkish>Oyuncuların Naloxone kullanmasına izin verilsin mi?</Turkish>
             <Italian>Permettere ai giocatori di usare il Naloxone?</Italian>
-            <Japanese>プレイヤーにナロキソンの使用を許可しますか?</Japanese>
+            <Japanese>ナロキソンの使用を許可</Japanese>
             <Russian>Разрешить игрокам использовать налоксон?</Russian>
         </Key>
         <Key ID="STR_kat_pharma_CARBONATE_ACTIVE">
@@ -26,7 +26,7 @@
             <Korean>플레이어가 탄산 암모늄을 사용하도록 허용하시겠습니까?</Korean>
             <Turkish>Oyuncuların Amonyum Karbonat kullanmasına izin verilsin mi?</Turkish>
             <Czech>Povolit hráčům použít Uhličitan amonný?</Czech>
-            <Japanese>プレイヤーに炭酸アンモニウムの使用を許可しますか?</Japanese>
+            <Japanese>炭酸アンモニウムの使用を許可</Japanese>
             <Russian>Разрешить игрокам использовать карбонат аммония?</Russian>
         </Key>
         <Key ID="STR_kat_pharma_TXA_ACTIVE">
@@ -40,7 +40,7 @@
             <Korean>플레이어가 TXA를 사용하도록 허용하시겠습니까?</Korean>
             <Turkish>Oyuncuların TXA kullanmasına izin verilsin mi?</Turkish>
             <Czech>Povolit hráčům použít TXA?</Czech>
-            <Japanese>プレイヤーにトラネキサム酸(TXA)の使用を許可しますか?</Japanese>
+            <Japanese>トラネキサム酸(TXA)の使用を許可</Japanese>
             <Russian>Разрешить игрокам использовать TXA?</Russian>
         </Key>
         <Key ID="STR_kat_pharma_IV_MEDIC">
@@ -54,7 +54,7 @@
             <Korean>IV/IO를 설정하는 데 필요한 의료 수준 변경</Korean>
             <Turkish>IV'leri/IO'ları ayarlamak için gereken tıbbi düzeyi değiştirir</Turkish>
             <Czech>Změní který medický level je potřeba k zavedení IV/IO</Czech>
-            <Japanese>IV/IOを刺入するために必要な医療レベルを変更します</Japanese>
+            <Japanese>IV/IOの許可</Japanese>
             <Russian>Изменяет медицинский уровень, необходимый для установки IV/IO.</Russian>
         </Key>
         <Key ID="STR_kat_pharma_IV_DROP_ENABLE">
@@ -68,7 +68,7 @@
             <French>Activer les délais d'attente pour les IV/IO</French>
             <Turkish>IV/IO bırakma sürelerini etkinleştir</Turkish>
             <Italian>Abilitare i tempi di caduta IV/IO</Italian>
-            <Japanese>IV/IOの時間経過での脱落を有効化</Japanese>
+            <Japanese>IV/IO針の時間経過での脱落</Japanese>
             <Russian>Включает время сброса IV/IO</Russian>
         </Key>
         <Key ID="STR_kat_pharma_IV_DROP">
@@ -82,7 +82,7 @@
             <Korean>IV/IO가 환자에게서 떨어지는 시간을 변경합니다.</Korean>
             <Turkish>IV'lerin/IO'ların bir hastadan düştüğü zamanı değiştirir</Turkish>
             <Czech>Změní čas po kterém samovolně vypadnou IV/IO z pacienta</Czech>
-            <Japanese>IV/IOが脱落する時間</Japanese>
+            <Japanese>IV/IO針が脱落する時間</Japanese>
             <Russian>Изменяет время выпадения IV/IO капельниц у пациента</Russian>
         </Key>
         <Key ID="STR_kat_pharma_IV_REUSE">
@@ -96,7 +96,7 @@
             <Korean>IV/IO 바늘 재사용 가능하나 </Korean>
             <Turkish>IV/IO iğnelerinin yeniden kullanılabilir olup olmadığını ayarlar</Turkish>
             <Czech>Nastaví, zda IV/IO jehly jsou znovu-použitelné</Czech>
-            <Japanese>IV/IO針が再利用可能かどうかを設定します</Japanese>
+            <Japanese>IV/IO針の再利用</Japanese>
             <Russian>Устанавливает, можно ли использовать иглы для IV/IO повторно</Russian>
         </Key>
         <Key ID="STR_kat_pharma_PUSH_TIME">
@@ -110,7 +110,7 @@
             <Korean>IV 약물을 쓸 시간을 밀워</Korean>
             <Turkish>Tüm IV İlaçlar için itme zamanı</Turkish>
             <Czech>Čas potřebný k vstříknutí všech IV léků</Czech>
-            <Japanese>すべての点滴薬の注入時間</Japanese>
+            <Japanese>点滴薬の注入にかかる時間</Japanese>
             <Russian>Время выталкивания всех IV лекарств</Russian>
         </Key>
         <Key ID="STR_kat_pharma_IV_TIME">
@@ -124,7 +124,7 @@
             <Korean>IV를 설정늘하는 시간</Korean>
             <Turkish>IV'ler oluşturma zamanı</Turkish>
             <Czech>Čas k zavedení IV</Czech>
-            <Japanese>IVを刺入する時間</Japanese>
+            <Japanese>IV針の刺入にかかる時間</Japanese>
             <Russian>Время устанавливать IV</Russian>
         </Key>
         <Key ID="STR_kat_pharma_IO_TIME">
@@ -138,7 +138,7 @@
             <Korean>IO 설정을하는 시간</Korean>
             <Turkish>IO'ları oluşturma zamanı</Turkish>
             <Czech>Čas k zavedení IO</Czech>
-            <Japanese>IOを刺入する時間</Japanese>
+            <Japanese>IO針の刺入にかかる時間</Japanese>
             <Russian>Время устанавливать IO</Russian>
         </Key>
         <Key ID="STR_kat_pharma_Painkillers_DescShort">
@@ -572,7 +572,7 @@
             <Korean>노르에피네프린</Korean>
             <Turkish>Norepinefrin</Turkish>
             <Czech>Norepinefrin</Czech>
-            <Japanese>ノルエピネフリン</Japanese>
+            <Japanese>ノルアドレナリン</Japanese>
             <Russian>Норадреналин</Russian>
         </Key>
         <Key ID="STR_kat_pharma_Take_Norep">
@@ -586,7 +586,7 @@
             <Korean>푸쉬 노르에피네프린</Korean>
             <Turkish>Norepinefrin itin</Turkish>
             <Czech>Vstříknout norepinefrin</Czech>
-            <Japanese>ノルエピネフリンを注入</Japanese>
+            <Japanese>ノルアドレナリンを注入</Japanese>
             <Russian>Ввести Норадреналин</Russian>
         </Key>
         <Key ID="STR_kat_pharma_Phenyl_DescShort">
@@ -1048,7 +1048,7 @@
             <French>Stimulation activé?</French>
             <Turkish>Yeniden yönlendirme etkin mi?</Turkish>
             <Italian>Stimolazione abilitata?</Italian>
-            <Japanese>患者に刺激を与える 機能を有効化しますか?</Japanese>
+            <Japanese>患者に刺激を与える機能の有効化</Japanese>
             <Russian>Переориентация включена?</Russian>
         </Key>
         <Key ID="STR_KAT_pharma_SETTING_Reorientation_Enable_DESC">
@@ -1076,7 +1076,7 @@
             <French>Autoriser stimulation</French>
             <Turkish>Yeniden yönlendirmeye izin ver</Turkish>
             <Italian>Autorizza stimolazione</Italian>
-            <Japanese>患者に刺激を与えることが出来る人</Japanese>
+            <Japanese>患者に刺激を与える許可</Japanese>
             <Russian>Разрешить переориентацию</Russian>
         </Key>
         <Key ID="STR_KAT_pharma_SETTING_Allow_Reorientation_DESC">
@@ -1090,7 +1090,7 @@
             <French>Niveau médical requis pour stimulation</French>
             <Turkish>Yeniden oryantasyon için gerekli tıbbi seviye</Turkish>
             <Italian>Livello medico richiesto per stimolazione</Italian>
-            <Japanese>患者を刺激して起こすために必要な医療レベルを変更します</Japanese>
+            <Japanese>患者を刺激を与えるために訓練レベルを必要とさせます。</Japanese>
             <Russian>Медицинский уровень, необходимый для переориентации</Russian>
         </Key>
     </Package>


### PR DESCRIPTION
Includes correction of fatal mistranslations in Japanese.
Since Recovery Position was used as a word equivalent to Head Turning, the meaning is mixed, this patch fixes it.
Also, some words are consistent with the Japanese translation of ACE.

**When merged this pull request will:**
- Update Japanese Translation for Recovery Position
- Mistranslation fix for Head Turning
- Consistent with ACE translation

This pull request is very important for Japanese users but don't have to hurry.