### PR TITLE
Fix low oxygen effect from being visible when it's not supposed to

### DIFF
--- a/addons/breathing/CfgFunctions.hpp
+++ b/addons/breathing/CfgFunctions.hpp
@@ -7,4 +7,12 @@ class CfgFunctions {
             };
         };
     };
+    class overwrite_medicalTreatment {
+        tag = "ace_medical_feedback";
+        class ace_medical_feedback {
+            class handleEffects {
+                file = QPATHTOF(functions\fnc_handleEffects.sqf);
+            };
+        };
+    };
 };

--- a/addons/breathing/XEH_PREP.hpp
+++ b/addons/breathing/XEH_PREP.hpp
@@ -1,5 +1,6 @@
 PREP(fullHealLocal);
 PREP(handleBreathing);
+PREP(handleEffects);
 PREP(handlePulmoHit);
 PREP(init);
 PREP(treatmentAdvanced_chestSeal);

--- a/addons/breathing/XEH_PREP.hpp
+++ b/addons/breathing/XEH_PREP.hpp
@@ -1,3 +1,4 @@
+PREP(effectLowOxygen);
 PREP(fullHealLocal);
 PREP(handleBreathing);
 PREP(handleEffects);

--- a/addons/breathing/functions/fnc_effectLowOxygen.sqf
+++ b/addons/breathing/functions/fnc_effectLowOxygen.sqf
@@ -1,0 +1,57 @@
+#include "script_component.hpp"
+/*
+ * Author: Miss Heda
+ * Triggers the low SPO2 visual effect.
+ *
+ * Arguments:
+ * 0: Enable <BOOL>
+ * 
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [true] call kat_breathing_fnc_effectLowOxygen
+ *
+ * Public: No
+ */
+
+params ["_enable"];
+
+if (_enable) then {
+    ["ColorCorrections", 1500, [1, 1, 0, [0, 0, 0, 0], [0, 0, 0, 1], [0.33, 0.33, 0.33, 0], [0.55, 0.5, 0, 0, 0, 0, 4]]] spawn
+    {
+        params ["_name", "_priority", "_effect", "_handle"];
+        while {
+            _handle = ppEffectCreate [_name, _priority];
+            _handle < 0
+        } do {
+            _priority = _priority + 1;
+        };
+        _handle ppEffectEnable true;
+        _handle ppEffectAdjust _effect;
+        _handle ppEffectCommit 0.7;
+        [{  params["_handle"];
+            ppEffectCommitted _handle
+        }, 
+        {   params["_handle"];          
+            _handle ppEffectAdjust [1, 1, 0, [0, 0, 0, 0.9], [0, 0, 0, 1], [0.33, 0.33, 0.33, 0], [0.55, 0.5, 0, 0, 0, 0, 4]];
+            _handle ppEffectCommit 0.7;
+            [{  params["_handle"];
+                ppEffectCommitted _handle
+            }, 
+            {   params["_handle"];
+                _handle ppEffectAdjust [1, 1, 0, [0, 0, 0, 0], [0, 0, 0, 1], [0.33, 0.33, 0.33, 0], [0.55, 0.5, 0, 0, 0, 0, 4]];
+                _handle ppEffectCommit 1.6;       
+
+                [{  params["_handle"];
+                    ppEffectCommitted _handle
+                }, 
+                {   params["_handle"];           
+                    _handle ppEffectEnable false;
+                    ppEffectDestroy _handle;
+                }, [_handle]] call CBA_fnc_waitUntilAndExecute;
+            }, [_handle]] call CBA_fnc_waitUntilAndExecute;
+        }, [_handle]] call CBA_fnc_waitUntilAndExecute;
+    };
+};

