### PR TITLE
Chemical - Fix Post process effect creation failed error on server .rpt log.

### DIFF
--- a/addons/chemical/XEH_postInit.sqf
+++ b/addons/chemical/XEH_postInit.sqf
@@ -18,16 +18,16 @@ KAT_ProjectileCache = ("([_x, 'KAT_projectile', 0] call BIS_fnc_returnConfigEntr
 ["ace_firedNonPlayer", LINKFUNC(throwGrenade)] call CBA_fnc_addEventHandler;
 
 if (hasInterface) then {
-	ppBlur_priority = 399;
-	[{
-		ppBlur_priority = ppBlur_priority + 1;
-		ppBlur = ppEffectCreate ["DynamicBlur", ppBlur_priority];
-		ppBlur != -1
-	}, {
-		ppBlur ppEffectEnable false;
-		ppBlurAmount = 0;
-		ppBluring = false;
-	}] call CBA_fnc_waitUntilAndExecute;
+    ppBlur_priority = 399;
+    [{
+        ppBlur_priority = ppBlur_priority + 1;
+        ppBlur = ppEffectCreate ["DynamicBlur", ppBlur_priority];
+        ppBlur != -1
+    }, {
+        ppBlur ppEffectEnable false;
+        ppBlurAmount = 0;
+        ppBluring = false;
+    }] call CBA_fnc_waitUntilAndExecute;
 };
 
 private _items = missionNamespace getVariable [QGVAR(availGasmask), "'G_AirPurifyingRespirator_01_F'"];

--- a/addons/chemical/XEH_postInit.sqf
+++ b/addons/chemical/XEH_postInit.sqf
@@ -17,16 +17,18 @@ KAT_ProjectileCache = ("([_x, 'KAT_projectile', 0] call BIS_fnc_returnConfigEntr
 ["ace_firedPlayerNonLocal", LINKFUNC(throwGrenade)] call CBA_fnc_addEventHandler;
 ["ace_firedNonPlayer", LINKFUNC(throwGrenade)] call CBA_fnc_addEventHandler;
 
-ppBlur_priority = 399;
-[{
-    ppBlur_priority = ppBlur_priority + 1;
-    ppBlur = ppEffectCreate ["DynamicBlur", ppBlur_priority];
-    ppBlur != -1
-}, {
-    ppBlur ppEffectEnable false;
-    ppBlurAmount = 0;
-    ppBluring = false;
-}] call CBA_fnc_waitUntilAndExecute;
+if (hasInterface) then {
+	ppBlur_priority = 399;
+	[{
+		ppBlur_priority = ppBlur_priority + 1;
+		ppBlur = ppEffectCreate ["DynamicBlur", ppBlur_priority];
+		ppBlur != -1
+	}, {
+		ppBlur ppEffectEnable false;
+		ppBlurAmount = 0;
+		ppBluring = false;
+	}] call CBA_fnc_waitUntilAndExecute;
+};
 
 private _items = missionNamespace getVariable [QGVAR(availGasmask), "'G_AirPurifyingRespirator_01_F'"];
 private _array = [_items, "CfgGlasses"] call FUNC(getList);

--- a/addons/chemical/functions/fnc_handleCSGas.sqf
+++ b/addons/chemical/functions/fnc_handleCSGas.sqf
@@ -29,13 +29,17 @@ params ["_unit", "_logic", "_radius"];
         _unit setVariable [QGVAR(CS), true, true];
         _unit say3D QGVAR(cough_1);
         private _rndBlur = selectRandom [5, 6, 7, 8];
-        ppBlur ppEffectAdjust [_rndBlur]; 
-        ppBlur ppEffectEnable true;  
-        ppBlur ppEffectCommit 5;
+        if (hasInterface) then {
+            ppBlur ppEffectAdjust [_rndBlur]; 
+            ppBlur ppEffectEnable true;  
+            ppBlur ppEffectCommit 5;
+        };
     } else {
-        ppBlur ppEffectAdjust [0]; 
-        ppBlur ppEffectEnable true; 
-        ppBlur ppEffectCommit 20;
+        if (hasInterface) then {
+            ppBlur ppEffectAdjust [0]; 
+            ppBlur ppEffectEnable true; 
+            ppBlur ppEffectCommit 20;
+        };
         _unit setVariable [QGVAR(CS), false, true];
         [_handler] call CBA_fnc_removePerFrameHandler;
         

--- a/addons/chemical/functions/fnc_handleCSGas.sqf
+++ b/addons/chemical/functions/fnc_handleCSGas.sqf
@@ -28,8 +28,8 @@ params ["_unit", "_logic", "_radius"];
         if ((goggles _unit) in (missionNamespace getVariable [QGVAR(availGasmaskList), []])) then {_unit setVariable[QGVAR(enteredPoison), false, true]};
         _unit setVariable [QGVAR(CS), true, true];
         _unit say3D QGVAR(cough_1);
-        private _rndBlur = selectRandom [5, 6, 7, 8];
         if (hasInterface) then {
+        private _rndBlur = selectRandom [5, 6, 7, 8];
             ppBlur ppEffectAdjust [_rndBlur]; 
             ppBlur ppEffectEnable true;  
             ppBlur ppEffectCommit 5;


### PR DESCRIPTION
**When merged this pull request will:**
- Add `hasInterface` check for XEH_postInit.sqf ppEffectCreate section.
- This stop spaming `Post process effect creation failed error` record on server .rpt log.
- This error is only shown on Dedicated server (maybe headless too?). but this error makes 2GB over log file.
- This fix also helps improve server FPS. Reduce unnecessary work on server.