### PR TITLE
Airway - Add description for obstruction and occlusion setting

### DIFF
--- a/addons/airway/XEH_preInit.sqf
+++ b/addons/airway/XEH_preInit.sqf
@@ -42,9 +42,9 @@ In real life, this will happen sometimes, not quiet often.
 [
     QGVAR(probability_obstruction),
     "SLIDER",
-    LLSTRING(SETTING_obstruction),
+    [LLSTRING(SETTING_obstruction),LLSTRING(SETTING_obstruction_DESC)],
     [CBA_SETTINGS_CAT, LSTRING(SubCategory_Basic)],
-    [0, 100, 15, 0],
+    [0, 100, 40, 0],
     true
 ] call CBA_Settings_fnc_init;
 
@@ -52,7 +52,7 @@ In real life, this will happen sometimes, not quiet often.
 [
     QGVAR(probability_occluded),
     "SLIDER",
-    LLSTRING(SETTING_occluded),
+    [LLSTRING(SETTING_occluded),LLSTRING(SETTING_occluded_DESC)],
     [CBA_SETTINGS_CAT, LSTRING(SubCategory_Basic)],
     [0, 100, 10, 0],
     true

--- a/addons/airway/functions/fnc_treatmentAdvanced_CancelRecoveryPositionLocal.sqf
+++ b/addons/airway/functions/fnc_treatmentAdvanced_CancelRecoveryPositionLocal.sqf
@@ -20,6 +20,7 @@ params ["_medic", "_patient"];
 
 _patient setVariable [QGVAR(recovery), false, true];
 _patient setVariable [QGVAR(overstretch), false, true];
+_patient call FUNC(handlePuking);
 
 private _output = LLSTRING(Recovery_Cancel);
 [_output, 1.5, _medic] call ACEFUNC(common,displayTextStructured);

--- a/addons/airway/stringtable.xml
+++ b/addons/airway/stringtable.xml
@@ -34,7 +34,7 @@
             <Portuguese>Probabilidade de obstrução das vias aéreas</Portuguese>
         </Key>
         <Key ID="STR_KAT_Airway_SETTING_obstruction_DESC">
-            <English>Probability for an obstructed airway in persentage that gets rolled every:\n- Falling unconscious\n- Removing KingLT / Guedel Tube</English>
+            <English>Probability for an obstructed airway in percentage that gets rolled every:\n- Falling unconscious\n- Removing KingLT / Guedel Tube</English>
             <German>Atemwegsverlegungswahrscheinlichkeit in prozent die berechnet wird sofern:\n- Bewustlos werden\n- Das Entfernen von Larynxtubus / Guedeltubus\n- Abbrechen der Stabile Seitenlage</German>
         </Key>
         <Key ID="STR_KAT_Airway_SETTING_occluded">

--- a/addons/airway/stringtable.xml
+++ b/addons/airway/stringtable.xml
@@ -33,6 +33,10 @@
             <Japanese>気道閉塞の確率</Japanese>
             <Portuguese>Probabilidade de obstrução das vias aéreas</Portuguese>
         </Key>
+        <Key ID="STR_KAT_Airway_SETTING_obstruction_DESC">
+            <English>Probability for an obstructed airway in persentage that gets rolled every:\n- Falling unconscious\n- Removing KingLT / Guedel Tube\n- Canceling Recovery Position</English>
+            <German>Atemwegsverlegungswahrscheinlichkeit in prozent die berechnet wird sofern:\n- Bewustlos werden\n- Das Entfernen von Larynxtubus / Guedeltubus\n- Abbrechen der Stabile Seitenlage</German>
+        </Key>
         <Key ID="STR_KAT_Airway_SETTING_occluded">
             <English>Probability for airway occluding</English>
             <German>Atemwegsverlegungswahrscheinlichkeit durch Erbrochenes</German>
@@ -48,6 +52,10 @@
             <Russian>Вероятность закупорки дыхательных путей</Russian>
             <Japanese>気道異物の確率</Japanese>
             <Portuguese>Probabilidade de oclusão das vias aéreas</Portuguese>
+        </Key>
+        <Key ID="STR_KAT_Airway_SETTING_occluded_DESC">
+            <English>Probability for an occlusion in persentage that gets rolled Setting:[Occlusion repeat timer] (default every 60s)</English>
+            <German>Atemwegsverlegungswahrscheinlichkeit durch Erbrochenes in prozent die durch Einstellung:[Zeit für die Wiederholung des Erbrechens] (standard alle 60s) berechnet wird.</German>
         </Key>
         <Key ID="STR_KAT_Airway_SETTING_occlusion_repeatTimer">
             <English>Occlusion repeat timer</English>

--- a/addons/airway/stringtable.xml
+++ b/addons/airway/stringtable.xml
@@ -34,7 +34,7 @@
             <Portuguese>Probabilidade de obstrução das vias aéreas</Portuguese>
         </Key>
         <Key ID="STR_KAT_Airway_SETTING_obstruction_DESC">
-            <English>Probability for an obstructed airway in persentage that gets rolled every:\n- Falling unconscious\n- Removing KingLT / Guedel Tube\n- Canceling Recovery Position</English>
+            <English>Probability for an obstructed airway in persentage that gets rolled every:\n- Falling unconscious\n- Removing KingLT / Guedel Tube</English>
             <German>Atemwegsverlegungswahrscheinlichkeit in prozent die berechnet wird sofern:\n- Bewustlos werden\n- Das Entfernen von Larynxtubus / Guedeltubus\n- Abbrechen der Stabile Seitenlage</German>
         </Key>
         <Key ID="STR_KAT_Airway_SETTING_occluded">
@@ -54,7 +54,7 @@
             <Portuguese>Probabilidade de oclusão das vias aéreas</Portuguese>
         </Key>
         <Key ID="STR_KAT_Airway_SETTING_occluded_DESC">
-            <English>Probability for an occlusion in persentage that gets rolled Setting:[Occlusion repeat timer] (default every 60s)</English>
+            <English>Probability for an occlusion in percentage that gets rolled Setting:[Occlusion repeat timer] (default every 60s)</English>
             <German>Atemwegsverlegungswahrscheinlichkeit durch Erbrochenes in prozent die durch Einstellung:[Zeit für die Wiederholung des Erbrechens] (standard alle 60s) berechnet wird.</German>
         </Key>
         <Key ID="STR_KAT_Airway_SETTING_occlusion_repeatTimer">


### PR DESCRIPTION
**When merged this pull request will:**
- Changes the default probability chance for an obstruction happening to 40%.
- Edited 2 string to display when a check for obstruction / occlusion is done.
![image](https://github.com/Tomcat-SG/KAM/assets/95135995/e9116fb7-1a26-47fa-a879-60e9cff910c6)
![image](https://github.com/Tomcat-SG/KAM/assets/95135995/2eed7c22-86ed-414b-9c25-2c0bad941a78)
![image](https://github.com/Tomcat-SG/KAM/assets/95135995/67292657-e7f1-4292-872b-3d24c76da236)
- Fixed cancel recovery position not recalling the handle puking.

### IMPORTANT

- [x] [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.