### PR TITLE
Chemical - Fix gas mask action visibility on dedicated server

### DIFF
--- a/addons/chemical/XEH_postInit.sqf
+++ b/addons/chemical/XEH_postInit.sqf
@@ -26,3 +26,6 @@ ppBlur_priority = 399;
     ppBlurAmount = 0;
     ppBluring = false;
 }] call CBA_fnc_waitUntilAndExecute;
+
+private _items = missionNamespace getVariable [QGVAR(availGasmask), "G_AirPurifyingRespirator_01_F"];
+missionNamespace setVariable [QGVAR(availGasmaskList), _items splitString ",", true];

--- a/addons/chemical/XEH_preInit.sqf
+++ b/addons/chemical/XEH_preInit.sqf
@@ -13,7 +13,11 @@ PREP_RECOMPILE_END;
     "EDITBOX",
     [LLSTRING(SETTING_AVAIL_GASMASK), LLSTRING(SETTING_AVAIL_GASMASK_DISC)],
     CBA_SETTINGS_CHEM,
-    """G_AirPurifyingRespirator_01_F""",
+    "G_AirPurifyingRespirator_01_F",
+    1,
+    {
+        missionNamespace setVariable [QGVAR(availGasmaskList), _this splitString ",", true];
+    },
     true
 ] call CBA_Settings_fnc_init;
 

--- a/addons/chemical/functions/fnc_afterWait.sqf
+++ b/addons/chemical/functions/fnc_afterWait.sqf
@@ -21,7 +21,7 @@
 
 params ["_unit", "_logic", "_gastype", "_radius_max"];
 
