### PR TITLE
New cyanosis show option, check breath change, fix pulseoximeter dupe, fix sound action error

### DIFF
--- a/addons/airway/functions/fnc_updateInjuryList.sqf
+++ b/addons/airway/functions/fnc_updateInjuryList.sqf
@@ -163,7 +163,7 @@ if (_target getVariable [QGVAR(recovery), false]) then {
 };
 
 // Display cyanosis in overview tab, only when head/arms are selected
-if (EGVAR(breathing,cyanosisShowInMenu) && (_selectionN isEqualTo 0 || _selectionN isEqualTo 2 || _selectionN isEqualTo 3)) then {
+if (EGVAR(breathing,cyanosisShowInMenu) && (_selectionN in [0,2,3])) then {
 	private _spO2 = 0;
 	
 	if (alive _target) then {
@@ -173,16 +173,16 @@ if (EGVAR(breathing,cyanosisShowInMenu) && (_selectionN isEqualTo 0 || _selectio
     if (_spO2 <= EGVAR(breathing,slightValue)) then {
         private _cyanosisArr = switch (true) do {
             case (_spO2 <= EGVAR(breathing,severeValue)): {
-                ["STR_kat_breathing_CyanosisStatus_Severe",[0.16, 0.16, 1, 1]];
+                [LELSTRING(breathing,CyanosisStatus_Severe), [0.16, 0.16, 1, 1]];
             };
             case (_spO2 <= EGVAR(breathing,mildValue)): {
-                ["STR_kat_breathing_CyanosisStatus_Mild",[0.16, 0.315, 1, 1]];
+                [LELSTRING(breathing,CyanosisStatus_Mild), [0.16, 0.315, 1, 1]];
             };
             default {
-                ["STR_kat_breathing_CyanosisStatus_Slight",[0.16, 0.47, 1, 1]];
+                [LELSTRING(breathing,CyanosisStatus_Slight), [0.16, 0.47, 1, 1]];
             };
         };
-        _entries pushBack [localize (_cyanosisArr select 0), (_cyanosisArr select 1)];
+        _entries pushBack [(_cyanosisArr select 0), (_cyanosisArr select 1)];
     };   
 };
 

--- a/addons/airway/functions/fnc_updateInjuryList.sqf
+++ b/addons/airway/functions/fnc_updateInjuryList.sqf
@@ -170,8 +170,9 @@ if (EGVAR(breathing,cyanosisShowInMenu) && (_selectionN in [0,2,3])) then {
         _spO2 = GET_SPO2(_target);
 	};
 	
-    if (_spO2 <= EGVAR(breathing,slightValue)) then {
+    if (_spO2 <= EGVAR(breathing,slightValue) || HAS_TOURNIQUET_APPLIED_ON(_target,_selectionN)) then {
         private _cyanosisArr = switch (true) do {
+            case (HAS_TOURNIQUET_APPLIED_ON(_target,_selectionN));
             case (_spO2 <= EGVAR(breathing,severeValue)): {
                 [LELSTRING(breathing,CyanosisStatus_Severe), [0.16, 0.16, 1, 1]];
             };

--- a/addons/airway/functions/fnc_updateInjuryList.sqf
+++ b/addons/airway/functions/fnc_updateInjuryList.sqf
@@ -162,6 +162,30 @@ if (_target getVariable [QGVAR(recovery), false]) then {
     _entries pushback [LLSTRING(RecoveryPosition), [0.1, 1, 1, 1]];
 };
 
+// Display cyanosis in overview tab, only when head/arms are selected
+if (EGVAR(breathing,cyanosisShowInMenu) && (_selectionN isEqualTo 0 || _selectionN isEqualTo 2 || _selectionN isEqualTo 3)) then {
+	private _spO2 = 0;
+	
+	if (alive _target) then {
+        _spO2 = GET_SPO2(_target);
+	};
+	
+    if (_spO2 <= EGVAR(breathing,slightValue)) then {
+        private _cyanosisArr = switch (true) do {
+            case (_spO2 <= EGVAR(breathing,severeValue)): {
+                ["STR_kat_breathing_CyanosisStatus_Severe",[0.16, 0.16, 1, 1]];
+            };
+            case (_spO2 <= EGVAR(breathing,mildValue)): {
+                ["STR_kat_breathing_CyanosisStatus_Mild",[0.16, 0.315, 1, 1]];
+            };
+            default {
+                ["STR_kat_breathing_CyanosisStatus_Slight",[0.16, 0.47, 1, 1]];
+            };
+        };
+        _entries pushBack [localize (_cyanosisArr select 0), (_cyanosisArr select 1)];
+    };   
+};
+
 private _tensionhemothorax = false;
 if (!(EGVAR(breathing,showPneumothorax_dupe))) then {
     if ((_target getVariable [QEGVAR(breathing,hemopneumothorax), false]) || (_target getVariable [QEGVAR(breathing,tensionpneumothorax), false])) then {

--- a/addons/airway/functions/script_component.hpp
+++ b/addons/airway/functions/script_component.hpp
@@ -20,3 +20,7 @@
 #define VAR_IN_PAIN           "ACE_medical_inPain"
 #define VAR_TOURNIQUET        "ACE_medical_tourniquets"
 #define VAR_FRACTURES         "ACE_medical_fractures"
+
+//
+#define VAR_SPO2              QEGVAR(breathing,airwayStatus)
+#define GET_SPO2(unit)        (unit getVariable [VAR_SPO2, 100])

--- a/addons/breathing/ACE_Medical_Treatment_Actions.hpp
+++ b/addons/breathing/ACE_Medical_Treatment_Actions.hpp
@@ -169,7 +169,7 @@ class ACE_Medical_Treatment_Actions {
         allowedSelections[] = {"Head", "LeftArm", "RightArm"};
         allowSelfTreatment = 1;
         medicRequired = QGVAR(medLvl_Cyanosis);
-        condition = QGVAR(enableCyanosis);
+        condition = GVAR(enableCyanosis) && !(GVAR(cyanosisShowInMenu));
         callbackSuccess = QFUNC(treatmentAdvanced_Cyanosis);
     };
 };

--- a/addons/breathing/XEH_preInit.sqf
+++ b/addons/breathing/XEH_preInit.sqf
@@ -249,6 +249,16 @@ PREP_RECOMPILE_END;
     true
 ] call CBA_Settings_fnc_init;
 
+//Enables displaying cyanosis in overview tab and hides cyanosis diagnose action
+[
+    QGVAR(cyanosisShowInMenu),
+    "CHECKBOX",
+    [LLSTRING(SETTING_Cyanosis_ShowInMenu), LLSTRING(SETTING_Cyanosis_ShowInMenu_DESC)],
+    [CBA_SETTINGS_CAT, LSTRING(SubCategory_Cyanosis)],
+    [false],
+    true
+] call CBA_Settings_fnc_init;
+
 //Settable list for checking Cyanosis per medical class
 [
     QGVAR(medLvl_Cyanosis),

--- a/addons/breathing/functions/fnc_treatmentAdvanced_pulseoximeterLocal.sqf
+++ b/addons/breathing/functions/fnc_treatmentAdvanced_pulseoximeterLocal.sqf
@@ -47,4 +47,3 @@ _patient setVariable [QGVAR(pulseoximeter), true, true];
 }, 1, [_patient, _bodyPart]] call CBA_fnc_addPerFrameHandler;
 
 [_patient, "activity", LSTRING(pulseoxi_Log_2), [[_medic] call ACEFUNC(common,getName)]] call ACEFUNC(medical_treatment,addToLog);
-[_patient, "Pulseoximeter"] call ACEFUNC(medical_treatment,addToTriageCard);

--- a/addons/breathing/stringtable.xml
+++ b/addons/breathing/stringtable.xml
@@ -936,6 +936,12 @@
             <Czech>Povolí diagnózu cyanózy</Czech>
             <Spanish>Permitir el diagnóstico de cianosis</Spanish>
         </Key>
+        <Key ID="STR_kat_breathing_SETTING_Cyanosis_ShowInMenu">
+            <English>Show cyanosis in overview tab</English>
+        </Key>
+        <Key ID="STR_kat_breathing_SETTING_Cyanosis_ShowInMenu_DESC">
+            <English>Shows cyanosis of patient in overview tab and hides cyanosis diagnose action</English>
+        </Key>
         <Key ID="STR_kat_breathing_SETTING_slightValue">
             <English>Slight cyanosis SpO2 value</English>
             <German>Leichter Zyanose SpO2-Wert</German>

--- a/addons/circulation/functions/fnc_treatment.sqf
+++ b/addons/circulation/functions/fnc_treatment.sqf
@@ -152,7 +152,8 @@ if (vehicle _medic == _medic && {_medicAnim != ""}) then {
 };
 
 // Play a random treatment sound globally if defined
-if (isArray (_config >> "sounds")) then {
+// Don't attempt to play if sounds array is empty
+if (isArray (_config >> "sounds") && count (_config >> "sounds") != 0) then {
     selectRandom getArray (_config >> "sounds") params ["_file", ["_volume", 1], ["_pitch", 1], ["_distance", 10]];
     playSound3D [_file, objNull, false, getPosASL _medic, _volume, _pitch, _distance];
 };

--- a/addons/pharma/functions/fnc_inspectBreath.sqf
+++ b/addons/pharma/functions/fnc_inspectBreath.sqf
@@ -19,6 +19,7 @@
 params ["_medic", "_patient"];
 
 private _ph = _patient getVariable [QGVAR(pH), 1500];
+private _hr = GET_HEART_RATE(_patient);
 private _output = LLSTRING(breath_stink);
 
 if (_ph > 250) then {
@@ -27,6 +28,10 @@ if (_ph > 250) then {
 
 if (_ph > 750) then {
     _output = LLSTRING(breath_good);
+};
+
+if (_hr == 0 || !(alive _patient)) then {
+    _output = LLSTRING(breath_none);
 };
 
 [_output, 1.5, _medic] call ACEFUNC(common,displayTextStructured);

--- a/addons/pharma/stringtable.xml
+++ b/addons/pharma/stringtable.xml
@@ -2114,6 +2114,9 @@
             <Spanish>El aliento del paciente es normal</Spanish>
             <Polish>Oddech pacjenta jest w porządku</Polish>
         </Key>
+        <Key ID="STR_kat_pharma_breath_none">
+            <English>Patient is not breathing</English>
+        </Key>
         <Key ID="STR_kat_pharma_SETTING_Kidney_Action">
             <English>Kidney damage/failure</English>
             <Italian>Rene danneggiato/collassato</Italian>


### PR DESCRIPTION
**When merged this pull request will:**
- Add new optional setting to show cyanosis in the overview tab, similarly to blood loss.
If this option is ticked it will hide the check cyanosis action and ignore the medlevel requirement.
![image](https://user-images.githubusercontent.com/15182031/212491647-50557946-17b7-4e2b-97ed-09b574c7aa7c.png)


https://user-images.githubusercontent.com/15182031/212492359-92b93d17-3b95-4c46-b006-84f55692a855.mp4


- Check breath action now indicates if the patient is not breathing.
![image](https://user-images.githubusercontent.com/15182031/212491585-5cea2e22-874d-45e0-97b0-c69ba3c1a137.png)


- Remove duplicate pulse oximeter line in the triage log.
![image](https://user-images.githubusercontent.com/15182031/212491620-de676e21-1da7-423b-bfe7-43114731e160.png)


- Fix popup script errors when doing actions without a set sound. (potentially caused by #232?)
![image](https://user-images.githubusercontent.com/15182031/212491684-18e1bbaa-68b8-4596-8b92-3d7e2ed36bf3.png)