### PR TITLE
Misc - Fix stuttering in self-interaction menu

### DIFF
--- a/addons/misc/XEH_postInit.sqf
+++ b/addons/misc/XEH_postInit.sqf
@@ -35,6 +35,10 @@ if (GVAR(incompatibilityWarning)) then {
 
 [QGVAR(headTourniquetLocal), LINKFUNC(headTourniquetLocal)] call CBA_fnc_addEventHandler;
 
+["loadout", {
+    GVAR(uniqueItemsCache) = nil;
+}] call CBA_fnc_addPlayerEventHandler;
+
 ["kat_Armband_Red_Cross_Item", "kat_armband_red_cross"] call ACEFUNC(common,registerItemReplacement);
 ["kat_Armband_Medic_Item", "kat_armband_medic"] call ACEFUNC(common,registerItemReplacement);
 ["kat_Armband_Doctor_Item", "kat_armband_doctor"] call ACEFUNC(common,registerItemReplacement);

--- a/addons/misc/functions/fnc_getUniqueItems.sqf
+++ b/addons/misc/functions/fnc_getUniqueItems.sqf
@@ -1,6 +1,6 @@
 #include "script_component.hpp"
 /*
- * Author: Blue
+ * Author: mharis001, Blue
  * Returns list of unique items in the target's inventory.
  *
  * Arguments:
@@ -19,22 +19,48 @@
 
 params ["_target", ["_isVehicle",false], ["_checkMagazine",false]];
 
-private _items = [];
+private _fnc_getItems = {
+    private _items = [];
 
-if !(_isVehicle) then {
-    if(_checkMagazine) then {
-        _items append (magazines _target);
+    if !(_isVehicle) then {
+        private _inventoryItems = [];
+
+        _inventoryItems append ((getItemCargo uniformContainer _target) select 0);
+        _inventoryItems append ((getItemCargo vestContainer _target) select 0);
+        _inventoryItems append ((getItemCargo backpackContainer _target) select 0);
+
+        _items set [0, _inventoryItems];
+        _items set [1, (magazines _target)];
     } else {
-        _items append ((getItemCargo uniformContainer _target) select 0);
-        _items append ((getItemCargo vestContainer _target) select 0);
-        _items append ((getItemCargo backpackContainer _target) select 0);
+        if (_checkMagazine) then {
+            _items append (magazineCargo _target);
+        } else {
+            _items append (itemCargo _target);
+        };
     };
-} else {
-    if (_checkMagazine) then {
-        _items append (magazineCargo _target);
-    } else {
-        _items append (itemCargo _target);
-    };
+
+    _items arrayIntersect _items
 };
 
-_items arrayIntersect _items
+// Cache items list if unit is ACE_player
+if (_target isEqualTo ACE_player) then {
+    if (isNil QGVAR(uniqueItemsCache)) then {
+        GVAR(uniqueItemsCache) = call _fnc_getItems;
+    };
+
+    if(_checkMagazine) then {
+        GVAR(uniqueItemsCache) select 1;
+    } else {
+        GVAR(uniqueItemsCache) select 0;
+    };
+} else {
+    if (_isVehicle) then {
+        call _fnc_getItems;
+    } else {
+        if(_checkMagazine) then {
+            (call _fnc_getItems) select 1;
+        } else {
+            (call _fnc_getItems) select 0;
+        };
+    };
+};

--- a/addons/misc/functions/fnc_hasItem.sqf
+++ b/addons/misc/functions/fnc_hasItem.sqf
@@ -37,4 +37,4 @@ private _fnc_checkItems = {
 
 private _vehicleCondition = (vehicle _medic) != _medic && (vehicle _medic) isEqualTo (vehicle _patient);
 
-_medic call _fnc_checkItems || {ACEGVAR(medical_treatment,allowSharedEquipment) != 2 && {_patient call _fnc_checkItems}} || {_vehicleCondition && [(vehicle _medic),true] call _fnc_checkItems && (GVAR(allowSharedVehicleEquipment) in [1,3] || (GVAR(allowSharedVehicleEquipment) isEqualTo 2 && _patient != _medic))}
+_medic call _fnc_checkItems || {ACEGVAR(medical_treatment,allowSharedEquipment) != 2 && {_patient call _fnc_checkItems}} || {_vehicleCondition && [(vehicle _medic), true] call _fnc_checkItems && (GVAR(allowSharedVehicleEquipment) in [1,3,4] || (GVAR(allowSharedVehicleEquipment) isEqualTo 2 && _patient != _medic))}


### PR DESCRIPTION
**When merged this pull request will:**
- Make getUniqueItems cache the unique items list to avoid re-generating it and fix stuttering when self-interacting.

### IMPORTANT

- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
