### PR TITLE
Chemical - Fix GasMaks selfinteractions are now displayed

### DIFF
--- a/addons/chemical/XEH_postInit.sqf
+++ b/addons/chemical/XEH_postInit.sqf
@@ -27,5 +27,6 @@ ppBlur_priority = 399;
     ppBluring = false;
 }] call CBA_fnc_waitUntilAndExecute;
 
-private _items = missionNamespace getVariable [QGVAR(availGasmask), "G_AirPurifyingRespirator_01_F"];
-missionNamespace setVariable [QGVAR(availGasmaskList), _items splitString ",", true];
+private _items = missionNamespace getVariable [QGVAR(availGasmask), "'G_AirPurifyingRespirator_01_F'"];
+private _array = [_items, "CfgGlasses"] call FUNC(getList);
+missionNamespace setVariable [QGVAR(availGasmaskList), _array, true];

--- a/addons/chemical/XEH_preInit.sqf
+++ b/addons/chemical/XEH_preInit.sqf
@@ -13,10 +13,11 @@ PREP_RECOMPILE_END;
     "EDITBOX",
     [LLSTRING(SETTING_AVAIL_GASMASK), LLSTRING(SETTING_AVAIL_GASMASK_DISC)],
     CBA_SETTINGS_CHEM,
-    "G_AirPurifyingRespirator_01_F",
+    "'G_AirPurifyingRespirator_01_F'",
     1,
     {
-        missionNamespace setVariable [QGVAR(availGasmaskList), _this splitString ",", true];
+        private _array = [_this, "CfgGlasses"] call FUNC(getList);
+        missionNamespace setVariable [QGVAR(availGasmaskList), _array, true];
     },
     true
 ] call CBA_Settings_fnc_init;


### PR DESCRIPTION
**When merged this pull request will:**
Fix the self interactions for gas masks to be displayed correctly again

### IMPORTANT

- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
