### PR TITLE
SpO2 system improvements

### DIFF
--- a/addons/airway/XEH_preInit.sqf
+++ b/addons/airway/XEH_preInit.sqf
@@ -48,6 +48,16 @@ In real life, this will happen sometimes, not quiet often.
     true
 ] call CBA_Settings_fnc_init;
 
+// Occlusion repeat timer
+[
+    QGVAR(occlusion_repeatTimer),
+    "SLIDER",
+    LLSTRING(SETTING_occlusion_repeatTimer),
+    CBA_SETTINGS_CAT,
+    [1, 1200, 60, 0],
+    true
+] call CBA_Settings_fnc_init;
+
 // Succes for headturning
 [
     QGVAR(probability_headturning),

--- a/addons/airway/functions/fnc_handleAirway.sqf
+++ b/addons/airway/functions/fnc_handleAirway.sqf
@@ -20,11 +20,6 @@ params ["_unit"];
 //Other mods can utilise KAT_Obstruction_Exclussion variable to prevent obstructions from happening
 if ( !(GVAR(enable)) || (_unit getVariable ["KAT_Obstruction_Exclussion", false])) exitWith {};
 
-//if !(_selectionName in ["head", "neck", "face_hub", "body"]) exitWith {};
-// it doesn't make sense to restrict it on the head. 'Cause unconcious state is the reason and not the damage selection
-
 if (random(100) <= GVAR(probability_obstruction)) then {
-	if !(_unit getVariable [QGVAR(obstruction), false]) then {
         _unit setVariable [QGVAR(obstruction), true, true];
-	};
 };

--- a/addons/airway/functions/fnc_handleAirway.sqf
+++ b/addons/airway/functions/fnc_handleAirway.sqf
@@ -17,14 +17,13 @@
 
 params ["_unit"];
 
-if !(GVAR(enable)) exitWith {};
+//Other mods can utilise KAT_Obstruction_Exclussion variable to prevent obstructions from happening
+if ( !(GVAR(enable)) || (_unit getVariable ["KAT_Obstruction_Exclussion", false])) exitWith {};
 
 //if !(_selectionName in ["head", "neck", "face_hub", "body"]) exitWith {};
 // it doesn't make sense to restrict it on the head. 'Cause unconcious state is the reason and not the damage selection
 
 
 if (random(100) <= GVAR(probability_obstruction)) then {
-    if !(_unit getVariable [QGVAR(obstruction), false]) then {
         _unit setVariable [QGVAR(obstruction), true, true];
-    };
 };

--- a/addons/airway/functions/fnc_handleAirway.sqf
+++ b/addons/airway/functions/fnc_handleAirway.sqf
@@ -23,7 +23,8 @@ if ( !(GVAR(enable)) || (_unit getVariable ["KAT_Obstruction_Exclussion", false]
 //if !(_selectionName in ["head", "neck", "face_hub", "body"]) exitWith {};
 // it doesn't make sense to restrict it on the head. 'Cause unconcious state is the reason and not the damage selection
 
-
 if (random(100) <= GVAR(probability_obstruction)) then {
+	if !(_unit getVariable [QGVAR(obstruction), false]) then {
         _unit setVariable [QGVAR(obstruction), true, true];
+	};
 };

--- a/addons/airway/functions/fnc_handlePuking.sqf
+++ b/addons/airway/functions/fnc_handlePuking.sqf
@@ -17,18 +17,16 @@
 
 params ["_unit"];
 
-if !(GVAR(enable)) exitWith {};
-
-if (_unit getVariable ["kat_pukeActive_PFH", false]) exitWith {};
+//Other mods can utilise KAT_Occlusion_Exclusion variable to prevent occlusions from happening
+if ((_unit getVariable ["kat_pukeActive_PFH", false]) || !(GVAR(enable)) || (_unit getVariable ["KAT_Occlusion_Exclusion", false])) exitWith {};
 _unit setVariable ["kat_pukeActive_PFH", true];
-
 
 [{
     params ["_args", "_idPFH"];
     _args params ["_unit"];
-    private _alive = _unit getVariable ["ACE_isUnconscious", false];
+    private _isUnconscious = _unit getVariable ["ACE_isUnconscious", false];
     private _recovery = _unit getVariable [QGVAR(recovery), false];
-    if (!_alive || (_unit getVariable [QGVAR(airway_item), ""] isEqualTo "larynx") || _recovery) exitWith {
+    if ((!(alive _unit)) || !_isUnconscious || (_unit getVariable [QGVAR(airway_item), ""] isEqualTo "larynx") || _recovery) exitWith {
         [_idPFH] call CBA_fnc_removePerFrameHandler;
         _unit setVariable ["kat_pukeActive_PFH", nil];
     };
@@ -40,4 +38,4 @@ _unit setVariable ["kat_pukeActive_PFH", true];
             };
         };
     };
-}, 60, [_unit]] call CBA_fnc_addPerFrameHandler;
+}, GVAR(occlusion_repeatTimer), [_unit]] call CBA_fnc_addPerFrameHandler;

