### PR TITLE
Incompatible addon warning

### DIFF
--- a/addons/misc/XEH_PREP.hpp
+++ b/addons/misc/XEH_PREP.hpp
@@ -15,3 +15,4 @@ PREP(heliStretcherAttach);
 PREP(actionLowerBy10);
 PREP(addActionRaise);
 PREP(heliAddActionDeploy);
+PREP(incompatibilityWarning);

--- a/addons/misc/XEH_postInit.sqf
+++ b/addons/misc/XEH_postInit.sqf
@@ -28,3 +28,7 @@
     params ["_unit", "_container", "_item", "_slot", "_params"];
     [_unit,_item] call kat_misc_fnc_heliStretcherAttach;
 },true] call CBA_fnc_addItemContextMenuOption;
+
+if (GVAR(incompatibilityWarning)) then {
+     call FUNC(incompatibilityWarning);
+};

--- a/addons/misc/XEH_preInit.sqf
+++ b/addons/misc/XEH_preInit.sqf
@@ -18,4 +18,14 @@ PREP_RECOMPILE_END;
     true
 ] call CBA_Settings_fnc_init;
 
+//Incompatibility Warning with other addons
+[
+    QGVAR(incompatibilityWarning),
+    "CHECKBOX",
+    [LLSTRING(SETTING_incompatibilityWarning), LLSTRING(SETTING_incompatibilityWarning_Desc)],
+    CBA_SETTINGS_CAT,
+    [true],
+    true
+] call CBA_Settings_fnc_init;
+
 ADDON = true;

