### PR TITLE
Circulation - Fix wrong language string for AED-X SpO2 warning

### DIFF
--- a/addons/circulation/XEH_preInit.sqf
+++ b/addons/circulation/XEH_preInit.sqf
@@ -215,7 +215,7 @@ PREP_RECOMPILE_END;
 [
     QGVAR(AED_X_Monitor_SpO2Warning),
     "SLIDER",
-    LELSTRING(breathing,SETTING_Threshold_SpO2Warning),
+    LLSTRING(SETTING_Threshold_SpO2Warning),
     [CBA_SETTINGS_CAT, LSTRING(SubCategory_AED)],
     [1, 100, 85, 1],
     true

--- a/addons/circulation/stringtable.xml
+++ b/addons/circulation/stringtable.xml
@@ -2090,7 +2090,7 @@
             <Czech>Střídavý tón</Czech>
         </Key>
         <Key ID="STR_KAT_Circulation_SETTING_Threshold_SpO2Warning">
-            <English>AED-X Alarm SpO2 Threshold</English>
+            <English>AED-X alarm SpO2 threshold</English>
             <Czech>Práh AED-X pro aktivaci alarmu Pulzního Oxymetru</Czech>
         </Key>
     </Package>

--- a/addons/circulation/stringtable.xml
+++ b/addons/circulation/stringtable.xml
@@ -2089,5 +2089,9 @@
             <German>Alternativer Ton</German>
             <Czech>Střídavý tón</Czech>
         </Key>
+        <Key ID="STR_KAT_Circulation_SETTING_Threshold_SpO2Warning">
+            <English>AED-X Alarm SpO2 Threshold</English>
+            <Czech>Práh AED-X pro aktivaci alarmu Pulzního Oxymetru</Czech>
+        </Key>
     </Package>
 </Project>


### PR DESCRIPTION
**When merged this pull request will:**
- Fix language string for AED-X SpO2 warning was reused from the pulse oximeter resulting in the misleading name in addon options

### IMPORTANT

- [x] [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.