### PR TITLE
German Translation Addition|Revision

### DIFF
--- a/addons/airway/stringtable.xml
+++ b/addons/airway/stringtable.xml
@@ -1091,7 +1091,7 @@
             <Czech>Nastavení stabilizované polohy a narovnávání hlavy</Czech>
             <French>Paramètres de position latérale de sécurité + hyperextension</French>
             <Korean>회복 자세 + 머리 젖히기 설정</Korean>
-            <German>Wiederherstellungsposition + Überdehnungseinstellungen</German>
+            <German>Einstellungen der stabilen Seitenlage + Überstreckung</German>
             <Chinesesimp>恢复体态设置</Chinesesimp>
             <Japanese>回復体位設定</Japanese>
             <Spanish>Parámetros de posición lateral de seguridad e hiperextensión de cabeza</Spanish>

--- a/addons/breathing/stringtable.xml
+++ b/addons/breathing/stringtable.xml
@@ -565,7 +565,7 @@
             <French>Activer les pneumothorax avancés</French>
             <Korean>고급 기흉 활성화</Korean>
             <Italian>Abilità pneumotorace avanzato</Italian>
-            <German>Erweiterte Pneumothoraces aktivieren</German>
+            <German>Ausgeprägte Pneumothoraces aktivieren</German>
             <Portuguese>Habilitar pneumotóraxes avançados</Portuguese>
         </Key>
         <Key ID="STR_kat_breathing_DESCRIPTION_ADVANCED_PTX_OPTION">
@@ -576,7 +576,7 @@
             <French>Active les pneumothorax avancés - Hémopneumothorax et pneumothorax sous tension</French>
             <Korean>고급 기흉을 활성화합니다. - 혈기흉 및 긴장성 기흉</Korean>
             <Italian>Abilità la pneumotorace avanzato - emopneumotorace e pneumotorace da tensione</Italian>
-            <German>Aktiviert erweiterte Pneumothoraces - Hämatopneumothoraces und Spannungspneumothoraces</German>
+            <German>Aktiviert Ausgeprägte Pneumothoraces - Hämatopneumothoraces und Spannungspneumothoraces</German>
             <Portuguese>Permite pneumotóraxes avançados - hemopneumotórax e pneumotórax hipertensivo</Portuguese>
         </Key>
         <Key ID="STR_kat_breathing_ADVANCED_PTX_CHANCE_OPTION">
@@ -587,7 +587,7 @@
             <French>Chance de pneumothorax avancé</French>
             <Korean>고급 기흉 확률</Korean>
             <Italian>Probabilità di pneumotorace avanzato</Italian>
-            <German>Wahrscheinlichkeit für erweiterte Pneumothorax</German>
+            <German>Wahrscheinlichkeit für ausgeprägten Pneumothorax</German>
             <Portuguese>Probabilidade de pneumotórax avançado</Portuguese>
         </Key>
         <Key ID="STR_kat_breathing_DESCRIPTION_ADVANCED_PTX_CHANCE_OPTION">

--- a/addons/breathing/stringtable.xml
+++ b/addons/breathing/stringtable.xml
@@ -491,7 +491,7 @@
         </Key>
         <Key ID="STR_kat_breathing_ncdKit_desc">
             <English>The Needle Chest Decompression Kit is a single use kit designed to treat a tensionpneumothorax.</English>
-            <German>Das Nadeldekompressions Kit ist ein Einweg-Kit das zur Behandlung eines Spannungspneumothorax vorgesehen ist.</German>
+            <German>Das Nadeldekompressions-Kit ist ein Einweg-Kit, das zur Behandlung eines Spannungspneumothorax vorgesehen ist.</German>
             <Polish>Zestaw NCD to zestaw jednorazowego użytku przeznaczony do leczenia odmy prężnej.</Polish>
             <Japanese>NCDキット (Needle Chest Decompression, 胸部針減圧術)は、緊張性気胸の治療用に設計された使い捨てキットです。</Japanese>
             <Czech>NCD Kit je sada pro ošetření tenzního pneumotoraxu. Jedná se o jednorázový předmět.</Czech>
@@ -518,6 +518,7 @@
             <French>Règle la chance d'avoir un hémopneumothorax. Règle également la chance d'un pneumothorax sous tension (60% Hémo = 40% Tension)</French>
             <Korean>혈기흉의 확률을 설정합니다. 또한 긴장성 기흉의 확률을 설정합니다. (혈기흉 60% = 긴장성 기흉 40%)</Korean>
             <Italian>Imposta la probabilità per l'emopneumotorace. Imposta inoltre la probabilità per pneumotorace da tensione. (60% Emopn. =  40% Pneum. tensione)</Italian>
