### PR TITLE
Breathing/Circulation - Fix medical menu breaking, fix AED-X behaviour

### DIFF
--- a/addons/breathing/functions/fnc_inspectChest.sqf
+++ b/addons/breathing/functions/fnc_inspectChest.sqf
@@ -53,8 +53,13 @@ if (GET_HEART_RATE(_patient) isEqualTo 0) then {
     };
 } else {
     if (_hasPneumothorax && (_airwaySecure || _airwayClear)) then {
-        _message = LLSTRING(inspectChest_unevenMovement);
-        _messageLog = LLSTRING(inspectChest_unevenMovement);
+        if (_patient getVariable [QGVAR(tensionpneumothorax), false] || _patient getVariable [QGVAR(hemopneumothorax), false]) then {
+            _message = LLSTRING(inspectChest_none);
+            _messageLog = LLSTRING(inspectChest_none_log);
+        } else {
+            _message = LLSTRING(inspectChest_unevenMovement);
+            _messageLog = LLSTRING(inspectChest_unevenMovement);
+        };
         if (_simpleSetting) then {
             _hintSize = 2;
             _hintWidth = 13;
@@ -69,6 +74,9 @@ if (GET_HEART_RATE(_patient) isEqualTo 0) then {
 
             _message = _message + "<br />" + format [LLSTRING(inspectChest_simple), _type];
             _messageLog = _messageLog + format [" (%1)", _type_log];
+        } else {
+            _message = format ["%1<br />%2", _message, LLSTRING(inspectChest_uneven)];
+            _messageLog = format ["%1%2", _messageLog, LLSTRING(inspectChest_uneven_log)];
         };
     } else {
         if !(_airwayClear) then {

--- a/addons/chemical/script_component.hpp
+++ b/addons/chemical/script_component.hpp
@@ -28,54 +28,6 @@
 
 #define IDC_INJURIES 1410
 
-#define VAR_WOUND_BLEEDING          "ace_medical_woundBleeding"
-#define GET_WOUND_BLEEDING(unit)    (unit getVariable [VAR_WOUND_BLEEDING, 0])
-#define IS_BLEEDING(unit)           (GET_WOUND_BLEEDING(unit) > 0)
-
-
-#define VAR_HEMORRHAGE              "ace_medical_hemorrhage"
-#define GET_HEMORRHAGE(unit)        (unit getVariable [VAR_HEMORRHAGE, 0])
-
-
-#define DEFAULT_TOURNIQUET_VALUES   [0,0,0,0,0,0]
-#define VAR_TOURNIQUET              "ace_medical_tourniquets"
-#define GET_TOURNIQUETS(unit)       (unit getVariable [VAR_TOURNIQUET, DEFAULT_TOURNIQUET_VALUES])
-#define HAS_TOURNIQUET_APPLIED_ON(unit,index) ((GET_TOURNIQUETS(unit) select index) > 0)
-
-
-#define DEFAULT_FRACTURE_VALUES [0,0,0,0,0,0]
-#define VAR_FRACTURES               "ace_medical_fractures"
-#define GET_FRACTURES(unit)         (unit getVariable [VAR_FRACTURES, DEFAULT_FRACTURE_VALUES])
-
-
-#define VAR_PAIN                    "ace_medical_pain"
-#define VAR_PAIN_SUPP               "ace_medical_painSuppress"
-#define GET_PAIN(unit)              (unit getVariable [VAR_PAIN, 0])
-#define GET_PAIN_SUPPRESS(unit)     (unit getVariable [VAR_PAIN_SUPP, 0])
-#define GET_PAIN_PERCEIVED(unit)    (0 max (GET_PAIN(unit) - GET_PAIN_SUPPRESS(unit)) min 1)
-#define VAR_IN_PAIN                 "ace_medical_inPain"
-
-
-#define VAR_OPEN_WOUNDS             "ace_medical_openWounds"
-#define GET_OPEN_WOUNDS(unit)       (unit getVariable [VAR_OPEN_WOUNDS, []])
-#define VAR_BANDAGED_WOUNDS         "ace_medical_bandagedWounds"
-#define GET_BANDAGED_WOUNDS(unit)   (unit getVariable [VAR_BANDAGED_WOUNDS, []])
-#define VAR_STITCHED_WOUNDS         "ace_medical_stitchedWounds"
-#define GET_STITCHED_WOUNDS(unit)   (unit getVariable [VAR_STITCHED_WOUNDS, []])
-
-#define DEFAULT_BLOOD_VOLUME        6.0 // in liters
-#define DEFAULT_HEART_RATE          80
-#define DEFAULT_PERIPH_RES          100
-#define VAR_MEDICATIONS             "ace_medical_medications"
-#define VAR_BLOOD_PRESS             "ace_medical_bloodPressure"
-#define VAR_BLOOD_VOL               "ace_medical_bloodVolume"
-#define VAR_HEART_RATE              "ace_medical_heartRate"
-#define VAR_PERIPH_RES              "ace_medical_peripheralResistance"
-
-#define VAR_UNCON                   "ACE_isUnconscious"
-#define IS_UNCONSCIOUS(unit)        (unit getVariable [VAR_UNCON, false])
-
-
 #define IDD_MEDICAL_MENU 38580
 
 #define IDC_BODY_GROUP      6000

--- a/addons/circulation/XEH_preInit.sqf
+++ b/addons/circulation/XEH_preInit.sqf
@@ -333,6 +333,8 @@ PREP_RECOMPILE_END;
     LLSTRING(SETTING_AdvRhythm_Enable),
     [CBA_SETTINGS_CAT, LSTRING(SubCategory_AdvRhythms)],
     [true],
+    true,
+    {},
     true
 ] call CBA_Settings_fnc_init;
 

--- a/addons/circulation/functions/fnc_AEDX_ViewMonitor_AnalyzeFeedback.sqf
+++ b/addons/circulation/functions/fnc_AEDX_ViewMonitor_AnalyzeFeedback.sqf
@@ -94,7 +94,7 @@ private _fnc_displayMsg = {
 {
     params ["_dlg", "_fnc_displayMsg"];
 
-    if (GVAR(AEDX_MonitorTarget) getVariable [QGVAR(cardiacArrestType), 0] > 2 || (!(GVAR(AdvRhythm)) && GVAR(AEDX_MonitorTarget) getVariable [QACEGVAR(medical,heartRate), 0] isEqualTo 0)) then {
+    if ((GVAR(AdvRhythm) && GVAR(AEDX_MonitorTarget) getVariable [QGVAR(cardiacArrestType), 0] > 2) || (!(GVAR(AdvRhythm)) && GVAR(AEDX_MonitorTarget) getVariable [QACEGVAR(medical,heartRate), 0] isEqualTo 0)) then {
         [_dlg, 2] call _fnc_displayMsg;
 
         [{

--- a/addons/circulation/functions/fnc_AED_Analyze.sqf
+++ b/addons/circulation/functions/fnc_AED_Analyze.sqf
@@ -66,6 +66,7 @@ playsound3D [QPATHTOF_SOUND(sounds\analyzingnow.wav), _soundSource, false, getPo
             playsound3D [QPATHTOF_SOUND(sounds\shockadvised.wav), _soundSource, false, getPosASL _soundSource, 6, 1, 15];
             [{ // If shock advised begin to charge
                 params ["_medic", "_patient", "_defibrillatorType", "_soundSource"];
+
                 [_medic, _patient, _soundSource, _defibrillatorType] call FUNC(AED_Charge);
             }, [_medic, _patient, _defibrillatorType, _soundSource], 1.7] call CBA_fnc_waitAndExecute;
         } else { // no shock advised
@@ -74,10 +75,11 @@ playsound3D [QPATHTOF_SOUND(sounds\analyzingnow.wav), _soundSource, false, getPo
         };
     } else { // If advanced rhythms are disabled just check if patient is in cardiac arrest
         if (_patient getVariable [QACEGVAR(medical,heartRate), 0] isEqualTo 0) then {
+            playsound3D [QPATHTOF_SOUND(sounds\shockadvised.wav), _soundSource, false, getPosASL _soundSource, 6, 1, 15];
             [{ // If shock advised begin to charge
                 params ["_medic", "_patient", "_defibrillatorType", "_soundSource"];
 
-                [_medic, _patient, _defibrillatorType, _soundSource] call FUNC(AED_Charge);
+                [_medic, _patient, _soundSource, _defibrillatorType] call FUNC(AED_Charge);
             }, [_medic, _patient, _defibrillatorType, _soundSource], 1.7] call CBA_fnc_waitAndExecute;
         } else {
             playsound3D [QPATHTOF_SOUND(sounds\noshockadvised.wav), _soundSource, false, getPosASL _soundSource, 6, 1, 15];

--- a/addons/circulation/functions/fnc_handleCardiacArrest.sqf
+++ b/addons/circulation/functions/fnc_handleCardiacArrest.sqf
@@ -29,7 +29,8 @@ params ["_unit", "_active", ["_initial",true]];
 
 private _cardiacArrestType = 0;
 
-if !(alive _unit) exitWith {};
+if !(GVAR(AdvRhythm)) exitWith {};
+if !(alive _unit) exitWith {_unit setVariable [QGVAR(cardiacArrestType), 1, true];};
 
 if (_initial) then {
     if !(_active) exitWith {};

--- a/addons/gui/functions/fnc_updateInjuryList.sqf
+++ b/addons/gui/functions/fnc_updateInjuryList.sqf
@@ -336,7 +336,7 @@ private _fnc_processWounds = {
 [GET_STITCHED_WOUNDS(_target), "[S] %1", [0.7, 0.7, 0.7, 1]] call _fnc_processWounds;
 
 if (_ptxEntry isNotEqualTo []) then {
-    _woundEntries pushBack _ptxEntry;
+    _woundEntries append _ptxEntry;
 };
 
 // Handle no wound entries

--- a/addons/main/script_version.hpp
+++ b/addons/main/script_version.hpp
@@ -1,4 +1,4 @@
 #define MAJOR 2
 #define MINOR 13
-#define PATCH 0
-#define BUILD 35
+#define PATCH 1
+#define BUILD 36

--- a/addons/misc/stringtable.xml
+++ b/addons/misc/stringtable.xml
@@ -843,22 +843,5 @@
             <French>Arrêt du transport de %1</French>
             <Korean>%1의 운반 취소함</Korean>
         </Key>
-        <Key ID="STR_ACE_Medical_Category">
-            <English>Medical</English>
-            <Czech>Zdravotní</Czech>
-            <French>Médical</French>
-            <German>Sanitäter</German>
-            <Italian>Medico</Italian>
-            <Polish>Medyczne</Polish>
-            <Portuguese>Médico</Portuguese>
-            <Russian>Медик</Russian>
-            <Spanish>Médico</Spanish>
-            <Hungarian>Orvosi</Hungarian>
-            <Japanese>治療</Japanese>
-            <Korean>의료</Korean>
-            <Chinesesimp>医疗设定</Chinesesimp>
-            <Chinese>醫療設定</Chinese>
-            <Turkish>Medikal</Turkish>
-        </Key>
     </Package>
 </Project>

--- a/addons/pharma/functions/fnc_init.sqf
+++ b/addons/pharma/functions/fnc_init.sqf
@@ -127,7 +127,7 @@ if (GVAR(coagulation)) then {
             [_idPFH] call CBA_fnc_removePerFrameHandler;
         };
 
-        private _openWounds = _unit getVariable [VAR_OPEN_WOUNDS, []];
+        private _openWounds = _unit getVariable [VAR_OPEN_WOUNDS, createHashMap];
         private _pulse = _unit getVariable [VAR_HEART_RATE, 80];
         private _coagulationFactor = _unit getVariable [QGVAR(coagulationFactor), 10];
 


### PR DESCRIPTION
**When merged this pull request will:**
- Fix medical menu breaking if `pneumothoraxAlwaysVisible` is enabled and the patient is suffering from pneumothorax
- Closes #420 
- Fix AED-X behaviour when `advRhythm` is disabled

### IMPORTANT

- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
