### PR TITLE
Surgery - Add Additional Settings to Allow Patient to Remain Awake During Surgeries

### DIFF
--- a/addons/surgery/XEH_preInit.sqf
+++ b/addons/surgery/XEH_preInit.sqf
@@ -176,7 +176,7 @@ PREP_RECOMPILE_END;
 [
     QGVAR(unconSurgery_requieredForAction),
     "LIST",
-    LLSTRING(unconSurgery_requieredForAction),
+    [LLSTRING(unconSurgery_requieredForAction), LLSTRING(unconSurgery_requieredForAction_DESC)],
     [CBA_SETTINGS_CAT, LSTRING(SubCategory_SurgicalActions)],
     [[0, 1, 2, 3], ["STR_KAT_Surgery_Causes_Unconsciouness", "STR_KAT_Surgery_Unconsciouness_Required", "STR_KAT_Surgery_No_Unconsciouness", "STR_KAT_Surgery_Surgery_Anesthesia"], 1],
     true

--- a/addons/surgery/XEH_preInit.sqf
+++ b/addons/surgery/XEH_preInit.sqf
@@ -169,16 +169,17 @@ PREP_RECOMPILE_END;
     [[0,1,2,3],["STR_ACE_Common_Anywhere", "STR_ACE_Common_Vehicle", "STR_ACE_Medical_Treatment_MedicalFacilities", "STR_ACE_Medical_Treatment_VehiclesAndFacilities"],3],
     true
 ] call CBA_Settings_fnc_init;
-//0Surgery Causes Unconsciouness: If you do an insision you will be knocked Unconsciouness from a CA
-//1Unconsciouness Required for Surgery: Pationt must be Unconsciouness to do Surgery
-//2No Unconsciouness from Surgery: They will not be knocked Unconsciouness when an insision in performed
-//3Surgery Anesthesia: The patient is able to stay awake through the entirety of the surgery. If Etomidate has not been applied, then the patient will lose consciousness.
+
+// 0 Surgery Causes Unconsciousness: If you do an incision (without anesthesia & sedative) patient will go into CA
+// 1 Unconsciousness Required for Surgery: Surgery fails unless patient is unconscious, needs anesthesia
+// 2 No Unconsciousness from Surgery: Patient can stay awake without anesthesia, causes pain
+// 3 Surgery Anesthesia: The patient is able to stay awake through the entirety of the surgery. If Etomidate has not been applied, then the patient will lose consciousness.
 [
-    QGVAR(unconSurgery_requieredForAction),
+    QGVAR(Surgery_ConsciousnessRequirement),
     "LIST",
-    [LLSTRING(unconSurgery_requieredForAction), LLSTRING(unconSurgery_requieredForAction_DESC)],
+    [LLSTRING(SETTING_ConsciousnessRequirement), LLSTRING(SETTING_ConsciousnessRequirement_DESC)],
     [CBA_SETTINGS_CAT, LSTRING(SubCategory_SurgicalActions)],
-    [[0, 1, 2, 3], ["STR_KAT_Surgery_Causes_Unconsciouness", "STR_KAT_Surgery_Unconsciouness_Required", "STR_KAT_Surgery_No_Unconsciouness", "STR_KAT_Surgery_Surgery_Anesthesia"], 1],
+    [[0, 1, 2, 3], [LLSTRING(SETTING_Causes_Unconsciousness), LLSTRING(SETTING_Unconsciousness_Required), LLSTRING(SETTING_No_Unconsciousness), LLSTRING(SETTING_Anesthesia)], 1],
     true
 ] call CBA_Settings_fnc_init;
 

--- a/addons/surgery/XEH_preInit.sqf
+++ b/addons/surgery/XEH_preInit.sqf
@@ -169,13 +169,16 @@ PREP_RECOMPILE_END;
     [[0,1,2,3],["STR_ACE_Common_Anywhere", "STR_ACE_Common_Vehicle", "STR_ACE_Medical_Treatment_MedicalFacilities", "STR_ACE_Medical_Treatment_VehiclesAndFacilities"],3],
     true
 ] call CBA_Settings_fnc_init;
