### PR TITLE
Internal bleeding while suffering from hemopneumothorax

### DIFF
--- a/addons/breathing/XEH_preInit.sqf
+++ b/addons/breathing/XEH_preInit.sqf
@@ -189,6 +189,16 @@ PREP_RECOMPILE_END;
     true
 ] call CBA_Settings_fnc_init;
 
+// Sets how much internal bleeding is applied while suffering from hemopneumothorax
+[
+    QGVAR(HPTXBleedAmount),
+    "SLIDER",
+    [LLSTRING(SETTING_HPTX_BleedAmount), LLSTRING(SETTING_HPTX_BleedAmount_DESC)],
+    [CBA_SETTINGS_CAT, LSTRING(SubCategory_ThoraxInjuries)],
+    [0, 1, 0.06, 0],
+    true
+] call CBA_Settings_fnc_init;
+
 // Enables hardcore mod for pneumothorax by not making it appear in medical menu - Stethoscope might help
 [
     QGVAR(pneumothorax_hardcore),

--- a/addons/breathing/XEH_preInit.sqf
+++ b/addons/breathing/XEH_preInit.sqf
@@ -195,7 +195,7 @@ PREP_RECOMPILE_END;
     "SLIDER",
     [LLSTRING(SETTING_HPTX_BleedAmount), LLSTRING(SETTING_HPTX_BleedAmount_DESC)],
     [CBA_SETTINGS_CAT, LSTRING(SubCategory_ThoraxInjuries)],
-    [0, 1, 0.06, 0],
+    [0, 1, 0.06, 2],
     true
 ] call CBA_Settings_fnc_init;
 

--- a/addons/breathing/functions/fnc_fullHealLocal.sqf
+++ b/addons/breathing/functions/fnc_fullHealLocal.sqf
@@ -81,6 +81,7 @@ _unit setVariable [QGVAR(tensionpneumothorax), false, true];
 
 // Update wound bleeding
 [_unit] call ACEFUNC(medical_status,updateWoundBloodLoss);
+[_unit] call EFUNC(circulation,updateInternalBleeding);
 
 // Vitals
 _unit setVariable [QACEGVAR(medical,heartRate), 80, true];

