### PR TITLE
Misc - Fix missing localized string for distance from patient hint

### DIFF
--- a/addons/airway/functions/fnc_displayPatientInformation.sqf
+++ b/addons/airway/functions/fnc_displayPatientInformation.sqf
@@ -40,7 +40,7 @@ if (isNull _display) then {
         if (ACE_player distance _target > MAX_DISTANCE && {vehicle _target != vehicle ACE_player}) exitWith {
             [_pfhID] call CBA_fnc_removePerFrameHandler;
             QACEGVAR(medical_gui,RscPatientInfo) cutFadeOut 0.3;
-            [[QACEGVAR(medical,DistanceToFar), _target call ACEFUNC(common,getName)], 2] call ACEFUNC(common,displayTextStructured);
+            [[ACELLSTRING(medical,DistanceToFar), _target call ACEFUNC(common,getName)], 2] call ACEFUNC(common,displayTextStructured);
         };
 
         // Update body image

--- a/addons/main/script_macros.hpp
+++ b/addons/main/script_macros.hpp
@@ -70,6 +70,7 @@
 #define QACEFUNC(module,function)   QUOTE(ACEFUNC(module,function))
 
 #define ACELSTRING(module,string)   QUOTE(TRIPLES(STR,DOUBLES(ACE_PREFIX,module),string))
+#define ACELLSTRING(module,string)  localize ACELSTRING(module,string)
 #define ACECSTRING(module,string)   QUOTE(TRIPLES($STR,DOUBLES(ACE_PREFIX,module),string))
 
 // item types

--- a/addons/zeus/functions/fnc_menuPFH.sqf
+++ b/addons/zeus/functions/fnc_menuPFH.sqf
@@ -18,12 +18,12 @@
  */
 
 // Check if menu should stay open for target
-if(isNUll findDisplay 312) then {
+if(isNull findDisplay 312) then {
     if !([ACE_player, ACEGVAR(medical_gui,target), ["isNotInside", "isNotSwimming"]] call ACEFUNC(common,canInteractWith) && {[ACE_player, ACEGVAR(medical_gui,target)] call ACEFUNC(medical_gui,canOpenMenu)}) then {
         closeDialog 0;
         // Show hint if distance condition failed
         if ((ACE_player distance ACEGVAR(medical_gui,target) > ACEGVAR(medical_gui,maxDistance)) && {vehicle ACE_player != vehicle ACEGVAR(medical_gui,target)}) then {
-            [[ACECSTRING(Medical,DistanceToFar), ACEGVAR(medical_gui,target) call ACEFUNC(common,getName)], 2] call ACEFUNC(common,displayTextStructured);
+            [[ACELLSTRING(medical,DistanceToFar), ACEGVAR(medical_gui,target) call ACEFUNC(common,getName)], 2] call ACEFUNC(common,displayTextStructured);
         };
     };
 };


### PR DESCRIPTION
**When merged this pull request will:**
- Fix missing localized string in hint when too far from patient
- Close #379 


### IMPORTANT

- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.