--- a/addons/airway/stringtable.xml
+++ b/addons/airway/stringtable.xml
@@ -78,7 +78,7 @@
         </Key>
         <Key ID="STR_kat_airway_SETTING_occlusion_repeatTimer">
             <English>Occlusion repeat timer</English>
-			<German>Zeit für die Wiederholung des Erbrechens</German>
+            <German>Zeit für die Wiederholung des Erbrechens</German>
         </Key>
         <Key ID="STR_kat_airway_SETTING_puking_sound">
             <English>Activate the puking sound?</English>

--- a/addons/airway/stringtable.xml
+++ b/addons/airway/stringtable.xml
@@ -76,6 +76,9 @@
             <Russian>Вероятность закупорки дыхательных путей</Russian>
             <Japanese>気道異物の確率</Japanese>
         </Key>
+        <Key ID="STR_kat_airway_SETTING_occlusion_repeatTimer">
+            <English>Occlusion repeat timer</English>
+        </Key>
         <Key ID="STR_kat_airway_SETTING_puking_sound">
             <English>Activate the puking sound?</English>
             <German>Erbrechengeräusch abspielen?</German>

--- a/addons/airway/stringtable.xml
+++ b/addons/airway/stringtable.xml
@@ -78,6 +78,7 @@
         </Key>
         <Key ID="STR_kat_airway_SETTING_occlusion_repeatTimer">
             <English>Occlusion repeat timer</English>
+			<German>Zeit für die Wiederholung des Erbrechens</German>
         </Key>
         <Key ID="STR_kat_airway_SETTING_puking_sound">
             <English>Activate the puking sound?</English>

--- a/addons/breathing/XEH_preInit.sqf
+++ b/addons/breathing/XEH_preInit.sqf
@@ -88,6 +88,16 @@ PREP_RECOMPILE_END;
     true
 ] call CBA_Settings_fnc_init;
 
