### PR TITLE
remove pulseoxymeter from log after detach

### DIFF
--- a/addons/breathing/functions/fnc_treatmentAdvanced_pulseoximeterLocal.sqf
+++ b/addons/breathing/functions/fnc_treatmentAdvanced_pulseoximeterLocal.sqf
@@ -30,6 +30,7 @@ _target setVariable [QGVAR(pulseoximeter), true, true];
     if !(_target getVariable [QGVAR(pulseoximeter), false]) exitWith {
         [_idPFH] call CBA_fnc_removePerFrameHandler;
         _target setVariable ["kat_PulseoxiInUse_PFH", nil];
+        [_target, "quick_view", "STR_kat_breathing_pulseoxi_Log"] call kat_circulation_fnc_removeLog;
     };
 
     [_target, "quick_view", "STR_kat_breathing_pulseoxi_Log"] call kat_circulation_fnc_removeLog;


### PR DESCRIPTION
To avoid confusion, especially with multiple medics working on patients, the Pulseoxymeter should be removed from the log after its removal. Otherwise medics will see and look at outdated data until they realise the values are not moving

**When merged this pull request will:**
- Remove the constantly updating log line for Pulseoxymeter, once it was removed