### PR TITLE
misc - Fix PPeffect error on server at fullHealLocal

### DIFF
--- a/addons/misc/functions/fnc_fullHealLocal.sqf
+++ b/addons/misc/functions/fnc_fullHealLocal.sqf
@@ -175,34 +175,35 @@ if (ACEGVAR(advanced_fatigue,enabled)) then {
 };
 
 /// Clear chroma effect & camera shake
-
-resetCamShake;
-["ChromAberration", 200, [ 0, 0, true ]] spawn
-{
-    params["_name", "_priority", "_effect", "_handle"];
-    while
+if (hasInterface) then {
+    resetCamShake;
+    ["ChromAberration", 200, [ 0, 0, true ]] spawn
     {
-        _handle = ppEffectCreate[_name, _priority];
-        _handle < 0
-    }
-    do
-    {
-        _priority = _priority + 1;
+        params["_name", "_priority", "_effect", "_handle"];
+        while
+        {
+            _handle = ppEffectCreate[_name, _priority];
+            _handle < 0
+        }
+        do
+        {
+            _priority = _priority + 1;
+        };
+        _handle ppEffectEnable true;
+        _handle ppEffectAdjust _effect;
+        _handle ppEffectCommit 0;
+        [
+            {
+                params["_handle"];
+                ppEffectCommitted _handle
+            },
+            {
+                params["_handle"];
+                _handle ppEffectEnable false;
+                ppEffectDestroy _handle;
+            },
+        [_handle]] call CBA_fnc_waitUntilAndExecute;
     };
-    _handle ppEffectEnable true;
-    _handle ppEffectAdjust _effect;
-    _handle ppEffectCommit 0;
-    [
-        {
-            params["_handle"];
-            ppEffectCommitted _handle
-        },
-        {
-            params["_handle"];
-            _handle ppEffectEnable false;
-            ppEffectDestroy _handle;
-        },
-    [_handle]] call CBA_fnc_waitUntilAndExecute;
 };
 
 // Reenable ace fatige animationspeed override


### PR DESCRIPTION
**When merged this pull request will:**
- _This is almost the same as this PR. https://github.com/KAT-Advanced-Medical/KAM/pull/385_
- _Add a hasInterface check to the ppEffectCreate section of fnc_fullHealLocal.sqf._
- _This will prevent error records `Post process effect creation failed` from being spammed in the server's .rpt log._
- _This error occurs when you run fullHealLocal against AI on the server (from ZEUS, etc)._
- _This error appears on dedicated servers (maybe even headless clients?). This error causes the log file to exceed 2 GB and slows down processing power due to spam._
- _This fix will also help improve the server's FPS. Reduce unnecessary work on server._

### IMPORTANT

- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
