### PR TITLE
Airway - Removable airway items

### DIFF
--- a/addons/airway/ACE_Medical_Treatment_Actions.hpp
+++ b/addons/airway/ACE_Medical_Treatment_Actions.hpp
@@ -24,6 +24,15 @@ class ACE_Medical_Treatment_Actions {
         litter[] = {};
         icon = QPATHTOF(ui\larynx.paa);
     };
+    class RemoveAirwayItem: Larynxtubus {
+        displayName = CSTRING(RemoveAirwayItem_Display);
+        displayNameProgress = CSTRING(action_removing);
+        treatmentTime = QGVAR(RemoveAirwayItem_time);
+        items[] = {};
+        condition = QUOTE(!([_patient] call ace_common_fnc_isAwake) && (missionNamespace getVariable [ARR_2(QQGVAR(enable),true)]) && (_patient getVariable [ARR_2(QQGVAR(airway),false)]));
+        consumeItem = 0;
+        callbackSuccess = QFUNC(treatmentAdvanced_removeAirwayItem);
+    };
     class Guedeltubus: Larynxtubus {
         displayName = CSTRING(Guedeltubus_Display);
         medicRequired = QGVAR(medLvl_Guedeltubus);

--- a/addons/airway/XEH_PREP.hpp
+++ b/addons/airway/XEH_PREP.hpp
@@ -14,6 +14,8 @@ PREP(treatmentAdvanced_CancelRecoveryPositionLocal);
 PREP(treatmentAdvanced_overstretchHead);
 PREP(treatmentAdvanced_RecoveryPosition);
 PREP(treatmentAdvanced_RecoveryPositionLocal);
+PREP(treatmentAdvanced_RemoveAirwayItem);
+PREP(treatmentAdvanced_RemoveAirwayItemLocal);
 PREP(treatmentAdvanced_turnaroundHead);
 PREP(updateInjuryList);
 PREP(updateLogList);

--- a/addons/airway/XEH_postInit.sqf
+++ b/addons/airway/XEH_postInit.sqf
@@ -8,6 +8,7 @@ if !(GVAR(enable)) exitWith {};
 [QGVAR(accuvacLocal), LINKFUNC(treatmentAdvanced_accuvacLocal)] call CBA_fnc_addEventHandler;
 [QGVAR(recoveryPositionLocal), LINKFUNC(treatmentAdvanced_RecoveryPositionLocal)] call CBA_fnc_addEventHandler;
 [QGVAR(cancelRecoveryPositionLocal), LINKFUNC(treatmentAdvanced_CancelRecoveryPositionLocal)] call CBA_fnc_addEventHandler;
+[QGVAR(removeAirwayItemLocal), LINKFUNC(treatmentAdvanced_removeAirwayItemLocal)] call CBA_fnc_addEventHandler;
 
 [QGVAR(airwayFeedback), {
     params ["_medic","_output"];

--- a/addons/airway/XEH_preInit.sqf
+++ b/addons/airway/XEH_preInit.sqf
@@ -208,4 +208,14 @@ In real life, this will happen sometimes, not quiet often.
     true
 ] call CBA_Settings_fnc_init;
 
+//Settable treatment time for removing airway item
+[
+    QGVAR(RemoveAirwayItem_time),
+    "SLIDER",
+    [LLSTRING(TIME_AIRWAYITEM),LLSTRING(TIME_AIRWAYITEM_DESC)],
+    [CBA_SETTINGS_CAT, LSTRING(SubCategory_Items)],
+    [1, 10, 3, 0],
+    true
+] call CBA_Settings_fnc_init;
+
 ADDON = true;

--- a/addons/airway/XEH_preInit.sqf
+++ b/addons/airway/XEH_preInit.sqf
@@ -218,4 +218,14 @@ In real life, this will happen sometimes, not quiet often.
     true
 ] call CBA_Settings_fnc_init;
 
+//Reusable Airway items
+[
+    QGVAR(reusableAirwayItem),
+    "CHECKBOX",
+    [LLSTRING(REUSABLE_AIRWAYITEMS)],
+    [CBA_SETTINGS_CAT, LSTRING(SubCategory_Items)],
+    [true],
+    true
+] call CBA_Settings_fnc_init;
+
 ADDON = true;

--- a/addons/airway/functions/fnc_treatmentAdvanced_removeAirwayItem.sqf
+++ b/addons/airway/functions/fnc_treatmentAdvanced_removeAirwayItem.sqf
@@ -1,0 +1,24 @@
+#include "script_component.hpp"
+/*
+ * Author: MiszczuZPolski
+ * Removing airway item from patient
+ *
+ * Arguments:
+ * 0: Medic <OBJECT>
+ * 1: Patient <OBJECT>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [player, cursorTarget] call kat_airway_fnc_treatmentAdvanced_removeAirwayItem;
+ *
+ * Public: No
+ */
+
+params ["_medic", "_patient"];
+
+[_patient, "activity", LSTRING(RemoveAirwayItem_Log), [[_medic] call ACEFUNC(common,getName)]] call ACEFUNC(medical_treatment,addToLog);
+
+[QGVAR(removeAirwayItemLocal), _patient, _patient] call CBA_fnc_targetEvent;
+

--- a/addons/airway/functions/fnc_treatmentAdvanced_removeAirwayItem.sqf
+++ b/addons/airway/functions/fnc_treatmentAdvanced_removeAirwayItem.sqf
@@ -20,5 +20,5 @@ params ["_medic", "_patient"];
 
 [_patient, "activity", LSTRING(RemoveAirwayItem_Log), [[_medic] call ACEFUNC(common,getName)]] call ACEFUNC(medical_treatment,addToLog);
 
-[QGVAR(removeAirwayItemLocal), _patient, _patient] call CBA_fnc_targetEvent;
+[QGVAR(removeAirwayItemLocal), [_medic, _patient], _patient] call CBA_fnc_targetEvent;
 

--- a/addons/airway/functions/fnc_treatmentAdvanced_removeAirwayItemLocal.sqf
+++ b/addons/airway/functions/fnc_treatmentAdvanced_removeAirwayItemLocal.sqf
@@ -22,9 +22,9 @@ private _item = _patient getVariable [QGVAR(airway_item), ""];
 
 if (GVAR(reusableAirwayItem)) then {
     if (_item isEqualTo "Larynxtubus") then {
-	    [_medic, "kat_larynx"] call ACEFUNC(common,addToInventory);
+        [_medic, "kat_larynx"] call ACEFUNC(common,addToInventory);
     } else {
-	    [_medic, "kat_guedel"] call ACEFUNC(common,addToInventory);
+        [_medic, "kat_guedel"] call ACEFUNC(common,addToInventory);
     };
 };
 

--- a/addons/airway/functions/fnc_treatmentAdvanced_removeAirwayItemLocal.sqf
+++ b/addons/airway/functions/fnc_treatmentAdvanced_removeAirwayItemLocal.sqf
@@ -1,0 +1,22 @@
+#include "script_component.hpp"
+/*
+ * Author: MiszczuZPolski
+ * Removing airway item from patient
+ *
+ * Arguments:
+ * 0: Medic <OBJECT>
+ * 1: Patient <OBJECT>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [player] call kat_airway_fnc_treatmentAdvanced_removeAirwayItemLocal;
+ *
+ * Public: No
+ */
+
+params ["_patient"];
+
+_patient setVariable [QGVAR(airway), false, true];
+_patient setVariable [QGVAR(airway_item), "", true];

--- a/addons/airway/functions/fnc_treatmentAdvanced_removeAirwayItemLocal.sqf
+++ b/addons/airway/functions/fnc_treatmentAdvanced_removeAirwayItemLocal.sqf
@@ -11,12 +11,22 @@
  * None
  *
  * Example:
- * [player] call kat_airway_fnc_treatmentAdvanced_removeAirwayItemLocal;
+ * [player, cursorObject] call kat_airway_fnc_treatmentAdvanced_removeAirwayItemLocal;
  *
  * Public: No
  */
 
-params ["_patient"];
+params ["_medic", "_patient"];
+
+private _item = _patient getVariable [QGVAR(airway_item), ""];
+
+if (GVAR(reusableAirwayItem)) then {
+	if (_item isEqualTo "Larynxtubus") then {
+		[_medic, "kat_larynx"] call ACEFUNC(common,addToInventory);
+	} else {
+		[_medic, "kat_guedel"] call ACEFUNC(common,addToInventory);
+	};
+};
 
 _patient setVariable [QGVAR(airway), false, true];
 _patient setVariable [QGVAR(airway_item), "", true];

--- a/addons/airway/functions/fnc_treatmentAdvanced_removeAirwayItemLocal.sqf
+++ b/addons/airway/functions/fnc_treatmentAdvanced_removeAirwayItemLocal.sqf
@@ -21,11 +21,11 @@ params ["_medic", "_patient"];
 private _item = _patient getVariable [QGVAR(airway_item), ""];
 
 if (GVAR(reusableAirwayItem)) then {
-	if (_item isEqualTo "Larynxtubus") then {
-		[_medic, "kat_larynx"] call ACEFUNC(common,addToInventory);
-	} else {
-		[_medic, "kat_guedel"] call ACEFUNC(common,addToInventory);
-	};
+    if (_item isEqualTo "Larynxtubus") then {
+	    [_medic, "kat_larynx"] call ACEFUNC(common,addToInventory);
+    } else {
+	    [_medic, "kat_guedel"] call ACEFUNC(common,addToInventory);
+    };
 };
 
 _patient setVariable [QGVAR(airway), false, true];

--- a/addons/airway/stringtable.xml
+++ b/addons/airway/stringtable.xml
@@ -1184,5 +1184,25 @@
             <Spanish>Parámetros de las herramientas (vias aéreas)</Spanish>
             <Portuguese>Configurações de itens de vias aéreas</Portuguese>
         </Key>
+        <Key ID="STR_KAT_Airway_TIME_AIRWAYITEM">
+            <English>Time for removing airway item</English>
+            <Polish>Czas na usunięcie przedmiotu z dróg oddechowych</Polish>
+        </Key>
+        <Key ID="STR_KAT_Airway_TIME_AIRWAYITEM_DESC">
+            <English>How long it will take to remove airway item</English>
+            <Polish>Jak długo potrwa usunięcie przedmiotu z dróg oddechowych</Polish>
+        </Key>
+        <Key ID="STR_KAT_Airway_RemoveAirwayItem_Display">
+            <English>Remove airway item</English>
+            <Polish>Usuń przedmiot z dróg oddechowych</Polish>
+        </Key>
+        <Key ID="STR_KAT_Airway_action_removing">
+            <English>Removing...</English>
+            <Polish>Wyciąganie...</Polish>
+        </Key>
+        <Key ID="STR_KAT_Airway_RemoveAirwayItem_Log">
+            <English>%1 removed airway item</English>
+            <Polish>%1 usunął rurkę z dróg oddechowych</Polish>
+        </Key>
     </Package>
 </Project>

--- a/addons/airway/stringtable.xml
+++ b/addons/airway/stringtable.xml
@@ -1194,7 +1194,7 @@
         </Key>
         <Key ID="STR_KAT_Airway_RemoveAirwayItem_Display">
             <English>Remove airway item</English>
-            <Polish>Usuń przedmiot z dróg oddechowych</Polish>
+            <Polish>Usuń rurkę z dróg oddechowych</Polish>
         </Key>
         <Key ID="STR_KAT_Airway_action_removing">
             <English>Removing...</English>
@@ -1203,6 +1203,10 @@
         <Key ID="STR_KAT_Airway_RemoveAirwayItem_Log">
             <English>%1 removed airway item</English>
             <Polish>%1 usunął rurkę z dróg oddechowych</Polish>
+        </Key>
+        <Key ID="STR_KAT_Airway_REUSABLE_AIRWAYITEMS">
+            <English>Sets if KingLT/Guedel is reusable</English>
+            <Polish>Czy rurka krtaniowa/ustno-gardłowa jest do ponownego użytku</Polish>
         </Key>
     </Package>
 </Project>


### PR DESCRIPTION
**When merged this pull request will:**
- Add new action to remove currently used item from airways
- If set, it will be reusable after removing (default on)

Native english translations need review, not sure if it sounds right.
I think condition for action might be reduced to just - variable airway is true.

Alternative to #297 