-
+//0Surgery Causes Unconsciouness: If you do an insision you will be knocked Unconsciouness from a CA
+//1Unconsciouness Required for Surgery: Pationt must be Unconsciouness to do Surgery
+//2No Unconsciouness from Surgery: They will not be knocked Unconsciouness when an insision in performed
+//3Surgery Anesthesia: The patient is able to stay awake through the entirety of the surgery. If Etomidate has not been applied, then the patient will lose consciousness.
 [
-    QGVAR(uncon_requieredForAction),
-    "CHECKBOX",
-    [LLSTRING(uncon_requieredForActions), LLSTRING(uncon_requieredForActions_DESC)],
+    QGVAR(unconSurgery_requieredForAction),
+    "LIST",
+    LLSTRING(unconSurgery_requieredForAction),
     [CBA_SETTINGS_CAT, LSTRING(SubCategory_SurgicalActions)],
-    [false],
+    [[0, 1, 2, 3], ["STR_KAT_Surgery_Causes_Unconsciouness", "STR_KAT_Surgery_Unconsciouness_Required", "STR_KAT_Surgery_No_Unconsciouness", "STR_KAT_Surgery_Surgery_Anesthesia"], 1],
     true
 ] call CBA_Settings_fnc_init;
 

--- a/addons/surgery/functions/fnc_incisionLocal.sqf
+++ b/addons/surgery/functions/fnc_incisionLocal.sqf
@@ -53,7 +53,7 @@ _patient setVariable [QGVAR(fractures), _fractureArray, true];
     
     if ((GVAR(Surgery_ConsciousnessRequirement) == 0 && !(IS_UNCONSCIOUS(_patient)) && _count == 0) || (GVAR(Surgery_ConsciousnessRequirement) == 3 && _count == 0)) exitWith {
         [_patient, "Pain", 10, 40, 200, 0, 40] call ACEFUNC(medical_status,addMedicationAdjustment);
-        [_target, true] call ACEFUNC(medical,setUnconscious);
+        [_patient, true] call ACEFUNC(medical,setUnconscious);
     };
     
     if (GVAR(Surgery_ConsciousnessRequirement) == 2 && _count == 0) then {

--- a/addons/surgery/functions/fnc_incisionLocal.sqf
+++ b/addons/surgery/functions/fnc_incisionLocal.sqf
@@ -19,11 +19,9 @@
 
 params ["_medic", "_patient", "_bodyPart"];
 
-if (GVAR(unconSurgery_requieredForAction) == 1) then {
-    if !(IS_UNCONSCIOUS(_patient)) exitWith {
-        private _output = LLSTRING(fracture_fail);
-        [_output, 1.5, _medic] call ACEFUNC(common,displayTextStructured);
-    };
+if (GVAR(unconSurgery_requieredForAction) == 1 && !(IS_UNCONSCIOUS(_patient))) exitWith {
+    private _output = LLSTRING(fracture_fail);
+    [_output, 1.5, _medic] call ACEFUNC(common,displayTextStructured);
 };
 
 
@@ -72,7 +70,7 @@ _patient setVariable [QGVAR(fractures), _fractureArray, true];
             [_target, true] call ACEFUNC(medical,setUnconscious);
         };
     };