--- a/addons/breathing/functions/fnc_handlePulmoHit.sqf
+++ b/addons/breathing/functions/fnc_handlePulmoHit.sqf
@@ -42,6 +42,7 @@ if (random 100 <= GVAR(pneumothoraxChance)) then {
 
         if (random 100 <= GVAR(hptxChance)) then {
             _unit setVariable [QGVAR(hemopneumothorax), true, true];
+            [_unit] call EFUNC(circulation,updateInternalBleeding);
         } else {
             _unit setVariable [QGVAR(tensionpneumothorax), true, true];
         };

--- a/addons/breathing/functions/fnc_treatmentAdvanced_hemopneumothoraxLocal.sqf
+++ b/addons/breathing/functions/fnc_treatmentAdvanced_hemopneumothoraxLocal.sqf
@@ -30,6 +30,7 @@ if !(GVAR(tensionhemothorax_hardcore)) exitWith {
 
 if (_patient getVariable [QGVAR(activeChestSeal), false]) then {
     _patient setVariable [QGVAR(hemopneumothorax), false, true];
+    [_patient] call EFUNC(circulation,updateInternalBleeding);
 };
 
 if (!(_patient getVariable [QGVAR(pneumothorax), false]) && {!(_patient getVariable [QGVAR(hemopneumothorax), false]) && {!(_patient getVariable [QGVAR(tensionpneumothorax), false])}}) then {

--- a/addons/breathing/stringtable.xml
+++ b/addons/breathing/stringtable.xml
@@ -604,6 +604,12 @@
             <Russian>Количество повреждений при одном ударе по шкале от 0 до 1, которое должно произойти, прежде чем возникнет вероятность пневмоторакса. Более низкие значения означают, что пневмоторакс более вероятен. Установка очень низкого значения или нуля может привести к неожиданному поведению или пневмотораксу из-за неожиданных травм.</Russian>
             <Japanese>一度の負傷で発生する気胸へのダメージ。値が低いほど、気胸が発生する可能性が高くなります。値を非常に低く設定するか、0に設定すると、予期しない動作や予期しない怪我による気胸を引き起こす可能性があります。</Japanese>
         </Key>
+        <Key ID="STR_kat_breathing_SETTING_HPTX_BleedAmount">
+            <English>Hemopneumothorax internal bleeding amount</English>
+        </Key>
+        <Key ID="STR_kat_breathing_SETTING_HPTX_BleedAmount_DESC">
+            <English>Sets amount of internal bleeding that is applied while suffering from hemopneumothorax</English>
+        </Key>
         <Key ID="STR_kat_breathing_SETTING_pneumothorax_hardcore">
             <English>Hardcore pneumothorax</English>
             <Polish>Trudna odma opłucnowa</Polish>

--- a/addons/circulation/XEH_PREP.hpp
+++ b/addons/circulation/XEH_PREP.hpp
@@ -25,6 +25,6 @@ PREP(removeLog);
 PREP(returnAED_X);
 PREP(treatment);
 PREP(treatmentAdvanced_IV);
+PREP(updateInternalBleeding);
 PREP(vehicleCheck);
 PREP(wrongBloodTreatment);
-PREP(updateInternalBleeding);

--- a/addons/circulation/XEH_PREP.hpp
+++ b/addons/circulation/XEH_PREP.hpp
@@ -27,3 +27,4 @@ PREP(treatment);
 PREP(treatmentAdvanced_IV);
 PREP(vehicleCheck);
 PREP(wrongBloodTreatment);
+PREP(updateInternalBleeding);

--- a/addons/circulation/functions/fnc_updateInternalBleeding.sqf
+++ b/addons/circulation/functions/fnc_updateInternalBleeding.sqf
@@ -1,0 +1,26 @@
+#include "script_component.hpp"
+/*
+ * Author: Blue
+ * Updates internal bleeding rate.
+ *
+ * Arguments:
+ * 0: The Unit <OBJECT>
+ *
+ * Return Value:
+ * Nothing
+ *
+ * Example:
+ * [player] call kat_circulation_fnc_updateInternalBleeding
+ *
+ * Public: No
+ */
+
+params ["_unit"];
+
+private _internalBleeding = 0;
+
+if (_unit getVariable [QEGVAR(breathing,hemopneumothorax), false]) then {
+    _internalBleeding = _internalBleeding + EGVAR(breathing,HPTXBleedAmount);
+};
+
+_unit setVariable [VAR_INTERNAL_BLEEDING, _internalBleeding, 0];

--- a/addons/circulation/script_component.hpp
+++ b/addons/circulation/script_component.hpp
@@ -34,3 +34,6 @@
     } else { \
         getNumber (cfg); \
     }
+
+#define VAR_INTERNAL_BLEEDING QEGVAR(circulation,internalBleeding)
+#define GET_INTERNAL_BLEEDING(unit) (unit getVariable [VAR_INTERNAL_BLEEDING, 0])

--- a/addons/pharma/functions/fnc_getBloodLoss.sqf
+++ b/addons/pharma/functions/fnc_getBloodLoss.sqf
@@ -18,10 +18,11 @@
 params ["_unit"];
 
 private _woundBleeding = GET_WOUND_BLEEDING(_unit);
-if (_woundBleeding == 0) exitWith {0};
+private _internalBleeding = GET_INTERNAL_BLEEDING(_unit);
+if (_woundBleeding + _internalBleeding == 0) exitWith {0};
 
 private _cardiacOutput = [_unit] call ACEFUNC(medical_status,getCardiacOutput);
 private _alphaAction = _unit getVariable [QGVAR(alphaAction), 1];
 
 // even if heart stops blood will still flow slowly (gravity)
-(_woundBleeding * (_cardiacOutput max 0.05) * ACEGVAR(medical,bleedingCoefficient) * _alphaAction)
+((_woundBleeding + _internalBleeding) * (_cardiacOutput max 0.05) * ACEGVAR(medical,bleedingCoefficient) * _alphaAction)

--- a/addons/pharma/functions/fnc_getBloodVolumeChange.sqf
+++ b/addons/pharma/functions/fnc_getBloodVolumeChange.sqf
@@ -19,7 +19,7 @@
 
 params ["_unit", "_deltaT", "_syncValues"];
 
-private _bloodLoss = [_unit] call ACEFUNC(medical_status,getBloodLoss);
+private _bloodLoss = [_unit] call EFUNC(pharma,getBloodLoss);
 private _bloodVolumeChange = -_deltaT * _bloodLoss;
 
 if (!isNil {_unit getVariable [QACEGVAR(medical,ivBags),[]]}) then {

--- a/addons/pharma/functions/fnc_hasStableVitals.sqf
+++ b/addons/pharma/functions/fnc_hasStableVitals.sqf
@@ -24,7 +24,7 @@ if IN_CRDC_ARRST(_unit) exitWith { false };
 if (_unit getVariable [QEGVAR(surgery,sedated), false]) exitWith { false };
 
 private _cardiacOutput = [_unit] call ACEFUNC(medical_status,getCardiacOutput);
-private _bloodLoss = _unit call ACEFUNC(medical_status,getBloodLoss);
+private _bloodLoss = _unit call EFUNC(pharma,getBloodLoss);
 if (_bloodLoss > (ACEGVAR(medical,const_bloodLossKnockOutThreshold) * _cardiacOutput / 2)) exitWith { false };
 
 private _bloodPressure = [_unit] call ACEFUNC(medical_status,getBloodPressure);

--- a/addons/pharma/script_component.hpp
+++ b/addons/pharma/script_component.hpp
@@ -34,3 +34,6 @@
     } else { \
         getNumber (cfg); \
     }
+    
+#define VAR_INTERNAL_BLEEDING QEGVAR(circulation,internalBleeding)
+#define GET_INTERNAL_BLEEDING(unit) (unit getVariable [VAR_INTERNAL_BLEEDING, 0])

--- a/addons/zeus/functions/fnc_ui_manageAirway.sqf
+++ b/addons/zeus/functions/fnc_ui_manageAirway.sqf
@@ -104,7 +104,8 @@ private _fnc_onConfirm = {
     if(_curSpO2Val isEqualTo 100) then { 
         [_unit] call EFUNC(breathing,handleBreathing);
     };
-
+    
+    [_unit] call EFUNC(circulation,updateInternalBleeding);
 };
 
 _display displayAddEventHandler ["unload", _fnc_onUnload];


### PR DESCRIPTION
**When merged this pull request will:**
- Apply a bleeding effect while the patient is suffering from hemopneumothorax


Internal bleeding is not displayed in the overview tab, but the total bloodloss still is.
Bleeding speed is affected by heartrate, meds and bleeding coefficient. (Like regular ace wounds)
Internal bleeding from HPTX is cleared when HPTX is treated.
Amount of internal bleeding applied while suffering from HPTX is adjustable in the cba settings.
![image](https://user-images.githubusercontent.com/15182031/212945556-e4032a38-d66c-4824-82a9-5a011b7a8574.png)