--- a/addons/breathing/functions/fnc_handleBreathing.sqf
+++ b/addons/breathing/functions/fnc_handleBreathing.sqf
@@ -146,50 +146,6 @@ if (!local _unit) then {
         if (!(_unit getVariable ["ACE_isUnconscious",false]) && {_finalOutput <= GVAR(SpO2_unconscious)}) then {
             [QACEGVAR(medical,CriticalVitals), _unit] call CBA_fnc_localEvent;
         };
-        
-        if (GVAR(enableSPO2Flashing)) then {
-            if (!(_unit getVariable ["ACE_isUnconscious",false]) && {_finalOutput <= GVAR(lowSPO2Level)}) then {
-                ["ColorCorrections", 1500, [1, 1, 0, [0, 0, 0, 0], [0, 0, 0, 1], [0.33, 0.33, 0.33, 0], [0.55, 0.5, 0, 0, 0, 0, 4]]] spawn
-                {
-                    params ["_name", "_priority", "_effect", "_handle"];
-                    while {
-                        _handle = ppEffectCreate [_name, _priority];
-                        _handle < 0
-                    } do {
-                        _priority = _priority + 1;
-                    };
-                    _handle ppEffectEnable true;
-                    _handle ppEffectAdjust _effect;
-                    _handle ppEffectCommit 0.7;
-
-                    [{  params["_handle"];
-                        ppEffectCommitted _handle
-                    }, 
-                    {   params["_handle"];          
-                        _handle ppEffectAdjust [1, 1, 0, [0, 0, 0, 0.9], [0, 0, 0, 1], [0.33, 0.33, 0.33, 0], [0.55, 0.5, 0, 0, 0, 0, 4]];
-                        _handle ppEffectCommit 0.7;
-
-                        [{  params["_handle"];
-                            ppEffectCommitted _handle
-                        }, 
-                        {   params["_handle"];
-                            _handle ppEffectAdjust [1, 1, 0, [0, 0, 0, 0], [0, 0, 0, 1], [0.33, 0.33, 0.33, 0], [0.55, 0.5, 0, 0, 0, 0, 4]];
-                            _handle ppEffectCommit 1.6;       
-                            
-                            [{  params["_handle"];
-                                ppEffectCommitted _handle
-                            }, 
-                            {   params["_handle"];           
-                                _handle ppEffectEnable false;
-                                ppEffectDestroy _handle;
-                            }, [_handle]] call CBA_fnc_waitUntilAndExecute;
-
-                        }, [_handle]] call CBA_fnc_waitUntilAndExecute;
-
-                    }, [_handle]] call CBA_fnc_waitUntilAndExecute;
-                };
-            };
-        };
 
         if(GVAR(staminaLossAtLowSPO2)) then {
             if (!(_unit getVariable ["ACE_isUnconscious",false]) && {_finalOutput <= GVAR(lowSPO2Level)}) then {

--- a/addons/breathing/functions/fnc_handleEffects.sqf
+++ b/addons/breathing/functions/fnc_handleEffects.sqf
@@ -2,6 +2,8 @@
 /*
  * Author: BaerMitUmlaut
  * Handles any visual effects of medical.
+ * Edit: Blue --> added SPO2 warning effect
+ *
  * Note: Heart beat sounds run in a different PFH - see fnc_effectHeartBeat.
  *
  * Arguments:
@@ -33,6 +35,7 @@ private _bloodVolume      = GET_BLOOD_VOLUME(ACE_player);
 private _unconscious      = IS_UNCONSCIOUS(ACE_player);
 private _heartRate        = GET_HEART_RATE(ACE_player);
 private _pain             = GET_PAIN_PERCEIVED(ACE_player);
+private _SPO2             = GET_SPO2(ACE_player);
 
 if ((!ACEGVAR(medical_feedback,heartBeatEffectRunning)) && {_heartRate != 0} && {(_heartRate > 160) || {_heartRate < 60}}) then {
     TRACE_1("Starting heart beat effect",_heartRate);
@@ -57,6 +60,7 @@ if ((!ACEGVAR(medical_feedback,heartBeatEffectRunning)) && {_heartRate != 0} && 
 
 [!_unconscious, _pain] call ACEFUNC(medical_feedback,effectPain);
 [!_unconscious, _bleedingStrength, _manualUpdate] call ACEFUNC(medical_feedback,effectBleeding);
+if (GVAR(enableSPO2Flashing) && _SPO2 <= GVAR(lowSPO2Level)) then {[!_unconscious] call FUNC(effectLowOxygen);};
 
 // - Tourniquets, fractures and splints indication ---------------------------------------
 if (ACEGVAR(medical_feedback,enableHUDIndicators)) then {

--- a/addons/breathing/functions/fnc_handleEffects.sqf
+++ b/addons/breathing/functions/fnc_handleEffects.sqf
@@ -1,0 +1,66 @@
+#include "script_component.hpp"
+/*
+ * Author: BaerMitUmlaut
+ * Handles any visual effects of medical.
+ * Note: Heart beat sounds run in a different PFH - see fnc_effectHeartBeat.
+ *
+ * Arguments:
+ * 0: Manual, instant update (optional, default false) <BOOL>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [] call ace_medical_feedback_fnc_handleEffects
+ *
+ * Public: No
+ */
+params [["_manualUpdate", false]];
+
+if (ACEGVAR(common,OldIsCamera) || {!alive ACE_player}) exitWith {
+    [false, 0] call ACEFUNC(medical_feedback,effectUnconscious);
+    [false]    call ACEFUNC(medical_feedback,effectPain);
+    [false]    call ACEFUNC(medical_feedback,effectBloodVolume);
+    [false]    call ACEFUNC(medical_feedback,effectBloodVolumeIcon);
+    [false]    call ACEFUNC(medical_feedback,effectBleeding);
+};
+
+BEGIN_COUNTER(handleEffects);
+
+// - Current state info -------------------------------------------------------
+private _bleedingStrength = GET_BLOOD_LOSS(ACE_player);
+private _bloodVolume      = GET_BLOOD_VOLUME(ACE_player);
+private _unconscious      = IS_UNCONSCIOUS(ACE_player);
+private _heartRate        = GET_HEART_RATE(ACE_player);
+private _pain             = GET_PAIN_PERCEIVED(ACE_player);
+
+if ((!ACEGVAR(medical_feedback,heartBeatEffectRunning)) && {_heartRate != 0} && {(_heartRate > 160) || {_heartRate < 60}}) then {
+    TRACE_1("Starting heart beat effect",_heartRate);
+    ACEGVAR(medical_feedback,heartBeatEffectRunning) = true;
+    [] call ACEFUNC(medical_feedback,effectHeartBeat);
+};
+
+// - Visual effects -----------------------------------------------------------
+[_unconscious, 2] call ACEFUNC(medical_feedback,effectUnconscious);
+[
+    true,
+    linearConversion [BLOOD_VOLUME_CLASS_2_HEMORRHAGE, BLOOD_VOLUME_CLASS_4_HEMORRHAGE, _bloodVolume, 0, 1, true]
+] call ACEFUNC(medical_feedback,effectBloodVolume);
+[
+    true,
+    ceil linearConversion [
+        BLOOD_VOLUME_CLASS_2_HEMORRHAGE, BLOOD_VOLUME_CLASS_4_HEMORRHAGE,
+        _bloodVolume,
+        ICON_BLOODVOLUME_IDX_MIN, ICON_BLOODVOLUME_IDX_MAX, true
+    ]
+] call ACEFUNC(medical_feedback,effectBloodVolumeIcon);
+
+[!_unconscious, _pain] call ACEFUNC(medical_feedback,effectPain);
+[!_unconscious, _bleedingStrength, _manualUpdate] call ACEFUNC(medical_feedback,effectBleeding);
+
+// - Tourniquets, fractures and splints indication ---------------------------------------
+if (ACEGVAR(medical_feedback,enableHUDIndicators)) then {
+    [] call ACEFUNC(medical_feedback,handleHUDIndicators);
+};
+
+END_COUNTER(handleEffects);

--- a/addons/breathing/functions/script_component.hpp
+++ b/addons/breathing/functions/script_component.hpp
@@ -21,6 +21,9 @@
 #define VAR_FRACTURES         "ACE_medical_fractures"
 #define STRING_BODY_PARTS ["head", "body", "left arm", "right arm", "left leg", "right leg"]
 
+#define VAR_SPO2              QEGVAR(breathing,airwayStatus)
+#define GET_SPO2(unit)        (unit getVariable [VAR_SPO2, 100])
+
 #define GET_BLOOD_LOSS(unit)  ([unit] call EFUNC(pharma,getBloodLoss))
 
 #define ICON_BLOODVOLUME_IDX_MIN 0

--- a/addons/breathing/functions/script_component.hpp
+++ b/addons/breathing/functions/script_component.hpp
@@ -20,3 +20,8 @@
 #define VAR_TOURNIQUET        "ACE_medical_tourniquets"
 #define VAR_FRACTURES         "ACE_medical_fractures"
 #define STRING_BODY_PARTS ["head", "body", "left arm", "right arm", "left leg", "right leg"]
+
+#define GET_BLOOD_LOSS(unit)  ([unit] call EFUNC(pharma,getBloodLoss))
+
+#define ICON_BLOODVOLUME_IDX_MIN 0
+#define ICON_BLOODVOLUME_IDX_MAX 6


### PR DESCRIPTION
**When merged this pull request will:**
- Fix the low SpO2 post processing effect being visible for players when their SpO2 isn't below the warning threshold.
