### PR TITLE
Circulation - Fix: Assign proper bloodtype to other players

### DIFF
--- a/addons/circulation/functions/fnc_bloodType.sqf
+++ b/addons/circulation/functions/fnc_bloodType.sqf
@@ -19,7 +19,7 @@
 params ["_unit"];
 
 if (isNil {_unit getVariable QGVAR(bloodtype)}) then {
-    if (_unit != player) then {
+    if (!(isPlayer _unit)) then {
         private _randomBloodType = selectRandomWeighted ["A", 0.3, "A_N", 0.08, "B", 0.09, "B_N", 0.02, "AB", 0.02, "AB_N", 0.01, "O", 0.35, "O_N", 0.13];
         _unit setVariable [QGVAR(bloodtype), _randomBloodType, true];
         _unit setVariable [QACEGVAR(dogtags,dogtagData), nil, true];


### PR DESCRIPTION
If a player did not have a bloodtype this will now give them the appropriate bloodtype according to the generateBloodType function instead of a random one. 

If a player checked their own bloodtype or drew their own blood this bug would not happen as the function checked if the unit was their own player and not a player in general.