--- a/addons/misc/functions/fnc_incompatibilityWarning.sqf
+++ b/addons/misc/functions/fnc_incompatibilityWarning.sqf
@@ -22,7 +22,7 @@ private _foundIncompatibleAddons = [];
 { if (isClass(configFile >> "CfgPatches" >> _x)) then {
 	_foundIncompatibleAddons append [_x];
 	         //Incompatible addons
-}; } forEach ["BAD_EXAMPLE_ADDON1","BAD_EXAMPLE_ADDON2","addon2bleeeee","addon3bleeeee"];
+}; } forEach ["KATMEDICALSTATIC","kat_evac","KATMEDICALsteth","adv_aceCPR","aceP_main"];
 
 if ((count _foundIncompatibleAddons) > 0) then {
 	diag_log format [LLSTRING(incompatibilityWarning_Desc), _foundIncompatibleAddons];

--- a/addons/misc/functions/fnc_incompatibilityWarning.sqf
+++ b/addons/misc/functions/fnc_incompatibilityWarning.sqf
@@ -1,0 +1,43 @@
+#include "script_component.hpp"
+/*
+ * Author: YetheSamartaka
+ * Throws a warning and add line to RPT log if incompatible addons(Listed by us - developers) that
+ * could negatively affect correct functionality of KAT are used. Warning disappears after 60 seconds.
+ *
+ * Arguments:
+ * None
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * call kat_misc_fnc_incompatibilityWarning
+ *
+ * Public: No
+ */
+
+private _foundIncompatibleAddons = [];
+
+//Checks if incompatible addons are loaded
+{ if (isClass(configFile >> "CfgPatches" >> _x)) then {
+	_foundIncompatibleAddons append [_x];
+	         //Incompatible addons
+}; } forEach ["BAD_EXAMPLE_ADDON1","BAD_EXAMPLE_ADDON2","addon2bleeeee","addon3bleeeee"];
+
+if ((count _foundIncompatibleAddons) > 0) then {
+	diag_log format [LLSTRING(incompatibilityWarning_Desc), _foundIncompatibleAddons];
+	private _text = format [LLSTRING(incompatibilityWarning_Desc), _foundIncompatibleAddons];
+    if (hasInterface) then {
+        _text = composeText [lineBreak, parseText format ["<t align='center'>%1</t>", _text]];
+        private _rscLayer = "ACE_RscErrorHint" call BIS_fnc_rscLayer;
+        _rscLayer cutRsc ["ACE_RscErrorHint", "PLAIN", 0, true];
+        disableSerialization;
+        private _ctrlHint = uiNamespace getVariable "ACE_ctrlErrorHint";
+        _ctrlHint ctrlSetStructuredText _text;
+
+		//Removes Warning message after 60 seconds
+		[{params ["_rscLayer"];
+            _rscLayer cutFadeOut 0.2;
+        }, [_rscLayer], 60] call CBA_fnc_waitAndExecute;		
+    };
+};

--- a/addons/misc/functions/fnc_incompatibilityWarning.sqf
+++ b/addons/misc/functions/fnc_incompatibilityWarning.sqf
@@ -22,6 +22,7 @@ private _foundIncompatibleAddons = [];
 { if (isClass(configFile >> "CfgPatches" >> _x)) then {
 	_foundIncompatibleAddons append [_x];
 	         //Incompatible addons
+		 //Here is the Wiki page with current list: https://github.com/Tomcat-SG/KAM/wiki/Incompatible-addons
 }; } forEach ["KATMEDICALSTATIC","kat_evac","KATMEDICALsteth","adv_aceCPR","aceP_main"];
 
 if ((count _foundIncompatibleAddons) > 0) then {

--- a/addons/misc/stringtable.xml
+++ b/addons/misc/stringtable.xml
@@ -346,5 +346,17 @@
             <Russian>Позволяет прикрепить носилки к вертолету (двойной щелчок)</Russian>
             <Japanese>ヘリコプターに担架を取り付けることができます(ダブルクリック)</Japanese>
         </Key>
+        <Key ID="STR_kat_misc_SETTING_incompatibilityWarning">
+            <English>Incompatible addon warning</English>
+            <Czech>Varování nekompatibilního addonu</Czech>
+        </Key>
+        <Key ID="STR_kat_misc_SETTING_incompatibilityWarning_Desc">
+            <English>Throws a warning and add line to RPT log if incompatible addons(Listed by us - developers) that could negatively affect correct functionality of KAT are used.\n Warning disappears after 60 seconds.</English>
+            <Czech>Vyhodí varování a přidá řádek do RPT logu pokud jsou použity nekompatibilní addony(Zanesené námi - vývojáři), které by mohli negativně ovlivnit správnou funkcionalitu KATu.\n Varování zmizí po 60 sekundách. </Czech>
+        </Key>
+        <Key ID="STR_kat_misc_incompatibilityWarning_Desc">
+            <English>[KAM WARNING] Incompatible addon(s) that could negatively affect correct functionality detected. KAT - Advanced Medical REWRITE Development Team strongly advises to remove these addons: %1</English>
+            <Czech>[KAM VAROVÁNÍ] Nekompatibilní addon(y), které by mohly negativně ovlivnit správnou funkcionalitu detekovány. KAT - Advanced Medical REWRITE Developerský Tým silně doporučuje odebrat tyto addony: %1</Czech>
+        </Key>
     </Package>
 </Project>

--- a/addons/misc/stringtable.xml
+++ b/addons/misc/stringtable.xml
@@ -348,18 +348,18 @@
         </Key>
         <Key ID="STR_kat_misc_SETTING_incompatibilityWarning">
             <English>Incompatible addon warning</English>
-			<German>Inkompatible Mods Warnung</German>
+            <German>Inkompatible Mods Warnung</German>
             <Czech>Varování nekompatibilního addonu</Czech>
         </Key>
         <Key ID="STR_kat_misc_SETTING_incompatibilityWarning_Desc">
             <English>Throws a warning and add line to RPT log if incompatible addons(Listed by us - developers) that could negatively affect correct functionality of KAT are used.\n Warning disappears after 60 seconds.</English>
-			<German>Wirft eine Warnung aus und fügt eine Zeile in das RPT-Protokoll ein, wenn inkompatible Addons (von uns aufgelistet - Entwickler) verwendet werden, die die korrekte Funktionalität von KAT beeinträchtigen könnten. Die Warnung verschwindet nach 60 Sekunden.</German>
-			<Czech>Vyhodí varování a přidá řádek do RPT logu pokud jsou použity nekompatibilní addony(Zanesené námi - vývojáři), které by mohli negativně ovlivnit správnou funkcionalitu KATu.\n Varování zmizí po 60 sekundách. </Czech>
+            <German>Wirft eine Warnung aus und fügt eine Zeile in das RPT-Protokoll ein, wenn inkompatible Addons (von uns aufgelistet - Entwickler) verwendet werden, die die korrekte Funktionalität von KAT beeinträchtigen könnten. Die Warnung verschwindet nach 60 Sekunden.</German>
+            <Czech>Vyhodí varování a přidá řádek do RPT logu pokud jsou použity nekompatibilní addony(Zanesené námi - vývojáři), které by mohli negativně ovlivnit správnou funkcionalitu KATu.\n Varování zmizí po 60 sekundách. </Czech>
         </Key>
         <Key ID="STR_kat_misc_incompatibilityWarning_Desc">
             <English>[KAM WARNING] Incompatible addon(s) that could negatively affect correct functionality detected. KAT - Advanced Medical REWRITE Development Team strongly advises to remove these addons: %1</English>
-			<German>[KAM WARNUNG] Es wurden inkompatible Addons entdeckt, die die korrekte Funktionalität beeinträchtigen könnten. Das KAT - Advanced Medical REWRITE Development Team rät dringend, diese Addons zu entfernen: %1</German>
-			<Czech>[KAM VAROVÁNÍ] Nekompatibilní addon(y), které by mohly negativně ovlivnit správnou funkcionalitu detekovány. KAT - Advanced Medical REWRITE Developerský Tým silně doporučuje odebrat tyto addony: %1</Czech>
+            <German>[KAM WARNUNG] Es wurden inkompatible Addons entdeckt, die die korrekte Funktionalität beeinträchtigen könnten. Das KAT - Advanced Medical REWRITE Development Team rät dringend, diese Addons zu entfernen: %1</German>
+            <Czech>[KAM VAROVÁNÍ] Nekompatibilní addon(y), které by mohly negativně ovlivnit správnou funkcionalitu detekovány. KAT - Advanced Medical REWRITE Developerský Tým silně doporučuje odebrat tyto addony: %1</Czech>
         </Key>
     </Package>
 </Project>

--- a/addons/misc/stringtable.xml
+++ b/addons/misc/stringtable.xml
@@ -348,15 +348,18 @@
         </Key>
         <Key ID="STR_kat_misc_SETTING_incompatibilityWarning">
             <English>Incompatible addon warning</English>
+			<German>Inkompatible Mods Warnung</German>
             <Czech>Varování nekompatibilního addonu</Czech>
         </Key>
         <Key ID="STR_kat_misc_SETTING_incompatibilityWarning_Desc">
             <English>Throws a warning and add line to RPT log if incompatible addons(Listed by us - developers) that could negatively affect correct functionality of KAT are used.\n Warning disappears after 60 seconds.</English>
-            <Czech>Vyhodí varování a přidá řádek do RPT logu pokud jsou použity nekompatibilní addony(Zanesené námi - vývojáři), které by mohli negativně ovlivnit správnou funkcionalitu KATu.\n Varování zmizí po 60 sekundách. </Czech>
+			<German>Wirft eine Warnung aus und fügt eine Zeile in das RPT-Protokoll ein, wenn inkompatible Addons (von uns aufgelistet - Entwickler) verwendet werden, die die korrekte Funktionalität von KAT beeinträchtigen könnten. Die Warnung verschwindet nach 60 Sekunden.</German>
+			<Czech>Vyhodí varování a přidá řádek do RPT logu pokud jsou použity nekompatibilní addony(Zanesené námi - vývojáři), které by mohli negativně ovlivnit správnou funkcionalitu KATu.\n Varování zmizí po 60 sekundách. </Czech>
         </Key>
         <Key ID="STR_kat_misc_incompatibilityWarning_Desc">
             <English>[KAM WARNING] Incompatible addon(s) that could negatively affect correct functionality detected. KAT - Advanced Medical REWRITE Development Team strongly advises to remove these addons: %1</English>
-            <Czech>[KAM VAROVÁNÍ] Nekompatibilní addon(y), které by mohly negativně ovlivnit správnou funkcionalitu detekovány. KAT - Advanced Medical REWRITE Developerský Tým silně doporučuje odebrat tyto addony: %1</Czech>
+			<German>[KAM WARNUNG] Es wurden inkompatible Addons entdeckt, die die korrekte Funktionalität beeinträchtigen könnten. Das KAT - Advanced Medical REWRITE Development Team rät dringend, diese Addons zu entfernen: %1</German>
+			<Czech>[KAM VAROVÁNÍ] Nekompatibilní addon(y), které by mohly negativně ovlivnit správnou funkcionalitu detekovány. KAT - Advanced Medical REWRITE Developerský Tým silně doporučuje odebrat tyto addony: %1</Czech>
         </Key>
     </Package>
 </Project>


### PR DESCRIPTION
- Adds Incompatible addon warning that throws a warning and add line to RPT log if incompatible addons(Listed by us - developers) that could negatively affect correct functionality of KAT are used. Warning disappears after 60 seconds.
- This will help both players and developers mitigate issues that can be easily prevented
- Has addon option that this warning can be turned off(It will be turned on in default)
- Here is the Wiki page with current list: https://github.com/Tomcat-SG/KAM/wiki/Incompatible-addons

- Example of how it looks in-game:
![20220716134119_1](https://user-images.githubusercontent.com/55753928/179353897-6b33f2c9-be69-4853-a0a6-82bd1ce1f1f8.jpg)

- Example of how it looks in RPT log file:
<img width="1007" alt="RPT Log Example" src="https://user-images.githubusercontent.com/55753928/179353917-2f75c48d-6024-4b10-8e9b-f7d9441774e8.PNG">