+// breathing SpO2 perfusion multiplier
+[
+    QGVAR(SpO2_PerfusionMultiplier),
+    "SLIDER",
+    LLSTRING(SETTING_PerfusionMultiplier),
+    CBA_SETTINGS_CAT,
+    [0, 10, 1, 1],
+    true
+] call CBA_Settings_fnc_init;
+
 // breathing probability for a pneumothorax
 // a pneumothorax is the presence of air or gas in the cavity between the lungs and the chest wall
 [

--- a/addons/breathing/functions/fnc_handleBreathing.sqf
+++ b/addons/breathing/functions/fnc_handleBreathing.sqf
@@ -32,7 +32,6 @@ if (!local _unit) then {
     if !(alive _unit) exitWith {
         [_idPFH] call CBA_fnc_removePerFrameHandler;
         _unit setVariable ["kat_O2Breathing_PFH", nil];
-        _unit setVariable ["KAT_medical_airwayStatus", 100, true];
     };
 
     private _airway = true;
@@ -59,7 +58,7 @@ if (!local _unit) then {
     //if lethal SpO2 value is activated and lower the value x, then kill _unit
     if ((_status <= GVAR(SpO2_dieValue)) && { GVAR(SpO2_dieActive) && { !_blockDeath } }) exitWith {
         [_idPFH] call CBA_fnc_removePerFrameHandler;
-        [_unit, "#setDead"] call ace_medical_status_fnc_setDead;
+        [_unit, "terminal_SpO2_death"] call ace_medical_status_fnc_setDead;
         _unit setVariable ["kat_O2Breathing_PFH", nil];
     };
 
@@ -107,7 +106,7 @@ if (!local _unit) then {
         };
 
         if ((_heartRate < 20) && {GVAR(SpO2_perfusion)}) then {
-            _output = -0.2 * _multiplierNegative;
+            _output = -0.2 * GVAR(SpO2_PerfusionMultiplier);
         };
 
         if (_heartRate >= 25) then {

--- a/addons/breathing/functions/fnc_handleBreathing.sqf
+++ b/addons/breathing/functions/fnc_handleBreathing.sqf
@@ -17,9 +17,8 @@
 
 params ["_unit"];
 
-if !(GVAR(enable)) exitWith {};
-
-if (_unit getVariable ["kat_O2Breathing_PFH", false]) exitWith {};
+//Other mods can utilise KAT_SpO2Change_Exclusion variable to prevent occlusions from happening
+if ((_unit getVariable ["kat_O2Breathing_PFH", false]) || !(GVAR(enable)) || (_unit getVariable ["KAT_SpO2Change_Exclusion", false])) exitWith {};
 _unit setVariable ["kat_O2Breathing_PFH", true];
 
 if (!local _unit) then {

--- a/addons/breathing/functions/fnc_handlePulmoHit.sqf
+++ b/addons/breathing/functions/fnc_handlePulmoHit.sqf
@@ -19,9 +19,9 @@
  params ["_unit", "_allDamages", "", "_ammo"];
  _allDamages select 0 params ["_damage","_bodyPart"];
 
-if !((GVAR(enable)) || (_bodyPart isEqualTo "Body") || (_ammo isKindOF "BulletBase")) exitWith {};
+if (!(GVAR(enable)) || !(_bodyPart isEqualTo "Body") || !(_ammo isKindOF "BulletBase")) exitWith {};
 //Other mods can utilise KAT_Pneumothorax_Exclusion variable to prevent Pneumothorax from happening
-if ((_damage < GVAR(pneumothoraxDamageThreshold)) || (GVAR(pneumothorax) == 0) || (_unit getVariable ["KAT_Pneumothorax_Exclusion", false])) exitWith {};
+if ((_damage < GVAR(pneumothoraxDamageThreshold)) || (GVAR(pneumothorax) isEqualTo 0) || (_unit getVariable ["KAT_Pneumothorax_Exclusion", false])) exitWith {};
 
 if (random 100 <= GVAR(pneumothorax)) then {
     // add breathing sound

--- a/addons/breathing/functions/fnc_handlePulmoHit.sqf
+++ b/addons/breathing/functions/fnc_handlePulmoHit.sqf
@@ -19,11 +19,9 @@
  params ["_unit", "_allDamages", "", "_ammo"];
  _allDamages select 0 params ["_damage","_bodyPart"];
 
-if !(GVAR(enable)) exitWith {};
-if !(_bodyPart isEqualTo "Body") exitWith {};
-if !(_ammo isKindOF "BulletBase") exitWith {};
-if (_damage < GVAR(pneumothoraxDamageThreshold)) exitWith {};
-if (GVAR(pneumothorax) == 0) exitWith {};
+if !((GVAR(enable)) || (_bodyPart isEqualTo "Body") || (_ammo isKindOF "BulletBase")) exitWith {};
+//Other mods can utilise KAT_Pneumothorax_Exclusion variable to prevent Pneumothorax from happening
+if ((_damage < GVAR(pneumothoraxDamageThreshold)) || (GVAR(pneumothorax) == 0) || (_unit getVariable ["KAT_Pneumothorax_Exclusion", false])) exitWith {};
 
 if (random 100 <= GVAR(pneumothorax)) then {
     // add breathing sound

--- a/addons/breathing/stringtable.xml
+++ b/addons/breathing/stringtable.xml
@@ -78,6 +78,7 @@
         </Key>
         <Key ID="STR_kat_breathing_SETTING_MultiplyPositive">
             <English>SpO2 positive multiplier</English>
+			<German>SpO2 positiver Multiplikator</German>
             <Japanese>SpO2正の乗数</Japanese>
             <Chinesesimp>SpO2值正乘数</Chinesesimp>
             <Russian>Положительный множитель SpO2</Russian>
@@ -86,6 +87,7 @@
         </Key>
         <Key ID="STR_kat_breathing_SETTING_MultiplyNegative">
             <English>SpO2 negative multiplier</English>
+			<German>SpO2 negativer Multiplikator</German>
             <Japanese>SpO2負の乗数</Japanese>
             <Chinesesimp>SpO2值负乘数</Chinesesimp>
             <Russian>Отрицательный множитель SpO2</Russian>
@@ -94,6 +96,7 @@
         </Key>
         <Key ID="STR_kat_breathing_SETTING_SpO2_Perfusion">
             <English>Enable cardiac arrest SpO2 reduction</English>
+			<German>Aktivieren von SpO2-Verlust bei Herzstillstand</German>
             <Japanese>心停止時のSpO2低下を有効化</Japanese>
             <Chinesesimp>心脏骤停时减少SpO2的下降</Chinesesimp>
             <Russian>Включить снижение SpO2 при остановке сердца</Russian>
@@ -102,6 +105,7 @@
         </Key>
         <Key ID="STR_kat_breathing_SETTING_PerfusionMultiplier">
             <English>Perfusion multiplier</English>
+			<German>Perfusionsindex</German>
         </Key>
         <Key ID="STR_kat_breathing_SETTING_pneumothorax">
             <English>Probability for a pneumothorax</English>
@@ -1081,8 +1085,7 @@
             <Chinesesimp>面色发紫的SpO2值</Chinesesimp>
             <Korean>심각한 치아노제 증상 값</Korean>
             <French>Valeur de SpO2 de la cyanose grave</French>
-            <Turkish>Şiddetli Siyanoz SpO2 değeri
-</Turkish>
+            <Turkish>Şiddetli Siyanoz SpO2 değeri</Turkish>
         </Key>
         <Key ID="STR_kat_breathing_SETTING_severeValue_DESC">
             <English>Severe cyanosis value - default 66 SpO2 \nShould be little bit higher than lethal SpO2 value</English>

--- a/addons/breathing/stringtable.xml
+++ b/addons/breathing/stringtable.xml
@@ -100,6 +100,9 @@
             <Korean>심정지 중 SpO2 감소 활성화</Korean>
             <French>Autoriser la réduction de la SpO2 d’arrêt cardiaque</French>
         </Key>
+        <Key ID="STR_kat_breathing_SETTING_PerfusionMultiplier">
+            <English>Perfusion multiplier</English>
+        </Key>
         <Key ID="STR_kat_breathing_SETTING_pneumothorax">
             <English>Probability for a pneumothorax</English>
             <German>Wahrscheinlichkeit für einen Pneumothorax</German>

--- a/addons/breathing/stringtable.xml
+++ b/addons/breathing/stringtable.xml
@@ -78,7 +78,7 @@
         </Key>
         <Key ID="STR_kat_breathing_SETTING_MultiplyPositive">
             <English>SpO2 positive multiplier</English>
-			<German>SpO2 positiver Multiplikator</German>
+            <German>SpO2 positiver Multiplikator</German>
             <Japanese>SpO2正の乗数</Japanese>
             <Chinesesimp>SpO2值正乘数</Chinesesimp>
             <Russian>Положительный множитель SpO2</Russian>
@@ -87,16 +87,16 @@
         </Key>
         <Key ID="STR_kat_breathing_SETTING_MultiplyNegative">
             <English>SpO2 negative multiplier</English>
-			<German>SpO2 negativer Multiplikator</German>
+            <German>SpO2 negativer Multiplikator</German>
             <Japanese>SpO2負の乗数</Japanese>
             <Chinesesimp>SpO2值负乘数</Chinesesimp>
             <Russian>Отрицательный множитель SpO2</Russian>
             <Korean>SpO2의 감소 배율</Korean>
-            <French>Multiplicateur négatif de la SpO2</French>		
+            <French>Multiplicateur négatif de la SpO2</French>        
         </Key>
         <Key ID="STR_kat_breathing_SETTING_SpO2_Perfusion">
             <English>Enable cardiac arrest SpO2 reduction</English>
-			<German>Aktivieren von SpO2-Verlust bei Herzstillstand</German>
+            <German>Aktivieren von SpO2-Verlust bei Herzstillstand</German>
             <Japanese>心停止時のSpO2低下を有効化</Japanese>
             <Chinesesimp>心脏骤停时减少SpO2的下降</Chinesesimp>
             <Russian>Включить снижение SpO2 при остановке сердца</Russian>
@@ -105,7 +105,7 @@
         </Key>
         <Key ID="STR_kat_breathing_SETTING_PerfusionMultiplier">
             <English>Perfusion multiplier</English>
-			<German>Perfusionsindex</German>
+            <German>Perfusionsindex</German>
         </Key>
         <Key ID="STR_kat_breathing_SETTING_pneumothorax">
             <English>Probability for a pneumothorax</English>


### PR DESCRIPTION
- Removed unnecessary setVariable of SpO2 value(Also this will help people to better identify the cause of death)
- Improved clarity of the cause of death due to terminal SpO2 for logging and acex_killTracker feature
- Improved performance of fnc_handleAirway.sqf
- Optimized exitWith conditions
- Added Exclusion variable checks for other mods that could utilize it to prevent certain things from happening(Like whole SpO2 change, Occlusions, Obstructions or Pneumothorax)
- Added alive check for handlePuking(Sometimes dead units puked even though they should not)
- Added Occlusion repeat timer
- added SpO2 perfusion multiplier