-if (goggles _unit in GVAR(availGasmasklist)) then {
+if ((goggles _unit) in (missionNamespace getVariable [QGVAR(availGasmaskList),[]])) then {
     private _isinGas = true;
     [
         {
@@ -39,7 +39,7 @@ if (goggles _unit in GVAR(availGasmasklist)) then {
                 _isinGas = false;
             };
 
-            if !(goggles _unit in GVAR(availGasmasklist) && _timeleft > 0) then {
+            if !((goggles _unit) in (missionNamespace getVariable [QGVAR(availGasmaskList),[]]) && _timeleft > 0) then {
                 _unit setVariable [QGVAR(poisonType), _gastype, true];
                 switch (_gastype) do {
                     case "Toxic": {

--- a/addons/chemical/functions/fnc_afterWait.sqf
+++ b/addons/chemical/functions/fnc_afterWait.sqf
@@ -21,7 +21,7 @@
 
 params ["_unit", "_logic", "_gastype", "_radius_max"];
 
-if ((goggles _unit) in (missionNamespace getVariable [QGVAR(availGasmaskList),[]])) then {
+if ((goggles _unit) in (missionNamespace getVariable [QGVAR(availGasmaskList), []])) then {
     private _isinGas = true;
     [
         {
@@ -39,7 +39,7 @@ if ((goggles _unit) in (missionNamespace getVariable [QGVAR(availGasmaskList),[]
                 _isinGas = false;
             };
 
-            if !((goggles _unit) in (missionNamespace getVariable [QGVAR(availGasmaskList),[]]) && _timeleft > 0) then {
+            if !((goggles _unit) in (missionNamespace getVariable [QGVAR(availGasmaskList), []]) && _timeleft > 0) then {
                 _unit setVariable [QGVAR(poisonType), _gastype, true];
                 switch (_gastype) do {
                     case "Toxic": {

--- a/addons/chemical/functions/fnc_breathing.sqf
+++ b/addons/chemical/functions/fnc_breathing.sqf
@@ -20,7 +20,7 @@ params ["_unit"];
 [
     {
         params ["_unit"];
-        goggles _unit in GVAR(availGasmaskList)
+        (goggles _unit) in (missionNamespace getVariable [QGVAR(availGasmaskList),[]])
     },
     {
         params ["_unit"];
@@ -28,7 +28,7 @@ params ["_unit"];
             {
                 params["_args", "_handler"];
                 _args params ["_unit"];
-                if !(goggles _unit in GVAR(availGasmaskList) || !(alive _unit) || _unit getVariable [QACEGVAR(medical,heartrate), 80] <= 0) then {
+                if (!(goggles _unit in (missionNamespace getVariable [QGVAR(availGasmaskList),[]])) || !(alive player) || _unit getVariable [QACEGVAR(medical,heartrate), 80] <= 0) then {
                     [_handler] call CBA_fnc_removePerFrameHandler;
                     [_unit] call FUNC(breathing);
                 } else {

--- a/addons/chemical/functions/fnc_breathing.sqf
+++ b/addons/chemical/functions/fnc_breathing.sqf
@@ -20,7 +20,7 @@ params ["_unit"];
 [
     {
         params ["_unit"];
-        (goggles _unit) in (missionNamespace getVariable [QGVAR(availGasmaskList),[]])
+        (goggles _unit) in (missionNamespace getVariable [QGVAR(availGasmaskList), []])
     },
     {
         params ["_unit"];
@@ -28,7 +28,7 @@ params ["_unit"];
             {
                 params["_args", "_handler"];
                 _args params ["_unit"];
-                if (!(goggles _unit in (missionNamespace getVariable [QGVAR(availGasmaskList),[]])) || !(alive player) || _unit getVariable [QACEGVAR(medical,heartrate), 80] <= 0) then {
+                if (!(goggles _unit in (missionNamespace getVariable [QGVAR(availGasmaskList), []])) || !(alive _unit) || _unit getVariable [QACEGVAR(medical,heartrate), 80] <= 0) then {
                     [_handler] call CBA_fnc_removePerFrameHandler;
                     [_unit] call FUNC(breathing);
                 } else {

--- a/addons/chemical/functions/fnc_canPutGasMask.sqf
+++ b/addons/chemical/functions/fnc_canPutGasMask.sqf
@@ -17,4 +17,6 @@
 
 params ["_medic", "_patient"];
 
-!(_patient call ACEFUNC(common,isAwake)) && ([_medic,_patient] call FUNC(hasGasmask)) && !(goggles _patient in GVAR(availGasmaskList))
+if(missionNamespace getVariable [QGVAR(availGasmaskList),[]] isEqualTo []) exitWith {false};
+
+!(_patient call ACE_common_fnc_isAwake) && ([_medic,_patient] call FUNC(hasGasmask)) && !((goggles _patient) in (missionNamespace getVariable [QGVAR(availGasmaskList),[]]))

--- a/addons/chemical/functions/fnc_canPutGasMask.sqf
+++ b/addons/chemical/functions/fnc_canPutGasMask.sqf
@@ -17,6 +17,6 @@
 
 params ["_medic", "_patient"];
 
-if(missionNamespace getVariable [QGVAR(availGasmaskList),[]] isEqualTo []) exitWith {false};
+if(missionNamespace getVariable [QGVAR(availGasmaskList), []] isEqualTo []) exitWith {false};
 
-!(_patient call ACE_common_fnc_isAwake) && ([_medic,_patient] call FUNC(hasGasmask)) && !((goggles _patient) in (missionNamespace getVariable [QGVAR(availGasmaskList),[]]))
+!(_patient call ACE_common_fnc_isAwake) && ([_medic,_patient] call FUNC(hasGasmask)) && !((goggles _patient) in (missionNamespace getVariable [QGVAR(availGasmaskList), []]))

--- a/addons/chemical/functions/fnc_canReplaceFilter.sqf
+++ b/addons/chemical/functions/fnc_canReplaceFilter.sqf
@@ -16,8 +16,6 @@
 
 params ["_target"];
 
-if (goggles _target in GVAR(availGasmaskList) && 'kat_gasmaskFilter' in items _target) then {
-    true
-} else {
-    false
-};
+if (missionNamespace getVariable [QGVAR(availGasmaskList),[]] isEqualTo []) exitWith {false};
+
+(goggles _target) in (missionNamespace getVariable [QGVAR(availGasmaskList),[]]) && 'kat_gasmaskFilter' in (items _target);

--- a/addons/chemical/functions/fnc_canReplaceFilter.sqf
+++ b/addons/chemical/functions/fnc_canReplaceFilter.sqf
@@ -14,8 +14,8 @@
  * Public: No
 */
 
-params ["_target"];
+params ["_unit"];
 
-if (missionNamespace getVariable [QGVAR(availGasmaskList),[]] isEqualTo []) exitWith {false};
+if (missionNamespace getVariable [QGVAR(availGasmaskList), []] isEqualTo []) exitWith {false};
 
-(goggles _target) in (missionNamespace getVariable [QGVAR(availGasmaskList),[]]) && 'kat_gasmaskFilter' in (items _target);
+(goggles _unit) in (missionNamespace getVariable [QGVAR(availGasmaskList), []]) && 'kat_gasmaskFilter' in (items _unit);

--- a/addons/chemical/functions/fnc_gasAI.sqf
+++ b/addons/chemical/functions/fnc_gasAI.sqf
@@ -49,7 +49,7 @@ private _skill = _unit skill "aimingAccuracy";
             _unit setVariable [QGVAR(enteredPoison), true, true];
             private _fnc_afterwait = {
                 params ["_unit", "_gastype", "_pos", "_skill"];
-                if !(goggles _unit in GVAR(availGasmaskList)) exitwith {
+                if !((goggles _unit) in (missionNamespace getVariable [QGVAR(availGasmaskList),[]])) exitwith {
                     if (_gastype isEqualTo "CS") then {
                         while {_unit distance _pos < 10 && _unit getVariable [QGVAR(enteredPoison), false]} do {
                             _unit say3D QGVAR(cough_1);

--- a/addons/chemical/functions/fnc_gasAI.sqf
+++ b/addons/chemical/functions/fnc_gasAI.sqf
@@ -49,7 +49,7 @@ private _skill = _unit skill "aimingAccuracy";
             _unit setVariable [QGVAR(enteredPoison), true, true];
             private _fnc_afterwait = {
                 params ["_unit", "_gastype", "_pos", "_skill"];
-                if !((goggles _unit) in (missionNamespace getVariable [QGVAR(availGasmaskList),[]])) exitwith {
+                if !((goggles _unit) in (missionNamespace getVariable [QGVAR(availGasmaskList), []])) exitwith {
                     if (_gastype isEqualTo "CS") then {
                         while {_unit distance _pos < 10 && _unit getVariable [QGVAR(enteredPoison), false]} do {
                             _unit say3D QGVAR(cough_1);

--- a/addons/chemical/functions/fnc_giveUnitGasMask.sqf
+++ b/addons/chemical/functions/fnc_giveUnitGasMask.sqf
@@ -20,7 +20,7 @@ params ["_medic", "_patient"];
 private _itemArr = _medic call ACEFUNC(common,uniqueItems);
 private _playerhasGasmask = false;
 private _playerGasMask = "";
-{ if(_x in GVAR(availGasmaskList)) then {_playerhasGasmask = true; _playerGasMask = _x} } forEach _itemArr;
+{ if(_x in (missionNamespace getVariable [QGVAR(availGasmaskList),[]])) then {_playerhasGasmask = true; _playerGasMask = _x} } forEach _itemArr;
 
 private _fnc_replaceItem = {
     params["_medic", "_patient", "_playerGasMask"];
@@ -38,6 +38,6 @@ if (_playerhasGasmask) then {
     [_medic,_patient,_playerGasMask] call _fnc_replaceItem;
 } else {
     _itemArr = _patient call ACEFUNC(common,uniqueItems);
-    { if(_x in GVAR(availGasmaskList)) then {_playerGasMask = _x} } forEach _itemArr;
+    { if(_x in (missionNamespace getVariable [QGVAR(availGasmaskList),[]])) then {_playerGasMask = _x} } forEach _itemArr;
     [_medic,_patient,_playerGasMask] call _fnc_replaceItem;
 };

--- a/addons/chemical/functions/fnc_giveUnitGasMask.sqf
+++ b/addons/chemical/functions/fnc_giveUnitGasMask.sqf
@@ -20,7 +20,7 @@ params ["_medic", "_patient"];
 private _itemArr = _medic call ACEFUNC(common,uniqueItems);
 private _playerhasGasmask = false;
 private _playerGasMask = "";
-{ if(_x in (missionNamespace getVariable [QGVAR(availGasmaskList),[]])) then {_playerhasGasmask = true; _playerGasMask = _x} } forEach _itemArr;
+{ if(_x in (missionNamespace getVariable [QGVAR(availGasmaskList), []])) then {_playerhasGasmask = true; _playerGasMask = _x} } forEach _itemArr;
 
 private _fnc_replaceItem = {
     params["_medic", "_patient", "_playerGasMask"];
@@ -38,6 +38,6 @@ if (_playerhasGasmask) then {
     [_medic,_patient,_playerGasMask] call _fnc_replaceItem;
 } else {
     _itemArr = _patient call ACEFUNC(common,uniqueItems);
-    { if(_x in (missionNamespace getVariable [QGVAR(availGasmaskList),[]])) then {_playerGasMask = _x} } forEach _itemArr;
+    { if(_x in (missionNamespace getVariable [QGVAR(availGasmaskList), []])) then {_playerGasMask = _x} } forEach _itemArr;
     [_medic,_patient,_playerGasMask] call _fnc_replaceItem;
 };

--- a/addons/chemical/functions/fnc_handleCSGas.sqf
+++ b/addons/chemical/functions/fnc_handleCSGas.sqf
@@ -20,7 +20,7 @@ params ["_logic","_radius"];
     _params params["_unit"];
     if (_unit getVariable[QGVAR(enteredPoison),false]) then {
         if (_unit getVariable [QACEGVAR(medical,pain), 0] < 0.25) then {_unit setVariable [QACEGVAR(medical,pain), 0.41]};
-        if (goggles _unit in GVAR(availGasmaskList)) then {_unit setVariable [QGVAR(enteredPoison), false, true]};
+        if ((goggles _unit) in (missionNamespace getVariable [QGVAR(availGasmaskList),[]])) then {_unit setVariable[QGVAR(enteredPoison),false,true]};
         _unit setVariable [QGVAR(CS), true, true];
         _unit say3D QGVAR(cough_1);
         private _rndBlur = selectRandom [5, 6, 7, 8];

--- a/addons/chemical/functions/fnc_handleCSGas.sqf
+++ b/addons/chemical/functions/fnc_handleCSGas.sqf
@@ -20,7 +20,7 @@ params ["_logic","_radius"];
     _params params["_unit"];
     if (_unit getVariable[QGVAR(enteredPoison),false]) then {
         if (_unit getVariable [QACEGVAR(medical,pain), 0] < 0.25) then {_unit setVariable [QACEGVAR(medical,pain), 0.41]};
-        if ((goggles _unit) in (missionNamespace getVariable [QGVAR(availGasmaskList),[]])) then {_unit setVariable[QGVAR(enteredPoison),false,true]};
+        if ((goggles _unit) in (missionNamespace getVariable [QGVAR(availGasmaskList), []])) then {_unit setVariable[QGVAR(enteredPoison), false, true]};
         _unit setVariable [QGVAR(CS), true, true];
         _unit say3D QGVAR(cough_1);
         private _rndBlur = selectRandom [5, 6, 7, 8];

--- a/addons/chemical/functions/fnc_handleGasMaskDur.sqf
+++ b/addons/chemical/functions/fnc_handleGasMaskDur.sqf
@@ -19,11 +19,11 @@ params ["_unit"];
 [
     {
         params["_unit"];
-        !isNil QGVAR(availGasmaskList) && _unit getVariable [QGVAR(enteredPoison), false]
+        !(missionNamespace getVariable [QGVAR(availGasmaskList),[]] isEqualTo []) && _unit getVariable [QGVAR(enteredPoison), false]
     },
     {
         params["_unit"];
-        if(_unit getVariable [QGVAR(enteredPoison), false] && goggles _unit in GVAR(availGasmaskList)) then {
+        if(_unit getVariable [QGVAR(enteredPoison), false] && (goggles _unit) in (missionNamespace getVariable [QGVAR(availGasmaskList),[]])) then {
             private _timeEntered = CBA_missionTime;
             private _maxTime = missionNamespace getVariable [QGVAR(gasmask_durability),900];
             private _currentDurability = _unit getVariable [QGVAR(gasmask_durability),10];
@@ -61,7 +61,7 @@ params ["_unit"];
             [
                 {
                     params["_unit"];
-                    _unit getVariable [QGVAR(enteredPoison), false] || goggles _unit in GVAR(availGasmaskList)
+                    _unit getVariable [QGVAR(enteredPoison), false] || (goggles _unit) in (missionNamespace getVariable [QGVAR(availGasmaskList),[]])
                 },
                 {
                     [_unit] call FUNC(handleGasMaskDur);

--- a/addons/chemical/functions/fnc_handleGasMaskDur.sqf
+++ b/addons/chemical/functions/fnc_handleGasMaskDur.sqf
@@ -19,11 +19,11 @@ params ["_unit"];
 [
     {
         params["_unit"];
-        !(missionNamespace getVariable [QGVAR(availGasmaskList),[]] isEqualTo []) && _unit getVariable [QGVAR(enteredPoison), false]
+        !(missionNamespace getVariable [QGVAR(availGasmaskList), []] isEqualTo []) && _unit getVariable [QGVAR(enteredPoison), false]
     },
     {
         params["_unit"];
-        if(_unit getVariable [QGVAR(enteredPoison), false] && (goggles _unit) in (missionNamespace getVariable [QGVAR(availGasmaskList),[]])) then {
+        if(_unit getVariable [QGVAR(enteredPoison), false] && (goggles _unit) in (missionNamespace getVariable [QGVAR(availGasmaskList), []])) then {
             private _timeEntered = CBA_missionTime;
             private _maxTime = missionNamespace getVariable [QGVAR(gasmask_durability),900];
             private _currentDurability = _unit getVariable [QGVAR(gasmask_durability),10];
@@ -61,7 +61,7 @@ params ["_unit"];
             [
                 {
                     params["_unit"];
-                    _unit getVariable [QGVAR(enteredPoison), false] || (goggles _unit) in (missionNamespace getVariable [QGVAR(availGasmaskList),[]])
+                    _unit getVariable [QGVAR(enteredPoison), false] || (goggles _unit) in (missionNamespace getVariable [QGVAR(availGasmaskList), []])
                 },
                 {
                     [_unit] call FUNC(handleGasMaskDur);

--- a/addons/chemical/functions/fnc_hasGasMaskON.sqf
+++ b/addons/chemical/functions/fnc_hasGasMaskON.sqf
@@ -16,4 +16,6 @@
 
 params ["_target"];
 
-goggles _target in GVAR(availGasmaskList)
+if(missionNamespace getVariable [QGVAR(availGasmaskList),[]] isEqualTo []) exitWith {false};
+
+goggles _target in (missionNamespace getVariable [QGVAR(availGasmaskList),[]]);

--- a/addons/chemical/functions/fnc_hasGasMaskON.sqf
+++ b/addons/chemical/functions/fnc_hasGasMaskON.sqf
@@ -16,6 +16,6 @@
 
 params ["_target"];
 
-if(missionNamespace getVariable [QGVAR(availGasmaskList),[]] isEqualTo []) exitWith {false};
+if(missionNamespace getVariable [QGVAR(availGasmaskList), []] isEqualTo []) exitWith {false};
 
-goggles _target in (missionNamespace getVariable [QGVAR(availGasmaskList),[]]);
+goggles _target in (missionNamespace getVariable [QGVAR(availGasmaskList), []]);

--- a/addons/chemical/functions/fnc_hasGasmask.sqf
+++ b/addons/chemical/functions/fnc_hasGasmask.sqf
@@ -20,10 +20,10 @@ params [["_player", objNull, [objNull]],["_patient", objNull, [objNull]]];
 
 private _playerarr = _player call ACEFUNC(common,uniqueItems);
 private _playerhasGasmask = false;
-{ if(_x in GVAR(availGasmaskList)) then {_playerhasGasmask = true} } forEach _playerarr;
+{ if(_x in (missionNamespace getVariable [QGVAR(availGasmaskList),[]])) then {_playerhasGasmask = true} } forEach _playerarr;
 
 private _patientarr = _patient call ACEFUNC(common,uniqueItems);
 private _patienthasGasmask = false;
-{ if(_x in GVAR(availGasmaskList)) then {_patienthasGasmask = true} } forEach _patientarr;
+{ if(_x in (missionNamespace getVariable [QGVAR(availGasmaskList),[]])) then {_patienthasGasmask = true} } forEach _patientarr;
 
 if (!_playerhasGasmask && !_patienthasGasmask) then { false } else { true }

--- a/addons/chemical/functions/fnc_hasGasmask.sqf
+++ b/addons/chemical/functions/fnc_hasGasmask.sqf
@@ -20,10 +20,10 @@ params [["_player", objNull, [objNull]],["_patient", objNull, [objNull]]];
 
 private _playerarr = _player call ACEFUNC(common,uniqueItems);
 private _playerhasGasmask = false;
-{ if(_x in (missionNamespace getVariable [QGVAR(availGasmaskList),[]])) then {_playerhasGasmask = true} } forEach _playerarr;
+{ if(_x in (missionNamespace getVariable [QGVAR(availGasmaskList), []])) then {_playerhasGasmask = true} } forEach _playerarr;
 
 private _patientarr = _patient call ACEFUNC(common,uniqueItems);
 private _patienthasGasmask = false;
-{ if(_x in (missionNamespace getVariable [QGVAR(availGasmaskList),[]])) then {_patienthasGasmask = true} } forEach _patientarr;
+{ if(_x in (missionNamespace getVariable [QGVAR(availGasmaskList), []])) then {_patienthasGasmask = true} } forEach _patientarr;
 
 if (!_playerhasGasmask && !_patienthasGasmask) then { false } else { true }

--- a/addons/chemical/functions/fnc_init.sqf
+++ b/addons/chemical/functions/fnc_init.sqf
@@ -17,10 +17,6 @@ params ["_unit", ["_isRespawn", true]];
 
 if (!local _unit) exitWith {};
 
-private _items = missionNamespace getVariable [QGVAR(availGasmask), """G_AirPurifyingRespirator_01_F"""];
-private _item_arr = [_items, "CfgGlasses"] call FUNC(getList);
-GVAR(availGasmaskList) = _item_arr;
-
 if (hasinterface) then {
     [_unit] call FUNC(coughing);
     [_unit] call FUNC(handleGasMaskDur);


### PR DESCRIPTION
**When merged this pull request will:**
- Properly hide gas mask related actions when the unit doesn't have one

### IMPORTANT

- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