-    
+
     if ((GVAR(unconSurgery_requieredForAction) == 0 && !(IS_UNCONSCIOUS(_patient)) && _count == 0) || (GVAR(unconSurgery_requieredForAction) == 3 && _count == 0)) exitWith {
         [_patient, "Pain", 10, 40, 200, 0, 40] call ACEFUNC(medical_status,addMedicationAdjustment);
         [_target, true] call ACEFUNC(medical,setUnconscious);

--- a/addons/surgery/functions/fnc_incisionLocal.sqf
+++ b/addons/surgery/functions/fnc_incisionLocal.sqf
@@ -19,11 +19,10 @@
 
 params ["_medic", "_patient", "_bodyPart"];
 
-if (GVAR(unconSurgery_requieredForAction) == 1 && !(IS_UNCONSCIOUS(_patient))) exitWith {
+if (GVAR(Surgery_ConsciousnessRequirement) == 1 && !(IS_UNCONSCIOUS(_patient))) exitWith {
     private _output = LLSTRING(fracture_fail);
     [_output, 1.5, _medic] call ACEFUNC(common,displayTextStructured);
 };
-
 
 private _part = ALL_BODY_PARTS find toLower _bodyPart;
 private _fractureArray = _patient getVariable [QGVAR(fractures), [0,0,0,0,0,0]];
@@ -52,12 +51,12 @@ _patient setVariable [QGVAR(fractures), _fractureArray, true];
         [_idPFH] call CBA_fnc_removePerFrameHandler;
     };
     
-    if ((GVAR(unconSurgery_requieredForAction) == 0 && !(IS_UNCONSCIOUS(_patient)) && _count == 0) || (GVAR(unconSurgery_requieredForAction) == 3 && _count == 0)) exitWith {
+    if ((GVAR(Surgery_ConsciousnessRequirement) == 0 && !(IS_UNCONSCIOUS(_patient)) && _count == 0) || (GVAR(Surgery_ConsciousnessRequirement) == 3 && _count == 0)) exitWith {
         [_patient, "Pain", 10, 40, 200, 0, 40] call ACEFUNC(medical_status,addMedicationAdjustment);
         [_target, true] call ACEFUNC(medical,setUnconscious);
     };
     
-    if (GVAR(unconSurgery_requieredForAction) == 2 && _count == 0) then {
+    if (GVAR(Surgery_ConsciousnessRequirement) == 2 && _count == 0) then {
         [_patient, 0.4] call ACEFUNC(medical_status,adjustPainLevel);
         [_patient, "Pain", 10, 40, 30, 0, 40] call ACEFUNC(medical_status,addMedicationAdjustment);
     };

--- a/addons/surgery/functions/fnc_incisionLocal.sqf
+++ b/addons/surgery/functions/fnc_incisionLocal.sqf
@@ -73,4 +73,13 @@ _patient setVariable [QGVAR(fractures), _fractureArray, true];
         };
     };
     
+    if ((GVAR(unconSurgery_requieredForAction) == 0 && !(IS_UNCONSCIOUS(_patient)) && _count == 0) || (GVAR(unconSurgery_requieredForAction) == 3 && _count == 0)) exitWith {
+        [_patient, "Pain", 10, 40, 200, 0, 40] call ACEFUNC(medical_status,addMedicationAdjustment);
+        [_target, true] call ACEFUNC(medical,setUnconscious);
+    };
+    if (GVAR(unconSurgery_requieredForAction) == 2 && _count == 0) then {
+        [_patient, 0.4] call ACEFUNC(medical_status,adjustPainLevel);
+        [_patient, "Pain", 10, 40, 30, 0, 40] call ACEFUNC(medical_status,addMedicationAdjustment);
+    };
+    
 }, GVAR(etomidateTime), [_patient, _part]] call CBA_fnc_addPerFrameHandler;

--- a/addons/surgery/functions/fnc_incisionLocal.sqf
+++ b/addons/surgery/functions/fnc_incisionLocal.sqf
@@ -53,28 +53,24 @@ _patient setVariable [QGVAR(fractures), _fractureArray, true];
     if ((!_alive) || (_liveFracture == 0)) exitWith {
         [_idPFH] call CBA_fnc_removePerFrameHandler;
     };
