### PR TITLE
Airway - Fix no hint appearing when airway item action failed

### DIFF
--- a/addons/airway/XEH_postInit.sqf
+++ b/addons/airway/XEH_postInit.sqf
@@ -9,6 +9,11 @@ if !(GVAR(enable)) exitWith {};
 [QGVAR(recoveryPositionLocal), LINKFUNC(treatmentAdvanced_RecoveryPositionLocal)] call CBA_fnc_addEventHandler;
 [QGVAR(cancelRecoveryPositionLocal), LINKFUNC(treatmentAdvanced_CancelRecoveryPositionLocal)] call CBA_fnc_addEventHandler;
 
+[QGVAR(airwayFeedback), {
+    params ["_medic","_output"];
+    [_output, 1.5, _medic] call ACEFUNC(common,displayTextStructured);
+}] call CBA_fnc_addEventHandler;
+
 ["ace_unconscious", {
     params ["_unit", "_state"];
     if !(_state) exitWith {

--- a/addons/airway/functions/fnc_treatmentAdvanced_airwayLocal.sqf
+++ b/addons/airway/functions/fnc_treatmentAdvanced_airwayLocal.sqf
@@ -21,20 +21,17 @@
 params ["_medic", "_patient","_classname", "_usedItem"];
 
 if (_patient getVariable [QGVAR(occluded), false]) exitWith {
-    private _output = LLSTRING(Airway_NotClearForItem);
-    [_output, 1.5, _medic] call ACEFUNC(common,displayTextStructured);
+    [QGVAR(airwayFeedback), [_medic, LLSTRING(Airway_NotClearForItem)], _medic] call CBA_fnc_targetEvent;
     [_medic, _usedItem] call ACEFUNC(common,addToInventory);
 };
 
 if (_patient getVariable [QGVAR(airway_item), ""] isEqualTo "Larynxtubus") exitWith {
-    private _output = LLSTRING(Airway_already);
-    [_output, 1.5, _medic] call ACEFUNC(common,displayTextStructured);
+    [QGVAR(airwayFeedback), [_medic, LLSTRING(Airway_already)], _medic] call CBA_fnc_targetEvent;
     [_medic, _usedItem] call ACEFUNC(common,addToInventory);
 };
 
 if (_patient getVariable [QGVAR(airway_item), ""] isEqualTo "Guedeltubus" && _usedItem isEqualTo "kat_guedel") exitWith {
-    private _output = LLSTRING(Airway_already);
-    [_output, 1.5, _medic] call ACEFUNC(common,displayTextStructured);
+    [QGVAR(airwayFeedback), [_medic, LLSTRING(Airway_already)], _medic] call CBA_fnc_targetEvent;
     [_medic, _usedItem] call ACEFUNC(common,addToInventory);
 };
 


### PR DESCRIPTION
**When merged this pull request will:**
- Fix no hint appearing when unable to insert King LT/Guedel Tube due to airway occlusion or if one is already inserted.
![image](https://user-images.githubusercontent.com/15182031/231510425-d16b031e-7677-4e83-8263-f1036d2696b7.png)
Seems to only happen on dedicated server