### PR TITLE
Breathing - Add setting to set what locations provide oxygen

### DIFF
--- a/addons/breathing/ACE_Medical_Treatment_Actions.hpp
+++ b/addons/breathing/ACE_Medical_Treatment_Actions.hpp
@@ -236,7 +236,7 @@ class ACE_Medical_Treatment_Actions {
         displayNameProgress = CSTRING(UseBVM_PortableOxygen_Progress);
         medicRequired = QGVAR(medLvl_BVM_Oxygen);
         items[] = {"kat_BVM"};
-        condition = QUOTE(_patient call FUNC(canUseBVM) && _medic call FUNC(hasOxygenTank) && !(_patient call ACEFUNC(medical_treatment,isInMedicalFacility) || _patient call ACEFUNC(medical_treatment,isInMedicalVehicle)));
+        condition = QUOTE(_patient call FUNC(canUseBVM) && _medic call FUNC(hasOxygenTank) && (GVAR(locationProvideOxygen) isEqualTo 0 || !((GVAR(locationProvideOxygen) in [ARR_2(2,3)] && _patient call ACEFUNC(medical_treatment,isInMedicalFacility)) || ((GVAR(locationProvideOxygen) in [ARR_2(1,3)] && _patient call ACEFUNC(medical_treatment,isInMedicalVehicle))))));
         callbackStart = QUOTE([ARR_5(_medic, _patient, false, true, true)] call FUNC(useBVM));
         callbackSuccess = QUOTE(_patient setVariable [ARR_3(QQGVAR(BVMInUse), false, true)]);
         callbackFailure = QUOTE(_patient setVariable [ARR_3(QQGVAR(BVMInUse), false, true)]);
@@ -246,7 +246,7 @@ class ACE_Medical_Treatment_Actions {
         displayNameProgress = CSTRING(UseBVM_Oxygen_Progress);
         medicRequired = QGVAR(medLvl_BVM_Oxygen);
         items[] = {"kat_BVM"};
-        condition = QUOTE(_patient call FUNC(canUseBVM) && (_patient call ACEFUNC(medical_treatment,isInMedicalFacility) || _patient call ACEFUNC(medical_treatment,isInMedicalVehicle)));
+        condition = QUOTE(_patient call FUNC(canUseBVM) && ((GVAR(locationProvideOxygen) in [ARR_2(2,3)] && _patient call ACEFUNC(medical_treatment,isInMedicalFacility)) || (GVAR(locationProvideOxygen) in [ARR_2(1,3)] && _patient call ACEFUNC(medical_treatment,isInMedicalVehicle))));
         callbackStart = QUOTE([ARR_4(_medic, _patient, false, true)] call FUNC(useBVM));
         callbackSuccess = QUOTE(_patient setVariable [ARR_3(QQGVAR(BVMInUse), false, true)]);
         callbackFailure = QUOTE(_patient setVariable [ARR_3(QQGVAR(BVMInUse), false, true)]);

--- a/addons/breathing/CfgVehicles.hpp
+++ b/addons/breathing/CfgVehicles.hpp
@@ -98,7 +98,7 @@ class CfgVehicles {
                 };
                 class Refill_OxygenTank_150_Facility {
                     displayName = CSTRING(RefillPortableOxygenTank_150);
-                    condition = QUOTE('kat_oxygenTank_150_Empty' in (items _player) && _player call ACEFUNC(medical_treatment,isInMedicalFacility));
+                    condition = QUOTE((GVAR(locationProvideOxygen) in [ARR_2(2,3)]) && 'kat_oxygenTank_150_Empty' in (items _player) && _player call ACEFUNC(medical_treatment,isInMedicalFacility));
                     statement = QUOTE([ARR_3(_player,'kat_oxygenTank_150', GVAR(PortableOxygenTank_RefillTime))] call FUNC(refillOxygenTank));
                     showDisabled = 0;
                     exceptions[] = 
@@ -114,7 +114,7 @@ class CfgVehicles {
                 };
                 class Refill_OxygenTank_300_Facility: Refill_OxygenTank_150_Facility {
                     displayName = CSTRING(RefillPortableOxygenTank_300);
-                    condition = QUOTE('kat_oxygenTank_300_Empty' in (items _player) && _player call ACEFUNC(medical_treatment,isInMedicalFacility));
+                    condition = QUOTE((GVAR(locationProvideOxygen) in [ARR_2(2,3)]) && 'kat_oxygenTank_300_Empty' in (items _player) && _player call ACEFUNC(medical_treatment,isInMedicalFacility));
                     statement = QUOTE([ARR_3(_player,'kat_oxygenTank_300', GVAR(PortableOxygenTank_RefillTime)*2)] call FUNC(refillOxygenTank));
                 };
             };
@@ -128,6 +128,7 @@ class CfgVehicles {
                 class RefillActionsVehicle {
                     displayName = CSTRING(RefillPortableOxygenTanks);
                     icon = QPATHTOF(ui\oxygenTank_ui.paa);
+                    condition = QUOTE(GVAR(locationProvideOxygen) in [ARR_2(1,3)]);
                     class Refill_OxygenTank_150_Vehicle {
                         displayName = CSTRING(RefillPortableOxygenTank_150);
                         condition = QUOTE('kat_oxygenTank_150_Empty' in (items _player) && _target call ACEFUNC(medical_treatment,isMedicalVehicle));

--- a/addons/breathing/XEH_preInit.sqf
+++ b/addons/breathing/XEH_preInit.sqf
@@ -433,4 +433,14 @@ PREP_RECOMPILE_END;
     true
 ] call CBA_settings_fnc_init;
 
+// Sets whether medical facilites and/or vehicles provide direct oxygen and refill capability 
+[
+    QGVAR(locationProvideOxygen),
+    "LIST",
+    [LLSTRING(SETTING_locationProvideOxygen), LLSTRING(SETTING_locationProvideOxygen_DESC)],
+    [CBA_SETTINGS_CAT, LSTRING(SubCategory_Items)],
+    [[0, 1, 2, 3], ["STR_ACE_Common_None", "STR_ACE_Common_Vehicle", "STR_ACE_Medical_Treatment_MedicalFacilities", "STR_ACE_Medical_Treatment_VehiclesAndFacilities"], 3],
+    true
+] call CBA_settings_fnc_init;
+
 ADDON = true;

--- a/addons/breathing/stringtable.xml
+++ b/addons/breathing/stringtable.xml
@@ -1813,5 +1813,11 @@
             <German>Definiere den 300L Sauerstofftank als bevorzugte Variante</German>
             <Czech>Nastavit přenosnou Kyslíkovou Lahev (300L) jako preferovanou</Czech>
         </Key>
+        <Key ID="STR_KAT_Breathing_SETTING_locationProvideOxygen">
+            <English>Location Provide Oxygen</English>
+        </Key>
+        <Key ID="STR_KAT_Breathing_SETTING_locationProvideOxygen_DESC">
+            <English>Sets if medical vehicles/facilites can provide oxygen</English>
+        </Key>
     </Package>
 </Project>


### PR DESCRIPTION
**When merged this pull request will:**
- Add new setting to set whether medical vehicles/facilities can provide oxygen
![image](https://github.com/KAT-Advanced-Medical/KAM/assets/15182031/6f92c0f8-4d5f-4bed-9867-e09b5cc26b7d)

### IMPORTANT

- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