-
-    //Check if unconSurgery_requiredForAction is set to "No Unconsciousness", and if so, 
-    //exit with minor pain and a slightly high heart rate. Skip this if the setting is not "No Unconsciousness".
-    if (GVAR(unconSurgery_requieredForAction) == 2) exitWith {
-        [_patient, 0.4] call ACEFUNC(medical_status,adjustPainLevel);
-        [_patient, "Pain", 10, 40, 30, 0, 40] call ACEFUNC(medical_status,addMedicationAdjustment);
+    switch (true) do
+    {
+        case (GVAR(unconSurgery_requieredForAction) == 2): 
+        {
+            [_patient, 0.4] call ACEFUNC(medical_status,adjustPainLevel);
+            [_patient, "Pain", 10, 40, 30, 0, 40] call ACEFUNC(medical_status,addMedicationAdjustment);
+        };
+        case (GVAR(unconSurgery_requieredForAction) == 3 && _count == 0): 
+        {
+            [_patient, "Pain", 10, 40, 200, 0, 40] call ACEFUNC(medical_status,addMedicationAdjustment);
+            [_target, true] call ACEFUNC(medical,setUnconscious);
+        };
+        case (GVAR(unconSurgery_requieredForAction) == 3): {};
+        case ((_count == 0 || !(IS_UNCONSCIOUS(_patient))) && (GVAR(unconSurgery_requieredForAction) == 0)): 
+        {
+            [_patient, "Pain", 10, 40, 200, 0, 40] call ACEFUNC(medical_status,addMedicationAdjustment);
+            [_target, true] call ACEFUNC(medical,setUnconscious);
+        };
     };
-
-    // Check if unconSurgery_requiredForAction is set to "Surgery Anesthesia" and no Etomidate is in the patient's system. 
-    //It will then exit with an added heart rate of 200 to the patient, forcing them unconscious. This is skipped if Etomidate 
-    //is in the system, and the setting is not "Surgery Anesthesia".
-    if (GVAR(unconSurgery_requieredForAction) == 3 && _count == 0) exitWith {
-        [_patient, "Pain", 10, 40, 200, 0, 40] call ACEFUNC(medical_status,addMedicationAdjustment);
-        [_target, true] call ACEFUNC(medical,setUnconscious);
-    };
-
-    //If unconSurgery_requiredForAction is set to "Unconsciousness Required", continue with the normal process, 
-    //which adds 200 beats per minute to the patient's heart rate and forces them unconscious if Patient is not sedated and unconscious. 
-    if (_count == 0 || !(IS_UNCONSCIOUS(_patient))) then {
-        [_patient, "Pain", 10, 40, 200, 0, 40] call ACEFUNC(medical_status,addMedicationAdjustment);
-        [_target, true] call ACEFUNC(medical,setUnconscious);
-    };
-
     
 }, GVAR(etomidateTime), [_patient, _part]] call CBA_fnc_addPerFrameHandler;

--- a/addons/surgery/functions/fnc_incisionLocal.sqf
+++ b/addons/surgery/functions/fnc_incisionLocal.sqf
@@ -51,30 +51,12 @@ _patient setVariable [QGVAR(fractures), _fractureArray, true];
     if ((!_alive) || (_liveFracture == 0)) exitWith {
         [_idPFH] call CBA_fnc_removePerFrameHandler;
     };
-    switch (true) do
-    {
-        case (GVAR(unconSurgery_requieredForAction) == 2): 
-        {
-            [_patient, 0.4] call ACEFUNC(medical_status,adjustPainLevel);
-            [_patient, "Pain", 10, 40, 30, 0, 40] call ACEFUNC(medical_status,addMedicationAdjustment);
-        };
-        case (GVAR(unconSurgery_requieredForAction) == 3 && _count == 0): 
-        {
-            [_patient, "Pain", 10, 40, 200, 0, 40] call ACEFUNC(medical_status,addMedicationAdjustment);
-            [_target, true] call ACEFUNC(medical,setUnconscious);
-        };
-        case (GVAR(unconSurgery_requieredForAction) == 3): {};
-        case ((_count == 0 || !(IS_UNCONSCIOUS(_patient))) && (GVAR(unconSurgery_requieredForAction) == 0)): 
-        {
-            [_patient, "Pain", 10, 40, 200, 0, 40] call ACEFUNC(medical_status,addMedicationAdjustment);
-            [_target, true] call ACEFUNC(medical,setUnconscious);
-        };
-    };
-
+    
     if ((GVAR(unconSurgery_requieredForAction) == 0 && !(IS_UNCONSCIOUS(_patient)) && _count == 0) || (GVAR(unconSurgery_requieredForAction) == 3 && _count == 0)) exitWith {
         [_patient, "Pain", 10, 40, 200, 0, 40] call ACEFUNC(medical_status,addMedicationAdjustment);
         [_target, true] call ACEFUNC(medical,setUnconscious);
     };
