### PR TITLE
Improve Issue template | Add automated RPT parsing 

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,24 +1,53 @@
-**Arma 3 Version:** `x.xx` (stable / rc / dev)
-**ACE3 Version:** `3.x.x` (stable / dev + commit hash)
-**KAT Version:** `x.xx` (stable / dev)
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+---
 
+<!--
+🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
 
-**Mods:**
-```
-- CBA_A3
-- ace
-- Kat
-(if you use a lot of mods feel free to add preset file)
-```
+I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
+1. If I delete this entire template or parts of it and go my own path, the team may close my issue without further explanation or engagement.
+2. If I list multiple bugs/concerns in this one issue, the team may close my issue without further explanation or engagement.
+3. If I write an issue that has duplicates, the team may close my issue without further explanation or engagement (and without necessarily spending time to find the exact duplicate ID number).
+4. If I leave the title incomplete when filing the issue, the team may close my issue without further explanation or engagement.
+5. If I file something completely blank in the body, the team may close my issue without further explanation or engagement.
+6. If I file an issue without collecting logs (RPT file, etc...), the team may close my issue without further explanation or engagement. 
+
+All good? Then proceed and fill out all items below.
+-->
+
+**Modlist and KAT Version will be auto extracted from your attached RPT**
+Make sure to attach it to this report!
+
+**CBA Settings**
+<!-- Add a export of your relevant CBA settings here (ACE Medical and all KAT related settings). Go to addon options, server or missions tab and then click export to copy them to your clipboard. -->
+<details>
+  <summary>CBA Settings</summary>
+
+  ```sqf
+  Paste your settings in here.
+  ```  
+</details>
 
 **Description:**
-- Add a detailed description of the error. This makes it easier for me to fix the issue.
+- Add a detailed description of the error. This makes it easier for us to fix the issue. If applicable, add screenshots to help explain your problem (simply copy and paste). 
 
 **Steps to reproduce:**
-- Add the steps needed to reproduce the issue.
+Add the steps needed to reproduce the issue.
+
+1. _Go to ..._
+2. _Click ..._
+3. _See ..._
 
 **Where did the issue occur?**
 - Dedicated / Self-Hosted Multiplayer / Singleplayer / Editor (Singleplayer) / Editor (Multiplayer) / Virtual Arsenal
 
+**Additional information:**
+Provide any additional information that will help us solve this issue.
+
 **RPT log file:**
-- Add a link ([gist](https://gist.github.com) or [pastebin](http://pastebin.com)) to the client and/or server RPT file. An instruction to find your RPT files can be found [here](https://community.bistudio.com/wiki/Crash_Files#Arma_3).
+- Attach your RPT log file as a txt file. It can be found in `C:\Users\YOURUSERNAME\AppData\Local\Arma 3` and then add `.txt` to the end of the filename. Detailed instructions to find your RPT files can be found [here](https://community.bistudio.com/wiki/Crash_Files#Arma_3).

--- a/.github/workflows/extract-data-and-update-issue.yml
+++ b/.github/workflows/extract-data-and-update-issue.yml
@@ -1,0 +1,34 @@
+name: Extract Data from Appended File and Update Issue
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  extract-data-and-update-issue:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Extract Data
+        run: |
+          set -x
+          # Get the issue number
+          ISSUE_NUMBER=$(echo "${{ github.event.issue.number }}")
+          # Get the contents of the appended file
+          # Get the URL of the first file linked in the issue
+          FILE_URL=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" "${{ github.api_url }}/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}" | jq -r '.body | match("(?i)https://github.com/[^/]+/[^/]+/files/[0-9]+/[^)]+") | .string' | grep -i '\.txt$')
+          # Download the file
+          APPENDED_FILE_CONTENTS=$(curl -s -L -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" "$FILE_URL" | tee /dev/stderr)
+          # Parse the contents of the appended file to extract the required data
+          Arma_Version=$(echo "$APPENDED_FILE_CONTENTS" | awk '/^Type:/{t=$0} /^Build:/{b=$0} /^Version:/{print t"\n"b"\n"$0}' | grep -oP '\d+\.\d+\.\d+')
+          ACE_Version=$(echo "$APPENDED_FILE_CONTENTS" | grep -oP 'Advanced Combat Environment \K\d+\.\d+\.\d+')
+          CBA_Version=$(echo "$APPENDED_FILE_CONTENTS" | grep -oP 'Community Base Addons v\K\d+\.\d+\.\d+')
+          KAT_Version=$(echo "$APPENDED_FILE_CONTENTS" | grep -oP 'kat_main\.pbo - \K\d+\.\d+\.\d+\.\d+')
+          Modlist=$(echo "$APPENDED_FILE_CONTENTS" | sed -n '/----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------/,/==========================================================================================================================================================================================================/ {/----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------/!{/==========================================================================================================================================================================================================/!p}}' | sed 's/^[0-9]\{2\}:[0-9]\{2\}:[0-9]\{2\}//' | awk -F '|' '{print $1}')
+          # Remove all @ symbols from the modlist so we don't tag people
+          Modlist=$(echo "$Modlist" | sed 's/@//g')
+          # Construct the comment body
+          comment_body="Arma Version: $Arma_Version<br> ACE Version: $ACE_Version<br> CBA Version: $CBA_Version<br> KAT Version: $KAT_Version <br> <details> <summary>Modlist</summary> $Modlist </details>"
+          # Add a comment to the opened issue using jq to escape the JSON data
+          curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -X POST "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/issues/$ISSUE_NUMBER/comments" -H "Accept: application/vnd.github+json" -d "$(jq -n --arg body "$comment_body" '{body: $body}')"


### PR DESCRIPTION
**When merged this pull request will:**
- Reword the issue template with heavy inspiration from ACE3
- Add a section specifying on how to get the RPT
- Add a section asking for KAT CBA settings
- Create a github workflow triggered on every opened issue that will parse the attached RPT and add a comment with modlist and mod/game versions

### IMPORTANT

You need to change the permissions for github actions in this repository, they can be found under `Settings/Actions/General` at the bottom.
![image](https://github.com/KAT-Advanced-Medical/KAM/assets/57712666/fcc38b2f-b21d-47f5-8e21-0f06d9db4ad3)

### Testing

If you'd like to see the new template and parser in action you can try it out [here](https://github.com/MildlyInterested/KAM/issues)