+            <German>Legt die Wahrscheinlichkeit für einen Hämatopneumothorax fest. Legt auch die Wahrscheinlichkeit auf einen Spannungspneumothorax fest(60 % Hämo = 40 % Spannungspneu</German>
         </Key>
         <Key ID="STR_kat_breathing_ADVANCED_PTX_OPTION">
             <English>Enable Advanced Pneumothoraxes</English>
@@ -527,6 +528,7 @@
             <French>Activer les pneumothorax avancés</French>
             <Korean>고급 기흉 활성화</Korean>
             <Italian>Abilità pneumotorace avanzato</Italian>
+            <German>Erweiterte Pneumothoraces aktivieren</German>
         </Key>
         <Key ID="STR_kat_breathing_DESCRIPTION_ADVANCED_PTX_OPTION">
             <English>Enables advanced pneumothoraxes - hemopneumothorax and tensionpneumothorax</English>
@@ -536,6 +538,7 @@
             <French>Active les pneumothorax avancés - Hémopneumothorax et pneumothorax sous tension</French>
             <Korean>고급 기흉을 활성화합니다. - 혈기흉 및 긴장성 기흉</Korean>
             <Italian>Abilità la pneumotorace avanzato - emopneumotorace e pneumotorace da tensione</Italian>
+            <German>Aktiviert erweiterte Pneumothoraces - Hämatopneumothoraces und Spannungspneumothoraces</German>
         </Key>
         <Key ID="STR_kat_breathing_ADVANCED_PTX_CHANCE_OPTION">
             <English>Advanced Pneumothorax Chance</English>
@@ -545,6 +548,7 @@
             <French>Chance de pneumothorax avancé</French>
             <Korean>고급 기흉 확률</Korean>
             <Italian>Probabilità di pneumotorace avanzato</Italian>
+            <German>Wahrscheinlichkeit für erweiterte Pneumothorax</German>
         </Key>
         <Key ID="STR_kat_breathing_DESCRIPTION_ADVANCED_PTX_CHANCE_OPTION">
             <English>The percentage chance that a patient will suffer from a hemopneumotorax or tension pneumothorax after they are treated for a pneumothorax. Treatment requires the draining of fluids with the use of an AAT Kit.</English>

--- a/addons/circulation/stringtable.xml
+++ b/addons/circulation/stringtable.xml
@@ -1338,7 +1338,7 @@
         <Key ID="STR_kat_circulation_TRAINING_LEVEL_AED">
             <English>Training level required to use an AED</English>
             <Polish>Poziom wyszkolenia wymagany do korzystania z AED</Polish>
-            <German>Benötigtes Trainingslevel, um den AED zu nutzen</German>
+            <German>Benötigter medizinischer Grad, um den AED zu nutzen</German>
             <Spanish>Nivel de entrenamiento requerido para usar un DEA</Spanish>
             <Chinese>使用AED所需的培訓水平</Chinese>
             <Chinesesimp>使用AED所需的医疗培训水平</Chinesesimp>
@@ -1368,7 +1368,7 @@
         <Key ID="STR_kat_circulation_TRAINING_LEVEL_AED_X">
             <English>Training level required to use an AED-X</English>
             <Polish>Poziom wyszkolenia wymagany do korzystania z AED-X</Polish>
-            <German>Benötigtes Trainingslevel, um den AED-X zu nutzen</German>
+            <German>Benötigter medizinischer Grad, um den AED-X zu nutzen</German>
             <Spanish>Nivel de entrenamiento requerido para usar un DEA-X</Spanish>
             <Chinese>使用AED-X所需的培訓水平</Chinese>
             <Chinesesimp>使用AED-X的医疗培训水平</Chinesesimp>
@@ -1428,7 +1428,7 @@
         <Key ID="STR_kat_circulation_SETTING_CPR_CHANCES">
             <English>Enable different CPR chances per medical level</English>
             <Polish>Włącz różne szanse resuscytacji, zależne od wyszkolenia medycznego</Polish>
-            <German>Aktiviere verschiedene HLW Erfolgsraten für verschiedene Medic Level</German>
+            <German>Aktiviere verschiedene HLW Erfolgsraten für verschiedene medizinische Grade</German>
             <Spanish>Permite diferentes probabilidades de RCP exitoso por nivel médico</Spanish>
             <Chinese>每個醫療級別啟用不同的CPR機會</Chinese>
             <Chinesesimp>每个医疗水平启用不同的CPR几率</Chinesesimp>
@@ -1792,6 +1792,7 @@
             <Japanese>AED-X: 心拍: %1 血圧: %2/%3 SpO2: %4</Japanese>
             <French>AED-X: HR: %1 BP: %2/%3 SpO2: %4</French>
             <Korean>X-시리즈 AED: 맥박: %1 혈압: %2 /%3 산소포화도: %4</Korean>
+            <German>AED-X: HR: %1 BP: %2/%3 SpO2: %4</German>
         </Key>
     </Package>
 </Project>

--- a/addons/misc/stringtable.xml
+++ b/addons/misc/stringtable.xml
@@ -303,7 +303,7 @@
         </Key>
         <Key ID="STR_kat_misc_SETTING_incompatibilityWarning">
             <English>Incompatible addon warning</English>
-            <German>Inkompatible Mods Warnung</German>
+            <German>Warnung inkompatibler Erweiterungen</German>
             <Czech>Varování nekompatibilního addonu</Czech>
             <Korean>호환되지 않는 애드온 경고</Korean>
             <Japanese>互換性のないアドオンの警告</Japanese>

--- a/addons/misc/stringtable.xml
+++ b/addons/misc/stringtable.xml
@@ -323,7 +323,7 @@
         </Key>
         <Key ID="STR_kat_misc_SETTING_incompatibilityWarning">
             <English>Incompatible addon warning</English>
-            <German>Warnung inkompatibler Erweiterungen</German>
+            <German>Warnung inkompatibler Mods</German>
             <Czech>Varování nekompatibilního addonu</Czech>
             <Korean>호환되지 않는 애드온 경고</Korean>
             <Japanese>互換性のないアドオンの警告</Japanese>

--- a/addons/pharma/stringtable.xml
+++ b/addons/pharma/stringtable.xml
@@ -2537,7 +2537,7 @@
         </Key>
         <Key ID="STR_kat_pharma_Pervitin_mid2">
             <English>You gain a sudden rush!</English>
-            <German>Du bekommst einen spontanen Schub...</German>
+            <German>Du bekommst einen spontanen Rush...</German>
             <French>Vous sentez un élan soudain !</French>
             <Korean>갑자기 심하게 두근거린다!</Korean>
             <Japanese>あなたを突如激しい動悸が襲う!</Japanese>
@@ -2546,7 +2546,7 @@
         </Key>
         <Key ID="STR_kat_pharma_Pervitin_mid3">
             <English>You gain another rush!</English>
-            <German>Du bekommst einen weiteren Schub...</German>
+            <German>Du bekommst einen weiteren Rush...</German>
             <French>Vous sentez un autre élan !</French>
             <Korean>두근거림이 더 격렬해진다!</Korean>
             <Japanese>動悸は激しさを増してゆく!</Japanese>

--- a/addons/pharma/stringtable.xml
+++ b/addons/pharma/stringtable.xml
@@ -77,7 +77,7 @@
         </Key>
         <Key ID="STR_kat_pharma_IV_DROP_TIME_DESC">
             <English>Changes the time at which IVs/IOs fall out of a patient</English>
-            <German>Ändert den Zeitpunkt, zu dem IVs/IOs aus einem Patienten herausfallen</German>
+            <German>Ändert den Zeitpunkt, nachdem IVs/IOs aus einem Patienten herausfallen</German>
             <Polish>Czas samoistnego wypadnięcia IV/IO z pacjenta</Polish>
             <French>Temps au bout du quel l'IV/IO tombe du patient</French>
             <Chinese>改变病人的静脉注射/IOs脱落的时间</Chinese>
@@ -811,7 +811,7 @@
         </Key>
         <Key ID="STR_kat_pharma_Applying_IV">
             <English>Establishing IV/IO</English>
-            <German>IV/IO einrichten</German>
+            <German>IV legen</German>
             <Polish>Zakładanie IV</Polish>
             <Spanish>Colocando IV</Spanish>
             <Czech>Zavádím IV</Czech>
@@ -826,7 +826,7 @@
         </Key>
         <Key ID="STR_kat_pharma_Applying_IO">
             <English>Establishing IO</English>
-            <German>IO einrichten</German>
+            <German>IO legen</German>
             <Polish>Zakładanie IO</Polish>
             <Spanish>Colocando IO</Spanish>
             <Czech>Zavádím IO</Czech>
@@ -841,7 +841,7 @@
         </Key>
         <Key ID="STR_kat_pharma_iv_log">
             <English>%1 established a %2</English>
-            <German>%1 errichtet eine %2</German>
+            <German>%1 legte ein %2</German>
             <Polish>%1 założył %2</Polish>
             <Spanish>%1 ha colocado %2</Spanish>
             <Chinese>%1 被插入一個 %2</Chinese>
@@ -1031,7 +1031,7 @@
         <Key ID="STR_KAT_pharma_SETTING_Allow_Reorientation_DESC">
             <English>Medical level required for reorientation</English>
             <Polish>Poziom wyszkolenia wymagany do cucenia</Polish>
-            <German>Erforderliches Medic Level zum Umorientieren</German>
+            <German>Erforderlicher medizinischer Grad zum Umorientieren</German>
             <Spanish>Nivel médico requerido para la bofetada</Spanish>
             <Chinese>调整方向所需的医疗水平</Chinese>
             <Chinesesimp>刺激患者所需的医疗水平</Chinesesimp>
@@ -1053,7 +1053,7 @@
         </Key>
         <Key ID="STR_KAT_pharma_SETTING_Chromatic_Aberration_Checkbox_Pervitin_DESC">
             <English>Enables if pervitin should influance your vision with chromatic aberration</English>
-            <German>Aktiviert ob Pervitin deine Sicht beinflussen soll mit chromatischen Abweichungen</German>
+            <German>Aktiviert, ob Pervitin deine Sicht mit chromatischen Abweichungen beeinflussen soll</German>
             <French>Définie si la pervitine devrait influancer la vision avec une aberration chromatique</French>
             <Japanese>ペルビチン服用時に色収差で視覚に影響を与えるかどうかを有効にします</Japanese>
             <Korean>페르피틴이 색수차로 시력에 영향을 미치는지의 여부를 활성화합니다.</Korean>
@@ -1061,7 +1061,7 @@
         </Key>
         <Key ID="STR_KAT_pharma_SETTING_Chromatic_Aberration_Slider_Pervitin">
             <English>Chromatic Aberration Strength</English>
-            <German>Chromatische Abweichungs Stärke</German>
+            <German>Chromatische Abweichung-Stärke</German>
             <French>Intensité de l'aberration chromatique</French>
             <Japanese>色収差強度</Japanese>
             <Korean>색수차 강도(페르피틴)</Korean>
@@ -1069,7 +1069,7 @@
         </Key>
         <Key ID="STR_KAT_pharma_SETTING_Chromatic_Aberration_Slider_Pervitin_DESC">
             <English>Changes the strength of the chromatic aberration</English>
-            <German>Bestimmt die Stärke von den Chromatischen Abweichungen</German>
+            <German>Bestimmt die Stärke von den chromatischen Abweichungen</German>
             <French>Définie l'intensité de l'aberration chromatique</French>
             <Japanese>色収差の強さを変更します</Japanese>
             <Korean>페르피틴의 색수차의 강도를 변경합니다.</Korean>
@@ -1085,7 +1085,7 @@
         </Key>
         <Key ID="STR_KAT_pharma_SETTING_Weapon_Sway_Pervitin_DESC">
             <English>Enables if pervitin should influance your weapon sway</English>
-            <German>Aktiviert ob Pervitin dein Waffen schwanken beinflussen soll</German>
+            <German>Aktiviert, ob Pervitin das Schwanken deiner Waffen beeinflussen soll</German>
             <French>Définie si la pervitine influance l'oscillation de l'arme</French>
             <Japanese>ペルビチンが武器の揺れに影響を与えるかどうかを有効にします</Japanese>
             <Korean>페르피틴이 무기의 흔들림에 영향을 미치는지의 여부를 활성화합니다.</Korean>
@@ -1093,19 +1093,19 @@
         </Key>
         <Key ID="STR_KAT_pharma_SETTING_PervitinSpeed_displayName">
             <English>Pervitin Speed Boost</English>
-            <German>Pervitin Geschwindigkeits Boost</German>
+            <German>Pervitin Geschwindigkeit Boost</German>
             <Korean>페르피틴 속도 부스트</Korean>
             <Japanese>ペルビチン速度上昇</Japanese>
         </Key>
         <Key ID="STR_KAT_pharma_SETTING_PervitinSpeed_DESC">
             <English>The animation speed that gets set in Stage 1 of Pervitin. (1 = normal, 2 = twice)</English>
-            <German>Geschindigkeit die in Phase 1 von Pervitin gesetzt wird. (1 = normal, 2 = doppelt)</German>
+            <German>Geschwindigkeit, die in Phase 1 von Pervitin gesetzt wird. (1 = normal, 2 = doppelt)</German>
             <Korean>페르피틴 효과 1단계에서 설정되는 애니메이션 속도. (1 = 정상, 2 = 두 배)</Korean>
             <Japanese>ペルビチン効果の第一段階でのアニメーションの再生速度を設定します (1 = 通常、2 = 2倍速)</Japanese>
         </Key>
         <Key ID="STR_KAT_pharma_SETTING_Chromatic_Aberration_Checkbox_Ketamine">
             <English>Enable Chromatic Aberration</English>
-            <German>Aktiviere Chromatische Abweichungen</German>
+            <German>Aktiviere chromatische Abweichungen</German>
             <French>Activer l'aberration chromatique</French>
             <Japanese>色収差を有効にする</Japanese>
             <Korean>색수차 활성화(케타민)</Korean>
@@ -1113,7 +1113,7 @@
         </Key>
         <Key ID="STR_KAT_pharma_SETTING_Chromatic_Aberration_Checkbox_Ketamine_DESC">
             <English>Enables if ketamine should influance your vision with chromatic aberration</English>
-            <German>Aktiviert ob Ketamin deine Sicht beinflussen soll mit chromatischen Abweichungen</German>
+            <German>Aktiviert, ob Ketamin deine Sicht, mit chromatischen Abweichungen beeinflussen soll</German>
             <French>Définie si la kétamine devrait influancer la vision avec une aberration chromatique</French>
             <Japanese>ケタミン服用時に色収差で視覚に影響を与えるかどうかを有効にします</Japanese>
             <Korean>케타민이 색수차로 시력에 영향을 미치는 지의 여부를 활성화합니다.</Korean>
@@ -1121,7 +1121,7 @@
         </Key>
         <Key ID="STR_KAT_pharma_SETTING_Chromatic_Aberration_Slider_Ketamine">
             <English>Chromatic Aberration Strength</English>
-            <German>Chromatische Abweichungs Stärke</German>
+            <German>Chromatische Abweichung-Stärke</German>
             <French>Intensité de l'aberration chromatique</French>
             <Japanese>色収差強度</Japanese>
             <Korean>색수차 강도(케타민)</Korean>
@@ -1129,7 +1129,7 @@
         </Key>
         <Key ID="STR_KAT_pharma_SETTING_Chromatic_Aberration_Slider_Ketamine_DESC">
             <English>Changes the strength of the chromatic aberration</English>
-            <German>Bestimmt die Stärke von den Chromatischen Abweichungen</German>
+            <German>Bestimmt die Stärke von den chromatischen Abweichungen</German>
             <French>Définie l'intensité de l'aberration chromatique</French>
             <Japanese>色収差の強さを変更します</Japanese>
             <Korean>케타민의 색수차의 강도를 변경합니다.</Korean>
@@ -1137,7 +1137,7 @@
         </Key>
         <Key ID="STR_KAT_pharma_SETTING_Chromatic_Aberration_Checkbox_Fentanyl">
             <English>Enable Chromatic Aberration</English>
-            <German>Aktiviere Chromatische Abweichungen</German>
+            <German>Aktiviere chromatische Abweichungen</German>
             <French>Activer l'aberration chromatique</French>
             <Japanese>色収差を有効にする</Japanese>
             <Korean>색수차 활성화(펜타닐)</Korean>
@@ -1145,7 +1145,7 @@
         </Key>
         <Key ID="STR_KAT_pharma_SETTING_Chromatic_Aberration_Checkbox_Fentanyl_DESC">
             <English>Enables if fentanyl should influance your vision with chromatic aberration</English>
-            <German>Aktiviert ob Fentanyl deine Sicht beinflussen soll mit chromatischen Abweichungen</German>
+            <German>Aktiviert, ob Fentanyl deine Sicht mit chromatischen Abweichungen beeinflussen soll</German>
             <French>Définie si le fentanyl devrait influancer la vision avec une aberration chromatique</French>
             <Japanese>フェンタニル服用時に色収差で視覚に影響を与えるかどうかを有効にします</Japanese>
             <Korean>펜타닐이 색수차로 시력에 영향을 미치는지의 여부를 활성화합니다.</Korean>
@@ -1153,7 +1153,7 @@
         </Key>
         <Key ID="STR_KAT_pharma_SETTING_Chromatic_Aberration_Slider_Fentanyl">
             <English>Chromatic Aberration Strength</English>
-            <German>Chromatische Abweichungs Stärke</German>
+            <German>Chromatische Abweichung-Stärke</German>
             <French>Intensité de l'aberration chromatique</French>
             <Japanese>色収差強度</Japanese>
             <Korean>색수차 강도(펜타닐)</Korean>
@@ -1161,7 +1161,7 @@
         </Key>
         <Key ID="STR_KAT_pharma_SETTING_Chromatic_Aberration_Slider_Fentanyl_DESC">
             <English>Changes the strength of the chromatic aberration</English>
-            <German>Bestimmt die Stärke von den Chromatischen Abweichungen</German>
+            <German>Bestimmt die Stärke von den chromatischen Abweichungen</German>
             <French>Définie l'intensité de l'aberration chromatique</French>
             <Japanese>色収差の強さを変更します</Japanese>
             <Korean>펜타닐의 색수차의 강도를 변경합니다.</Korean>
@@ -1199,7 +1199,7 @@
             <French>Anesthésie générale</French>
             <Polish>Anestetyk</Polish>
             <Korean>일반적인 마취제</Korean>
-            <German>Allgemeinanästhesie</German>
+            <German>Allgemeines Anästhetikum</German>
             <Japanese>全身麻酔</Japanese>
             <Spanish>Anestesia general</Spanish>
         </Key>
@@ -1487,7 +1487,7 @@
             <Czech>Zdravotnická úroveň potřebná pro Naloxon</Czech>
             <French>Niveau médical requis pour la Naloxone</French>
             <Korean>날록손을 사용할 수 있는 필요한 의료 레벨 수준 변경</Korean>
-            <German>Erforderliches medizinisches Level für die Gabe von Naloxon </German>
+            <German>Erforderlicher medizinischer Grad für die Gabe von Naloxon</German>
             <Japanese>ナロキソンに必要な医療レベル</Japanese>
             <Spanish>Nivel médico requerido para la Naloxona</Spanish>
         </Key>
@@ -1513,7 +1513,7 @@
         </Key>
         <Key ID="STR_kat_pharma_medLvl_Pervitin">
             <English>Medical level required for Pervitin</English>
-            <German>Erforderliches medizinisches Level für die Gabe von Pervitin</German>
+            <German>Erforderliches medizinischer Grad für die Gabe von Pervitin</German>
             <French>Niveau médical requis pour la Pervitine</French>
             <Japanese>ペルビチンに必要な医療レベル</Japanese>
             <Korean>페르피틴을 사용하는데 필요한 의료 레벨 수준 변경</Korean>
@@ -1527,7 +1527,7 @@
             <Czech>Zdravotnická úroveň potřebná pro TXA</Czech>
             <French>Niveau médical requis pour l'Acide Tranexamique</French>
             <Korean>TXA를 사용하는 데 필요한 의료 레벨 수준 변경</Korean>
-            <German>Erforderliches medizinisches Level für die Gabe von TXA</German>
+            <German>Erforderliches medizinischer Grad für die Gabe von TXA</German>
             <Japanese>TXAに必要な医療レベル</Japanese>
             <Spanish>Nivel médico requerido para el ATX</Spanish>
         </Key>
@@ -1551,7 +1551,7 @@
             <Italian>Livello medico richiesto per la Norepinefrina</Italian>
             <French>Niveau médical requis pour la Noradrénaline</French>
             <Korean>노르에피네프린을 사용하는 데 필요한 의료 레벨 수준 변경</Korean>
-            <German>Erforderliches medizinisches Level für die Gabe von Norepinephrin</German>
+            <German>Erforderliches medizinischer Grad für die Gabe von Norepinephrin</German>
             <Japanese>ノルアドレナリンに必要な医療レベル</Japanese>
             <Spanish>Nivel médico requerido para la Norepinefrina</Spanish>
         </Key>
@@ -1575,7 +1575,7 @@
             <Italian>Livello medico richiesto per la Fenilefrina</Italian>
             <French>Niveau médical requis pour la Phényléphrine</French>
             <Korean>페닐에프린을 사용하는 데 필요한 의료 레벨 수준 변경</Korean>
-            <German>Erforderliches medizinisches Level für die Gabe von Phenylephrin</German>
+            <German>Erforderliches medizinischer Grad für die Gabe von Phenylephrin</German>
             <Japanese>フェニレフリンに必要な医療レベル</Japanese>
             <Spanish>Nivel médico requerido para la Fenilefrina</Spanish>
         </Key>
@@ -1611,7 +1611,7 @@
             <Italian>Tempo di trattamento per la Nitroglicerina</Italian>
             <French>Temps de traitement de la Nitroglycérine</French>
             <Korean>니트로글리세린으로 치료하는 시간</Korean>
-            <German>Erforderliches medizinisches Level für die Gabe von Nitroglycerin</German>
+            <German>Erforderliches medizinischer Grad für die Gabe von Nitroglycerin</German>
             <Japanese>ニトログリセリンの治療時間</Japanese>
             <Spanish>Tiempo para uso de la Nitroglicerina</Spanish>
         </Key>
@@ -1635,7 +1635,7 @@
             <Czech>Doba léčby pro Amiodaron</Czech>
             <French>Temps de traitement de l'Amiodarone</French>
             <Korean>아미오다론으로 치료하는 시간</Korean>
-            <German>Erforderliches medizinisches Level für die Gabe von Amiodaron</German>
+            <German>Erforderliches medizinischer Grad für die Gabe von Amiodaron</German>
             <Japanese>アミオダロンの治療時間</Japanese>
             <Spanish>Tiempo para uso de la Amiodarona</Spanish>
         </Key>
@@ -1647,7 +1647,7 @@
             <Italian>Livello medico richiesto per la Lidocaina</Italian>
             <French>Niveau médical requis pour la Lidocaïne</French>
             <Korean>리도카인을 사용하는 데 필요한 의료 레벨 수준 변경</Korean>
-            <German>Erforderliches medizinisches Level für die Gabe von Lidocain</German>
+            <German>Erforderliches medizinischer Grad für die Gabe von Lidocain</German>
             <Japanese>リドカインに必​​要な医療レベル</Japanese>
             <Spanish>Nivel médico requerido para la Lidocaína</Spanish>
         </Key>
@@ -1671,7 +1671,7 @@
             <Italian>Livello medico richiesto per l'Atropina</Italian>
             <French>Niveau médical requis pour l'Atropine</French>
             <Korean>아트로핀을 사용하는 데 필요한 의료 레벨 수준 변경</Korean>
-            <German>Erforderliches medizinisches Level für die Gabe von Atropin</German>
+            <German>Erforderliches medizinischer Grad für die Gabe von Atropin</German>
             <Japanese>アトロピンに必要な医療レベル</Japanese>
             <Spanish>Nivel médico requerido para la Atropina</Spanish>
         </Key>
@@ -1695,7 +1695,7 @@
             <Czech>Zdravotnická úroveň potřebná pro EACA</Czech>
             <French>Niveau médical requis pour l'Acide Aminocaproïque</French>
             <Korean>아미노카프로산을 사용하는 데 필요한 의료 레벨 수준 변경</Korean>
-            <German>Erforderliches medizinisches Level für die Gabe von Aminocapronsäure</German>
+            <German>Erforderliches medizinischer Grad für die Gabe von Aminocapronsäure</German>
             <Japanese>EACAに必要な医療レベル</Japanese>
             <Spanish>Nivel médico requerido para el EACA</Spanish>
         </Key>
@@ -1718,7 +1718,7 @@
             <Czech>Zdravotnická úroveň potřebná pro Flumazenil</Czech>
             <French>Niveau médical requis pour le Flumazénil</French>
             <Korean>플루마제닐을 사용하는 데 필요한 의료 레벨 수준 변경</Korean>
-            <German>Erforderliches medizinisches Level für die Gabe von Flumazenil</German>
+            <German>Erforderliches medizinischer Grad für die Gabe von Flumazenil</German>
             <Polish>Poziom wyszkolenia medycznego dla Flumazenilu</Polish>
             <Japanese>フルマゼニルに必要な医療レベル</Japanese>
             <Spanish>Nivel médico requerido para el Flumazenil</Spanish>
@@ -1742,7 +1742,7 @@
             <Czech>Zdravotnická úroveň potřebná pro Lorazepam</Czech>
             <French>Niveau médical requis pour le Lorazépam</French>
             <Korean>로라제팜을 사용하는 데 필요한 의료 레벨 수준 변경</Korean>
-            <German>Erforderliches medizinisches Level für die Gabe von Lorazepam</German>
+            <German>Erforderliches medizinischer Grad für die Gabe von Lorazepam</German>
             <Polish>Poziom wyszkolenia medycznego dla Lorazepamu</Polish>
             <Japanese>ロラゼパムに必要な医療レベル</Japanese>
             <Spanish>Nivel médico requerido para el Lorazepam</Spanish>
@@ -1766,7 +1766,7 @@
             <Czech>Zdravotnická úroveň potřebná pro Etomidát</Czech>
             <French>Niveau médical requis pour l'Étomidate</French>
             <Korean>에토미데이트를 사용하는 데 필요한 의료 레벨 수준 변경</Korean>
-            <German>Erforderliches medizinisches Level für die Gabe von Etomidat</German>
+            <German>Erforderliches medizinischer Grad für die Gabe von Etomidat</German>
             <Polish>Poziom wyszkolenia medycznego dla Etomidatu</Polish>
             <Japanese>エトミダートに必要な医療レベル</Japanese>
             <Spanish>Nivel médico requerido para el Etomidato</Spanish>
@@ -1791,7 +1791,7 @@
             <Italian>Livello medico richiesto per la Ketamina</Italian>
             <French>Niveau médical requis pour la Kétamine</French>
             <Korean>케타민을 사용하는 데 필요한 의료 레벨 수준 변경</Korean>
-            <German>Erforderliches medizinisches Level für die Gabe von Ketamin</German>
+            <German>Erforderliches medizinischer Grad für die Gabe von Ketamin</German>
             <Japanese>ケタミンに必要な医療レベル</Japanese>
             <Spanish>Nivel médico requerido para la Ketamina</Spanish>
         </Key>
@@ -1815,7 +1815,7 @@
             <Czech>Zdravotnická úroveň potřebná pro Fentanyl</Czech>
             <French>Niveau médical requis pour le Fentanyl</French>
             <Korean>펜타닐을 사용하는 데 필요한 의료 레벨 수준 변경</Korean>
-            <German>Erforderliches medizinisches Level für die Gabe von Fentayl</German>
+            <German>Erforderliches medizinischer Grad für die Gabe von Fentanyl</German>
             <Japanese>フェンタニルに必要な医療レベル</Japanese>
             <Spanish>Nivel médico requerido para el Fentalino</Spanish>
         </Key>
@@ -1827,7 +1827,7 @@
             <Czech>Doba léčby pro Fentanyl</Czech>
             <French>Temps de traitement du Fentanyl</French>
             <Korean>펜타닐로 치료하는 시간</Korean>
-            <German>Anwendungszeit für Fentayl</German>
+            <German>Anwendungszeit für Fentanyl</German>
             <Japanese>フェンタニルの治療時間</Japanese>
             <Spanish>Tiempo para uso del Fentalino</Spanish>
         </Key>
@@ -1839,7 +1839,7 @@
             <Italian>Livello medico richiesto per Nalbufina (nubain)</Italian>
             <French>Niveau médical requis pour la Nalbuphine</French>
             <Korean>날부핀을 사용하는 데 필요한 의료 레벨 수준 변경</Korean>
-            <German>Erforderliches medizinisches Level für die Gabe von Nalbuphin </German>
+            <German>Erforderliches medizinischer Grad für die Gabe von Nalbuphin </German>
             <Japanese>ナルブフィンに必要な医療レベル</Japanese>
             <Spanish>Nivel médico requerido para la Nalbufina</Spanish>
         </Key>
@@ -1937,7 +1937,7 @@
         </Key>
         <Key ID="STR_kat_pharma_SubCategory_Caffeine">
             <English>Caffeine Settings</English>
-            <German>Koffein Einstellungen </German>
+            <German>Koffein Einstellungen</German>
             <French>Paramètres de la Caféine</French>
             <Japanese>カフェイン設定</Japanese>
             <Korean>카페인 설정</Korean>
@@ -2188,6 +2188,7 @@
             <Japanese>患者は呼吸していません</Japanese>
             <Korean>환자가 숨을 쉬지 않습니다</Korean>
             <Italian>Il paziente non sta respirando</Italian>
+            <German>Patient atmet nicht</German>
         </Key>
         <Key ID="STR_kat_pharma_SETTING_Kidney_Action">
             <English>Kidney damage/failure</English>
@@ -2323,7 +2324,7 @@
         </Key>
         <Key ID="STR_kat_pharma_Take_Pervitin">
             <English>Take Pervitin</English>
-            <German> Pervitin einnehmen </German>
+            <German>Pervitin einnehmen</German>
             <French>Prendre la pervitine</French>
             <Japanese>ペルビチンを服用する</Japanese>
             <Korean>페르피틴 복용</Korean>
@@ -2347,7 +2348,7 @@
         </Key>
         <Key ID="STR_kat_pharma_Pervitin_mid2">
             <English>You gain a sudden rush!</English>
-            <German>Du bekommst einen spontanan Rush...</German>
+            <German>Du bekommst einen spontanen Schub...</German>
             <French>Vous sentez un élan soudain !</French>
             <Korean>갑자기 심하게 두근거린다!</Korean>
             <Japanese>あなたを突如激しい動悸が襲う!</Japanese>
@@ -2355,7 +2356,7 @@
         </Key>
         <Key ID="STR_kat_pharma_Pervitin_mid3">
             <English>You gain another rush!</English>
-            <German>Du bekommst einen weiteren Rush...</German>
+            <German>Du bekommst einen weiteren Schub...</German>
             <French>Vous sentez un autre élan !</French>
             <Korean>두근거림이 더 격렬해진다!</Korean>
             <Japanese>動悸は激しさを増してゆく!</Japanese>
@@ -2379,7 +2380,7 @@
         </Key>
         <Key ID="STR_kat_pharma_Pervitin_chrom">
             <English>You start to see everything twice.</English>
-            <German>Du siehst alles Zweimal.</German>
+            <German>Du siehst alles doppelt.</German>
             <French>Vous commencez à voir tout en double</French>
             <Korean>모든 게 두 개로 보이기 시작한다.</Korean>
             <Japanese>全てが二重に見える...</Japanese>
@@ -2411,7 +2412,7 @@
         </Key>
         <Key ID="STR_kat_pharma_Caffeine_Bottle_DescShort">
             <English>Keeps you awake</English>
-            <German>Hällt dich wach</German>
+            <German>Hält dich wach</German>
             <French>Vous tient éveillé</French>
             <Japanese>眠気防止に役立つ</Japanese>
             <Korean>계속 깨어 있게 해줍니다.</Korean>

--- a/addons/surgery/stringtable.xml
+++ b/addons/surgery/stringtable.xml
@@ -3,7 +3,7 @@
     <Package name="surgery">
         <Key ID="STR_kat_surgery_Using">
             <English>Using</English>
-            <German>Schlucke</German>
+            <German>Verwenden</German>
             <Polish>Używanie</Polish>
             <Spanish>Usando</Spanish>
             <Chinese>服用中</Chinese>
@@ -31,7 +31,7 @@
         </Key>
         <Key ID="STR_kat_surgery_push_log">
             <English>%1 pushed %2</English>
-            <German>%1 intubierte mit %2</German>
+            <German>%1 verabreichte %2</German>
             <Polish>%1 wstrzyknął %2</Polish>
             <Spanish>%1 administró %2</Spanish>
             <Chinese>%1 被插入一個 %2</Chinese>
@@ -45,7 +45,7 @@
         </Key>
         <Key ID="STR_kat_surgery_inject_log">
             <English>%1 injected %2</English>
-            <German>%1 intubierte mit %2</German>
+            <German>%1 injizierte %2</German>
             <Polish>%1 włożył %2</Polish>
             <Spanish>%1 inyectó %2</Spanish>
             <Chinese>%1 被插入一個 %2</Chinese>
@@ -59,7 +59,7 @@
         </Key>
         <Key ID="STR_kat_surgery_use_log">
             <English>%1 used %2</English>
-            <German>%1 intubierte mit %2</German>
+            <German>%1 verwendete %2</German>
             <Polish>%1 użył %2</Polish>
             <Spanish>%1 usó %2</Spanish>
             <Chinese>%1 被插入一個 %2</Chinese>
@@ -211,7 +211,7 @@
             <Czech>%1 %2 zlomenina na %3</Czech>
             <French>%1 %2 la fracture sur le %3</French>
             <Korean>%1 은(는) %3 의 골절을 %2 (으)로 수행하였습니다</Korean>
-            <German>%1 %2 der Bruch an der %3</German>
+            <German>%1 %2 des Bruches an dem %3</German>
             <Japanese>%1 は %3 の骨折に %2</Japanese>
             <Spanish>%1 %2 la fractura sobre el/la %3</Spanish>
         </Key>
@@ -223,7 +223,7 @@
             <Czech>%1 provedl řez na %2</Czech>
             <French>%1 a effectuée une incision sur le %2</French>
             <Korean>%1 이(가) %2 을(를) 절개했습니다</Korean>
-            <German>%1 hat einen Einschnitt an der %2</German>
+            <German>%1 hat einen Einschnitt an dem %2 vorgenommen</German>
             <Japanese>%1 が %2 を切開しました</Japanese>
             <Spanish>%1 hizo una incisión sobre el/la %2</Spanish>
         </Key>
@@ -270,7 +270,7 @@
             <Czech>Používá se pro vytváření řezů a čištění ran</Czech>
             <French>Utilisé pour inciser et débrider les plaies</French>
             <Korean>절개 부위를 생성하고 상처를 제거하는 데 사용됩니다.</Korean>
-            <German>Für das Anlegen von Inzisionen und das Debridieren von Wunden</German>
+            <German>Für das Durchführen von Inzisionen und das Debridieren von Wunden</German>
             <Japanese>切開と創面切除に使用</Japanese>
             <Spanish>Usado para crear incisiones y desbridar heridas</Spanish>
             <Polish>Służy do tworzenia nacięć i oczyszczania ran</Polish>
@@ -331,7 +331,7 @@
             <Czech>Odhalování</Czech>
             <French>Exposition</French>
             <Korean>노출 중</Korean>
-            <German>Freilegen</German>
+            <German>Lege Frei</German>
             <Japanese>露出させています</Japanese>
             <Spanish>Exponiendo</Spanish>
         </Key>

--- a/addons/surgery/stringtable.xml
+++ b/addons/surgery/stringtable.xml
@@ -343,7 +343,7 @@
             <Czech>Svorka</Czech>
             <French>Clamp</French>
             <Korean>클램프</Korean>
-            <German>Klemme</German>
+            <German>Klammern</German>
             <Japanese>鉗子 (クランプ)</Japanese>
             <Spanish>Pinza de sujeción</Spanish>
         </Key>
@@ -354,7 +354,7 @@
             <Czech>Používá se k upnutí rozdrcených zlomenin</Czech>
             <French>Utilisé pour clamper les fractures comminutives</French>
             <Korean>분쇄 골절을 클램프하는 데 사용됩니다</Korean>
-            <German>Zum Klemmen von Trümmerfrakturen</German>
+            <German>Zum Klammern von Trümmerfrakturen</German>
             <Japanese>粉砕骨折をクランプするために使用</Japanese>
             <Spanish>Usada para sujetar las fracturas conminutas</Spanish>
             <Polish>Służy do zaciskania skomplikowanych złamań</Polish>
@@ -379,7 +379,7 @@
             <Czech>Upínání</Czech>
             <French>Clampage</French>
             <Korean>클램프 중</Korean>
-            <German>Abklemmen</German>
+            <German>Klammern</German>
             <Japanese>クランプ中</Japanese>
             <Spanish>Alineando trozos</Spanish>
         </Key>

--- a/addons/surgery/stringtable.xml
+++ b/addons/surgery/stringtable.xml
@@ -439,7 +439,7 @@
             <Czech>Vyčistit rány</Czech>
             <French>Débrider les plaies</French>
             <Korean>상처 제거</Korean>
-            <German>Wunddebridement</German>
+            <German>Wunde debridieren</German>
             <Japanese>創面切除</Japanese>
             <Spanish>Desbridar heridas</Spanish>
         </Key>
@@ -451,7 +451,7 @@
             <Czech>Čištění</Czech>
             <French>Débridement</French>
             <Korean>제거 중</Korean>
-            <German>Debridement </German>
+            <German>Debridement</German>
             <Japanese>切除中</Japanese>
             <Spanish>Desbridando</Spanish>
         </Key>
@@ -499,7 +499,7 @@
             <Czech>Aplikování</Czech>
             <French>Application</French>
             <Korean>적용 중</Korean>
-            <German>Anwendung</German>
+            <German>Lege an</German>
             <Japanese>適用中</Japanese>
             <Spanish>Colocando</Spanish>
         </Key>
@@ -579,11 +579,13 @@
             <English>Closed reduction fail chance</English>
             <Korean>폐쇄정복 실패 확률</Korean>
             <Japanese>非観血的整復術の失敗率</Japanese>
+            <German>Chance das die geschlossene Reduktion fehlschlägt</German>
         </Key>
         <Key ID="STR_kat_surgery_CLOSED_REDUCTION_FAIL_DESC">
             <English>Chance that closed reduction will fail. Default value 10%</English>
             <Korean>폐쇄정복을 실패할 확률입니다. 기본값은 10%</Korean>
             <Japanese>非観血的整復術の失敗率を設定します。デフォルト値は10%です</Japanese>
+            <German> Legt die Chance fest, dass die geschlossene Reduktion fehlschlägt. Standard: 10%</German>
         </Key>
         <Key ID="STR_kat_surgery_COMPOUND_FRACTURE_CHANCE">
             <English>Compound fracture chance</English>
@@ -593,7 +595,7 @@
             <Czech>Šance na otevřenou zlomeninu</Czech>
             <French>Chance de fracture ouverte</French>
             <Korean>복합 골절 확률</Korean>
-            <German>Wahrscheinlichkeit eines zusammengesetzten Bruchs</German>
+            <German>Wahrscheinlichkeit einer offenen Fraktur</German>
             <Japanese>開放骨折の確率</Japanese>
             <Spanish>Probabilidad de fractura compuesta</Spanish>
         </Key>
@@ -605,7 +607,7 @@
             <Czech>Nastavuje šanci na otevřené zlomeniny. Také nastavuje šanci na rozdrcené zlomeniny (60% otevřené = 40% rozdrcené)</Czech>
             <French>Règle la chance de fracture ouverte. Règle également la chance de fractures comminutives (60% ouvertes = 40 % comminutives)</French>
             <Korean>복합 골절의 확률을 설정합니다. 또한 분쇄 골절의 확률을 설정합니다. (복합 60% = 분쇄 40%)</Korean>
-            <German>Legt die Wahrscheinlichkeit für zusammengesetzte Frakturen fest. Legt auch die Wahrscheinlichkeit für Trümmerfrakturen fest (60% zusammengesetzte Frakturen = 40% Trümmerfrakturen)</German>
+            <German>Legt die Wahrscheinlichkeit für offene Frakturen fest. Legt auch die Wahrscheinlichkeit für Trümmerfrakturen fest (60% offene Frakturen = 40% Trümmerfrakturen)</German>
             <Japanese>開放骨折の可能性を設定します。粉砕骨折の可能性も設定します (開放骨折60% = 粉砕骨折40%)</Japanese>
             <Spanish>Establece la probabilidad para fracturas compuestas. También establece la probabilidad de fracturas conminutas (60% Compuesta - 40% Conminuta)</Spanish>
         </Key>
@@ -641,7 +643,7 @@
             <Czech>Čas provádění uzavřené repozice</Czech>
             <French>Temps pour effectuer une réduction fermée</French>
             <Korean>폐쇄 정복 수행 시간</Korean>
-            <German>Zeit für die Durchführung geschlossener Repositionen</German>
+            <German>Zeit für die Durchführung geschlossener Reduktionen</German>
             <Japanese>非観血的整復術にかかる時間</Japanese>
             <Spanish>Tiempo para realizar reducciones cerradas</Spanish>
         </Key>
@@ -653,7 +655,7 @@
             <Czech>Čas provádění otevřené repozice</Czech>
             <French>Temps pour effectuer une réduction ouverte</French>
             <Korean>개방정복 수행 시간</Korean>
-            <German>Zeit für die Durchführung offener Repositionen</German>
+            <German>Zeit für die Durchführung offener Reduktionen</German>
             <Japanese>観血的整復術にかかる時間</Japanese>
             <Spanish>Tiempo para realizar reducciones abiertas</Spanish>
         </Key>
@@ -773,7 +775,7 @@
             <Czech>Zdravotnická úroveň potřebná pro uzavřenou repozici</Czech>
             <French>Niveau médical requis pour effectuer une réduction fermée</French>
             <Korean>폐쇄정복을 하는 데 필요한 의료 레벨 수준</Korean>
-            <German>Erforderliches medizinisches Training für die geschlossene Reposition</German>
+            <German>Erforderliches medizinisches Training für die geschlossene Reduktion</German>
             <Japanese>非観血的整復術に必要な医療レベル</Japanese>
             <Spanish>Nivel médico requerido para realizar una reducción cerrada</Spanish>
         </Key>
@@ -809,7 +811,7 @@
             <Czech>Umístění uzavřené repozice</Czech>
             <French>Lieu des réductions fermées</French>
             <Korean>폐쇄정복 장소</Korean>
-            <German>Ort für die geschlossene Reposition</German>
+            <German>Ort für die geschlossene Reduktion</German>
             <Japanese>非観血的整復が可能な場所</Japanese>
             <Spanish>Zona para reducciones cerradas</Spanish>
         </Key>
@@ -821,7 +823,7 @@
             <Czech>Otevřená repozice/chirurgická poloha</Czech>
             <French>Lieu des réductions ouvertes / chirurgies</French>
             <Korean>개방정복 및 수술 장소</Korean>
-            <German>Ort für die offene Reposition/chirurgischer Eingriff</German>
+            <German>Ort für die offene Reduktion/chirurgischer Eingriffe</German>
             <Japanese>観血的整復術・手術が可能な場所</Japanese>
             <Spanish>Zona para reducciones abiertas/Acciones quirúrgicas</Spanish>
         </Key>
@@ -845,7 +847,7 @@
             <Czech>Roztaženo</Czech>
             <French>exposé(e)</French>
             <Korean>노출됨</Korean>
-            <German>freiliegend</German>
+            <German>freigelegt</German>
             <Japanese>露出した</Japanese>
             <Spanish>expuesto/a</Spanish>
         </Key>
@@ -869,7 +871,7 @@
             <Czech>Upnuto</Czech>
             <French>clampé(e)</French>
             <Korean>클램프됨</Korean>
-            <German>abgeklemmt</German>
+            <German>geklammert</German>
             <Japanese>クランプした</Japanese>
             <Spanish>alineado/a</Spanish>
         </Key>
@@ -893,7 +895,7 @@
             <Czech>Otevřená zlomenina</Czech>
             <French>Fracture ouverte</French>
             <Korean>복합 골절</Korean>
-            <German>Zusammengesetzte Fraktur</German>
+            <German>Offene Fraktur</German>
             <Japanese>開放骨折</Japanese>
             <Spanish>Fractura Compuesta</Spanish>
         </Key>

--- a/addons/surgery/stringtable.xml
+++ b/addons/surgery/stringtable.xml
@@ -343,7 +343,7 @@
             <Czech>Svorka</Czech>
             <French>Clamp</French>
             <Korean>클램프</Korean>
-            <German>Klammern</German>
+            <German>Klemme</German>
             <Japanese>鉗子 (クランプ)</Japanese>
             <Spanish>Pinza de sujeción</Spanish>
         </Key>
@@ -354,7 +354,7 @@
             <Czech>Používá se k upnutí rozdrcených zlomenin</Czech>
             <French>Utilisé pour clamper les fractures comminutives</French>
             <Korean>분쇄 골절을 클램프하는 데 사용됩니다</Korean>
-            <German>Zum Klammern von Trümmerfrakturen</German>
+            <German>Zum Abklemmen von Trümmerfrakturen</German>
             <Japanese>粉砕骨折をクランプするために使用</Japanese>
             <Spanish>Usada para sujetar las fracturas conminutas</Spanish>
             <Polish>Służy do zaciskania skomplikowanych złamań</Polish>
@@ -379,7 +379,7 @@
             <Czech>Upínání</Czech>
             <French>Clampage</French>
             <Korean>클램프 중</Korean>
-            <German>Klammern</German>
+            <German>Abklemmen</German>
             <Japanese>クランプ中</Japanese>
             <Spanish>Alineando trozos</Spanish>
         </Key>
@@ -871,7 +871,7 @@
             <Czech>Upnuto</Czech>
             <French>clampé(e)</French>
             <Korean>클램프됨</Korean>
-            <German>geklammert</German>
+            <German>abgeklemmt</German>
             <Japanese>クランプした</Japanese>
             <Spanish>alineado/a</Spanish>
         </Key>

--- a/addons/zeus/stringtable.xml
+++ b/addons/zeus/stringtable.xml
@@ -108,7 +108,7 @@
         </Key>
         <Key ID="STR_kat_zeus_ModuleManageAirway_bloodVolume">
             <English>Blood volume: </English>
-            <German>blutvolumen: </German>
+            <German>Blutvolumen: </German>
             <Czech>Množství krve: </Czech>
             <French>Volume sanguin: </French>
             <Polish>Ilość krwi: </Polish>
@@ -243,7 +243,7 @@
         </Key>
         <Key ID="STR_kat_zeus_OnlyInfantry">
             <English>Unit must be infantry.</English>
-            <German>Nur bei Infanterie verwendbar.</German>
+            <German>Nur bei abgesessener Infanterie verwendbar.</German>
             <Czech>Jednotka musí být pěchota.</Czech>
             <French>L'unité doit être une infanterie.</French>
             <Polish>Jednostką musi być piechota.</Polish>
@@ -273,7 +273,7 @@
         </Key>
         <Key ID="STR_kat_zeus_NotUnconscious">
             <English>Unit must be unconscious.</English>
-            <German>Einheit muss Ohnmächtig sein.</German>
+            <German>Einheit muss bewusstlos sein.</German>
             <Czech>Jednotka musí být při vědomí.</Czech>
             <French>L'unité doit être inconsciente.</French>
             <Polish>Jednostka musi być nieprzytomna.</Polish>


### PR DESCRIPTION
- Fixed German spelling across Stringtables (excluding Chemical)
- Filled Missing Translations
- Unified "Mediclevel"/"Trainigs level" to "Medizinischer Grad"
- "Zusammengesetzte Fraktur" (is the 1 to1 Translation of Compound Fracture, but it is an outdated term) zu "Offene Fraktur"
- "Reposition" unified to"Reduktion"