+    
     if (GVAR(unconSurgery_requieredForAction) == 2 && _count == 0) then {
         [_patient, 0.4] call ACEFUNC(medical_status,adjustPainLevel);
         [_patient, "Pain", 10, 40, 30, 0, 40] call ACEFUNC(medical_status,addMedicationAdjustment);

--- a/addons/surgery/functions/fnc_openReductionLocal.sqf
+++ b/addons/surgery/functions/fnc_openReductionLocal.sqf
@@ -42,4 +42,3 @@ if ((_liveFracture == 2.5) || (_liveFracture == 3.5)) exitWith {
 
 private _output = LLSTRING(fracture_fail);
 [_output, 1.5, _medic] call ACEFUNC(common,displayTextStructured);
-

--- a/addons/surgery/functions/fnc_openReductionProgressLocal.sqf
+++ b/addons/surgery/functions/fnc_openReductionProgressLocal.sqf
@@ -20,11 +20,9 @@
 
 params ["_medic", "_patient", "_bodyPart", "_entry"];
 
-if (GVAR(unconSurgery_requieredForAction == 1)) then {
-    if !(IS_UNCONSCIOUS(_patient)) exitWith {
-        private _output = LLSTRING(fracture_fail);
-        [_output, 1.5, _medic] call ACEFUNC(common,displayTextStructured);
-    };
+if (GVAR(unconSurgery_requieredForAction) == 1 && !(IS_UNCONSCIOUS(_patient))) exitWith {
+    private _output = LLSTRING(fracture_fail);
+    [_output, 1.5, _medic] call ACEFUNC(common,displayTextStructured);
 };
 
 private _part = ALL_BODY_PARTS find toLower _bodyPart;

--- a/addons/surgery/functions/fnc_openReductionProgressLocal.sqf
+++ b/addons/surgery/functions/fnc_openReductionProgressLocal.sqf
@@ -20,7 +20,7 @@
 
 params ["_medic", "_patient", "_bodyPart", "_entry"];
 
-if (GVAR(uncon_requieredForAction)) then {
+if (GVAR(unconSurgery_requieredForAction == 1)) then {
     if !(IS_UNCONSCIOUS(_patient)) exitWith {
         private _output = LLSTRING(fracture_fail);
         [_output, 1.5, _medic] call ACEFUNC(common,displayTextStructured);

--- a/addons/surgery/functions/fnc_openReductionProgressLocal.sqf
+++ b/addons/surgery/functions/fnc_openReductionProgressLocal.sqf
@@ -20,7 +20,7 @@
 
 params ["_medic", "_patient", "_bodyPart", "_entry"];
 
-if (GVAR(unconSurgery_requieredForAction) == 1 && !(IS_UNCONSCIOUS(_patient))) exitWith {
+if (GVAR(Surgery_ConsciousnessRequirement) == 1 && !(IS_UNCONSCIOUS(_patient))) exitWith {
     private _output = LLSTRING(fracture_fail);
     [_output, 1.5, _medic] call ACEFUNC(common,displayTextStructured);
 };

--- a/addons/surgery/stringtable.xml
+++ b/addons/surgery/stringtable.xml
@@ -1091,7 +1091,6 @@
         <Key ID="STR_KAT_Surgery_No_Unconsciouness">
             <English>No Unconsciouness from Surgery</English>
         </Key>
-        </Key>
         <Key ID="STR_KAT_Surgery_Surgery_Anesthesia">
             <English>Surgery Anesthesia</English>
         </Key>

--- a/addons/surgery/stringtable.xml
+++ b/addons/surgery/stringtable.xml
@@ -1079,24 +1079,23 @@
             <Portuguese>[KAM] Caixa cirúrgica</Portuguese>
             <Spanish>[KAM] Caja quirurgica</Spanish>
         </Key>
-        <Key ID="STR_KAT_Surgery_unconSurgery_requieredForAction">
+        <Key ID="STR_KAT_Surgery_SETTING_ConsciousnessRequirement">
             <English>Surgery Consciousness Controls</English>
         </Key>
-        <Key ID="STR_KAT_Surgery_Causes_Unconsciouness">
-            <English>Surgery Causes Unconsciouness</English>
+        <Key ID="STR_KAT_Surgery_SETTING_ConsciousnessRequirement_DESC">
+            <English>Surgery Causes Unconsciousness: Surgery without anesthesia and sedation results in unconsciousness from CA. &#10;Unconsciousness Required for Surgery: Surgery requires patient to be unconscious. &#10;No Unconsciousness from Surgery: Surgery doesn't induce unconsciousness, causes pain. &#10;Surgery Anesthesia: Patient stays awake during surgery if given Etomidate.</English>
         </Key>
-        <Key ID="STR_KAT_Surgery_Unconsciouness_Required">
-            <English>Unconsciouness Required for Surgery</English>
+        <Key ID="STR_KAT_Surgery_SETTING_Causes_Unconsciousness">
+            <English>Surgery Causes Unconsciousness</English>
         </Key>
-        <Key ID="STR_KAT_Surgery_No_Unconsciouness">
-            <English>No Unconsciouness from Surgery</English>
+        <Key ID="STR_KAT_Surgery_SETTING_Unconsciousness_Required">
+            <English>Unconsciousness Required for Surgery</English>
         </Key>
-        <Key ID="STR_KAT_Surgery_Surgery_Anesthesia">
+        <Key ID="STR_KAT_Surgery_SETTING_No_Unconsciousness">
+            <English>No Unconsciousness from Surgery</English>
+        </Key>
+        <Key ID="STR_KAT_Surgery_SETTING_Anesthesia">
             <English>Surgery Anesthesia</English>
         </Key>
-        <Key ID="STR_KAT_Surgery_unconSurgery_requieredForAction_DESC">
-            <English>Surgery Causes Unconsciousness: Surgery results in unconsciousness from a CA. &#10;Unconsciousness Required for Surgery: Surgery requires patient unconsciousness. &#10;No Unconsciousness from Surgery: Surgery doesn't induce unconsciousness. &#10;Surgery Anesthesia: Patient stays awake during surgery if given Etomidate.</English>
-        </Key>
-        
     </Package>
 </Project>

--- a/addons/surgery/stringtable.xml
+++ b/addons/surgery/stringtable.xml
@@ -1094,5 +1094,9 @@
         <Key ID="STR_KAT_Surgery_Surgery_Anesthesia">
             <English>Surgery Anesthesia</English>
         </Key>
+        <Key ID="STR_KAT_Surgery_unconSurgery_requieredForAction_DESC">
+            <English>Surgery Causes Unconsciousness: Surgery results in unconsciousness from a CA. &#10;Unconsciousness Required for Surgery: Surgery requires patient unconsciousness. &#10;No Unconsciousness from Surgery: Surgery doesn't induce unconsciousness. &#10;Surgery Anesthesia: Patient stays awake during surgery if given Etomidate.</English>
+        </Key>
+        
     </Package>
 </Project>

--- a/addons/surgery/stringtable.xml
+++ b/addons/surgery/stringtable.xml
@@ -971,32 +971,6 @@
             <Spanish>Fractura Simple</Spanish>
             <Portuguese>Fratura simples</Portuguese>
         </Key>
-        <Key ID="STR_KAT_Surgery_uncon_requieredForActions">
-            <English>Unconsciouness Requierement</English>
-            <Chinesesimp>要求无意识</Chinesesimp>
-            <Italian>Requisito di incoscienza</Italian>
-            <Polish>Nieprzytomność wymagana</Polish>
-            <Czech>Vyžadování bezvědomí</Czech>
-            <French>Inconscience requise</French>
-            <Korean>의식불명 요구</Korean>
-            <German>Bewusstlosigkeit vorausgesetzt</German>
-            <Japanese>無意識状態の要求</Japanese>
-            <Spanish>Requiere inconsciencia</Spanish>
-            <Portuguese>Requer inconsciência</Portuguese>
-        </Key>
-        <Key ID="STR_KAT_Surgery_uncon_requieredForActions_DESC">
-            <English>Whether or not is unconsciousness requiered to perform some surgery actions</English>
-            <Chinesesimp>进行某些手术动作是否需要无意识</Chinesesimp>
-            <Italian>Decidere se l'incoscienza sia richiesta o meno per eseguire alcune azioni chirurgiche</Italian>
-            <Polish>Czy nieprzytomność jest wymagana do przeprowadzenia niektórych akcji chirurgicznych</Polish>
-            <Czech>Zda je či není vyžadováno bezvědomí, aby bylo možno provést některé chirurgické akce</Czech>
-            <French>Définie si l'inconscience est nécessaire ou non pour effectuer des actions chirurgicales</French>
-            <Korean>일부 수술 조치를 수행하기 위해 의식불명이 필요한 지 여부</Korean>
-            <German>Ist Bewusstlosigkeit für die Durchführung bestimmter chirurgischer Eingriffe erforderlich</German>
-            <Japanese>いくつかの手術行為を行うために無意識状態が必要かどうか</Japanese>
-            <Spanish>Si se necesita o no que el paciente esté inconsciente para realizar acciones quirúrgicas</Spanish>
-            <Portuguese>Se a inconsciência é ou não necessária para realizar algumas ações cirúrgicas</Portuguese>
-        </Key>
         <Key ID="STR_KAT_Surgery_SETTING_DebrideTime">
             <English>Debride Patient Time</English>
             <Chinesesimp>进行伤口清创的时间</Chinesesimp>
@@ -1104,6 +1078,22 @@
             <Korean>[KAM] 수술도구 상자</Korean>
             <Portuguese>[KAM] Caixa cirúrgica</Portuguese>
             <Spanish>[KAM] Caja quirurgica</Spanish>
+        </Key>
+        <Key ID="STR_KAT_Surgery_unconSurgery_requieredForAction">
+            <English>Surgery Consciousness Controls</English>
+        </Key>
+        <Key ID="STR_KAT_Surgery_Causes_Unconsciouness">
+            <English>Surgery Causes Unconsciouness</English>
+        </Key>
+        <Key ID="STR_KAT_Surgery_Unconsciouness_Required">
+            <English>Unconsciouness Required for Surgery</English>
+        </Key>
+        <Key ID="STR_KAT_Surgery_No_Unconsciouness">
+            <English>No Unconsciouness from Surgery</English>
+        </Key>
+        </Key>
+        <Key ID="STR_KAT_Surgery_Surgery_Anesthesia">
+            <English>Surgery Anesthesia</English>
         </Key>
     </Package>
 </Project>


### PR DESCRIPTION
**When merged this pull request will:**

- Added 1 Dropdown Setting with 4 options In the Surgery category.(In XEH_preInit)
  - Option 1 Surgery Causes Unconsciousness: An incision causes cardiac arrest if the patient is not unconscious and sedated(With Etomidate). Uses a Switch Statement in fnc_incisionLocal.sqf 
    - Checks if the patient Has Etomidate and if they are in an unconscious state. 
  - Option 2 Unconsciousness Required for Surgery: Surgery can only begin if the patient is unconscious and sedated(With Etomidate).
    - Changed the First if statement in fnc_incisionLocal from checking for uncon_requieredForAction to Checking for unconSurgery_requieredForAction equals 1. This statement checks to make sure the patient is unconscious and if they aren't then Surgery is aborted(This setting is the old uncon_requieredForAction, Which has been brought into the switch state due to the similarity of the job)
    - Removed Setting "uncon_requieredForAction" and the localizations for the same setting 
  - Option 3 No Unconsciousness from Surgery: The patient is able to stay awake through the entirety of the surgery, experiencing a little pain and a slight increase in heart rate (Etomidate not required). Uses a Switch Statement in fnc_incisionLocal.sqf 
    - This Case Uses the adjustPainLevel and addMedicationAdjustment, to cause pain and increase in heart rate[There is a chance this can be simplified with just the addMedicationAdjustment, but was unsure when searching for similar use cases in Code so went with 2 separate functions]
  - Option 4 Surgery Anesthesia: The patient can remain awake for the duration of the surgery. However, if Etomidate hasn't been applied, the patient will lose consciousness and go into CA. There are two cases in the switch statement in fnc_incisionLocal.sqf. 
    - The first case checks the unconSurgery_requieredForAction setting and whether there's no Etomidate in the patient's system. If so, it induces cardiac arrest by causing a heart rate increase of 200 and forces the patient into unconsciousness. 
    - The second case applies when there's Etomidate in the patient's system. In this scenario, the incision can proceed without complications, allowing the surgery to be carried out without issues.
    
- Added English Translations For All new Text Used in Settings Area


### IMPORTANT

- [x] [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
