### PR TITLE
Translation - Improve Japanese

### DIFF
--- a/addons/breathing/stringtable.xml
+++ b/addons/breathing/stringtable.xml
@@ -989,10 +989,12 @@
         <Key ID="STR_KAT_Breathing_SETTING_showCyanosis">
             <English>Show cyanosis</English>
             <Korean>치아노제 표시</Korean>
+            <Japanese>チアノーゼの表示</Japanese>
         </Key>
         <Key ID="STR_KAT_Breathing_SETTING_showCyanosis_DESC">
             <English>Shows cyanosis of patient in overview tab</English>
             <Korean>개요 탭에 환자의 치아노제를 표시합니다</Korean>
+            <Japanese>チアノーゼを患者の概況に表示する</Japanese>
         </Key>
         <Key ID="STR_KAT_Breathing_SETTING_slightValue">
             <English>Slight cyanosis SpO2 value</English>

--- a/addons/breathing/stringtable.xml
+++ b/addons/breathing/stringtable.xml
@@ -208,7 +208,7 @@
             <French>Oxymètre de pouls: PR: %1 SpO2: %2</French>
             <Turkish>Nabız Oksimetresi: PR: %1 SpO2: %2</Turkish>
             <Italian>Pulsossimetro: PR: %1 SpO2: %2</Italian>
-            <Japanese>パルスオキシメーター: PR: %1 SpO2: %2</Japanese>
+            <Japanese>パルスオキシメーター: 脈拍: %1 SpO2: %2</Japanese>
             <Portuguese>Oxímetro de Pulso: PR: %1 SpO2: %2</Portuguese>
         </Key>
         <Key ID="STR_KAT_Breathing_pulseoxi_Log_2">
@@ -1721,7 +1721,7 @@
         </Key>
         <Key ID="STR_KAT_Breathing_breath_stink">
             <English>, harsh and metallic</English>
-            <Japanese>、吸気はきつい金属臭がする</Japanese>
+            <Japanese>、吸気は掠れて金属臭がする</Japanese>
             <French>, l'haleine dégage une forte odeur métallique</French>
             <Korean>, 거칠고 금속같다</Korean>
         </Key>

--- a/addons/circulation/stringtable.xml
+++ b/addons/circulation/stringtable.xml
@@ -29,7 +29,7 @@
             <Italian>Ritmo avanzato attivato?</Italian>
             <Spanish>¿Ritmo avanzado activado?</Spanish>
             <Czech>Pokročilý Rytmus aktivován?</Czech>
-            <Japanese>高度な心電図波形 を有効化しますか?</Japanese>
+            <Japanese>高度な心調律 を有効化しますか?</Japanese>
             <Russian>Продвинутый ритм активирован?</Russian>
             <Portuguese>Ritmo avançado ativado?</Portuguese>
         </Key>
@@ -819,7 +819,7 @@
         </Key>
         <Key ID="STR_KAT_Circulation_AnalyzeRhythm">
             <English>Analyze Rhythm</English>
-            <Japanese>波形を測定</Japanese>
+            <Japanese>心調律を測定</Japanese>
             <French>Chiffrer la fréquence cardiaque</French>
             <Korean>리듬 분석</Korean>
         </Key>
@@ -1277,11 +1277,13 @@
             <English>HR</English>
             <French>FC</French>
             <Korean>심박수</Korean>
+            <Japanese>HR</Japanese>
         </Key>
         <Key ID="STR_KAT_Circulation_AEDX_Monitor_PR">
             <English>PR</English>
             <French>FP</French>
             <Korean>맥박</Korean>
+            <Japanese>PR</Japanese>
         </Key>
         <Key ID="STR_KAT_Circulation_crosspanel">
             <English>Blood groups cheat sheet</English>
@@ -2086,31 +2088,31 @@
         </Key>
         <Key ID="STR_KAT_Circulation_SubCategory_AdvRhythms">
             <English>Advanced Rhythms</English>
-            <Japanese>高度な心電図波形</Japanese>
+            <Japanese>高度な心調律</Japanese>
             <French>Rythmes avancés</French>
             <Korean>고급 리듬</Korean>
         </Key>
         <Key ID="STR_KAT_Circulation_SETTING_AdvRhythm_canDeteriorate">
             <English>Can Deteriorate</English>
-            <Japanese>心機能低下の可能性</Japanese>
+            <Japanese>調律状態悪化の可能性</Japanese>
             <French>Possibilité de diminution de la fonction cardiaque</French>
             <Korean>심장기능이 악화될 수 있음</Korean>
         </Key>
         <Key ID="STR_KAT_Circulation_SETTING_AdvRhythm_deteriorateTimeMax">
             <English>Random Deteriorate Time Maximum</English>
-            <Japanese>心機能低下するランダムな時間の最大値</Japanese>
+            <Japanese>調律状態悪化するランダムな時間の最大値</Japanese>
             <French>Délai aléatoire maximum jusqu'à l'arrêt cardiaque</French>
             <Korean>심장기능 무작위 악화 시간 최대값</Korean>
         </Key>
         <Key ID="STR_KAT_Circulation_SETTING_AdvRhythm_deteriorateTimeWeight">
             <English>Random Deteriorate Time Weight</English>
-            <Japanese>心機能低下するランダムな時間の重みづけ</Japanese>
+            <Japanese>調律状態悪化するランダムな時間の重みづけ</Japanese>
             <French>Poids temporel de la détérioration de la fonction cardiaque</French>
             <Korean>심장기능 무작위 악화 시간 가중치</Korean>
         </Key>
         <Key ID="STR_KAT_Circulation_SETTING_AdvRhythm_deteriorateAfterTreatment">
             <English>Deteriorate After Treatment</English>
-            <Japanese>治療後の心機能低下</Japanese>
+            <Japanese>治療後の調律状態悪化</Japanese>
             <French>Diminution de la fonction cardiaque après le traitement</French>
             <Korean>심장기능 치료 후 악화</Korean>
         </Key>
@@ -2146,13 +2148,13 @@
         </Key>
         <Key ID="STR_KAT_Circulation_SETTING_AdvRhythm_Hardcore_Enable">
             <English>Hardcore Rhythms</English>
-            <Japanese>ハードコア心電図波形</Japanese>
+            <Japanese>ハードコア心調律</Japanese>
             <French>Rythmes cardiaques intenses</French>
             <Korean>하드코어 리듬</Korean>
         </Key>
         <Key ID="STR_KAT_Circulation_SETTING_AdvRhythm_hardcoreDeteriorationChance">
             <English>Hardcore Deterioration Chance</English>
-            <Japanese>ハードコア心機能低下確率</Japanese>
+            <Japanese>ハードコア調律状態悪化</Japanese>
             <French>Chance de rythmes cardiaques intenses</French>
             <Korean>하드코어 심장기능 악화 확률</Korean>
         </Key>
@@ -2184,6 +2186,7 @@
             <English>AED-X: PR: %1 BP: %2/%3 SpO2: %4</English>
             <French>AED-X: FP: %1 PA: %2/%3 SpO2: %4</French>
             <Korean>X-시리즈 자동심장충격기: 맥박: %1 혈압: %2/%3 산소포화도: %4</Korean>
+            <Japanese>AED-X: 脈拍: %1 血圧: %2/%3 SpO2: %4</Japanese>
         </Key>
         <Key ID="STR_KAT_Circulation_VitalsMonitor_StatusLog">
             <English>AED-X: HR: %1 BP: %2/%3 SpO2: %4</English>

--- a/addons/gui/stringtable.xml
+++ b/addons/gui/stringtable.xml
@@ -49,26 +49,32 @@
         <Key ID="STR_KAT_GUI_Status_NoIv">
             <English>No pushed fluids</English>
             <Korean>주입된 액체 없음</Korean>
+            <Japanese>注入された液体なし</Japanese>
         </Key>
         <Key ID="STR_KAT_GUI_SETTING_showInactiveStatuses">
             <English>Show Inactive Statuses</English>
             <Korean>비활성 상태 표시</Korean>
+            <Japanese>非活動状態の表示</Japanese>
         </Key>
         <Key ID="STR_KAT_GUI_SETTING_showBleedRate">
             <English>Show Bleed Rate</English>
             <Korean>출혈 속도 표시</Korean>
+            <Japanese>出血率の表示</Japanese>
         </Key>
         <Key ID="STR_KAT_GUI_SETTING_showBleedRate_DESC">
             <English>Display bleed rate (slow/moderate/severe/massive)</English>
             <Korean>출혈 속도(느림/중간/심각/과다)를 표시합니다</Korean>
+            <Japanese>出血率を表示する (遅い/中程度/重い/大量)</Japanese>
         </Key>
         <Key ID="STR_KAT_GUI_SETTING_overlayBodyPart">
             <English>Overlay Selected Body Part</English>
             <Korean>선택한 신체 부위 오버레이</Korean>
+            <Japanese>選択した身体部位のオーバーレイ表示</Japanese>
         </Key>
         <Key ID="STR_KAT_GUI_SETTING_showPatientSideLabels">
             <English>Label Patient Sides</English>
             <Korean>환자 측면에 라벨 붙이기</Korean>
+            <Japanese>患者側面のラベル</Japanese>
         </Key>
     </Package>
 </Project>

--- a/addons/pharma/stringtable.xml
+++ b/addons/pharma/stringtable.xml
@@ -2838,10 +2838,12 @@
         <Key ID="STR_KAT_Pharma_SETTING_staminaMedication">
             <English>Medication Modifies Stamina</English>
             <Korean>약물이 스태미나를 조절합니다</Korean>
+            <Japanese>薬品によるスタミナの変化</Japanese>
         </Key>
         <Key ID="STR_KAT_Pharma_SETTING_staminaMedication_DESC">
             <English>Allow certain medications to modify (vanilla/advanced fatigue) stamina as a side effect</English>
             <Korean>부작용으로 특정 약물이 (바닐라/고급 피로도) 스태미나를 조절할 수 있도록 허용</Korean>
+            <Japanese>特定の薬の副作用としてスタミナ(バニラ/高度な疲労)を変更することを許可する</Japanese>
         </Key>
     </Package>
 </Project>

--- a/addons/pharma/stringtable.xml
+++ b/addons/pharma/stringtable.xml
@@ -817,7 +817,7 @@
             <French>Cathéther intra-veineux</French>
             <Turkish>Ağrıyı bastırmak için kullanılır</Turkish>
             <Italian>Catetere intravenoso</Italian>
-            <Japanese>静脈注射(IV)針</Japanese>
+            <Japanese>経静脈注射(IV)針</Japanese>
             <Russian>Внутривенное игла</Russian>
             <Portuguese>Cateter Intravenoso</Portuguese>
         </Key>
@@ -849,7 +849,7 @@
             <French>Cathéther intra-osseux</French>
             <Turkish>Ağrıyı bastırmak için kullanılır</Turkish>
             <Italian>Sistema d'infusione intraossea</Italian>
-            <Japanese>骨髄穿刺注射(IO)針</Japanese>
+            <Japanese>経骨髄注射(IO)針</Japanese>
             <Russian>Внутривенное игла</Russian>
             <Portuguese>Infusão Intraóssea</Portuguese>
         </Key>

--- a/addons/surgery/stringtable.xml
+++ b/addons/surgery/stringtable.xml
@@ -85,7 +85,7 @@
             <French>L'haleine du patient est mauvaise et métallique</French>
             <Korean>환자의 호흡이 거칠고 쇠같습니다.</Korean>
             <German>Der Atem des Patienten ist rau und metallisch</German>
-            <Japanese>患者の息はきつく金属臭がします</Japanese>
+            <Japanese>患者の吐息は掠れて金属臭がします</Japanese>
             <Spanish>El aliento del paciente es áspero y metálico</Spanish>
             <Portuguese>O hálito do paciente é aspero e metálico</Portuguese>
         </Key>
@@ -98,7 +98,7 @@
             <French>L'haleine du patient est mauvaise et métallique</French>
             <Korean>환자의 호흡이 거칠고 쇠같습니다.</Korean>
             <German>Der Atem des Patienten ist rau und metallisch</German>
-            <Japanese>患者の息はきつく金属臭がします</Japanese>
+            <Japanese>患者の吐息は掠れて金属臭がします</Japanese>
             <Spanish>El aliento del paciente es áspero y metálico</Spanish>
             <Portuguese>O hálito do paciente é aspero e metálico</Portuguese>
         </Key>
@@ -111,7 +111,7 @@
             <French>L'haleine du patient est légèrement fruitée</French>
             <Korean>환자의 호흡에서 과일향이 약간 납니다</Korean>
             <German>Der Atem des Patienten ist leicht fruchtig</German>
-            <Japanese>患者の息は少し果物臭がします</Japanese>
+            <Japanese>患者の吐息は少し果物臭がします</Japanese>
             <Spanish>El aliento del paciente es dulce</Spanish>
             <Portuguese>O hálito do paciente é ligeiramente frutado</Portuguese>
         </Key>
@@ -124,7 +124,7 @@
             <French>L'haleine du patient est bonne</French>
             <Korean>환자의 호흡이 정상입니다</Korean>
             <German>Der Atem des Patienten ist in Ordnung</German>
-            <Japanese>患者の息は普通です</Japanese>
+            <Japanese>患者の吐息は一般的です</Japanese>
             <Spanish>El aliento del paciente es normal</Spanish>
             <Portuguese>O hálito do paciente é normal</Portuguese>
         </Key>
@@ -267,7 +267,7 @@
             <French>Echec du pansement</French>
             <Korean>상처 치료 실패</Korean>
             <German>Wundverband fehlgeschlagen</German>
-            <Japanese>創面切除に失敗しました</Japanese>
+            <Japanese>創縁切除に失敗しました</Japanese>
             <Spanish>Vendaje al vacío falló</Spanish>
             <Portuguese>Falha no curativo da ferida</Portuguese>
         </Key>
@@ -292,7 +292,7 @@
             <French>Utilisé pour inciser et débrider les plaies</French>
             <Korean>절개 부위를 생성하고 상처를 제거하는 데 사용됩니다.</Korean>
             <German>Für das Durchführen von Inzisionen und das Debridieren von Wunden</German>
-            <Japanese>切開とデブリードマン(創面切除)に使用する</Japanese>
+            <Japanese>切開と創縁切除に使用する</Japanese>
             <Spanish>Usado para crear incisiones y desbridar heridas</Spanish>
             <Polish>Służy do tworzenia nacięć i oczyszczania ran</Polish>
             <Portuguese>Usado para criar incisões e desbridar feridas</Portuguese>
@@ -423,7 +423,7 @@
             <French>Irriguer la plaie</French>
             <Korean>상처 세척</Korean>
             <German>Wunde spülen</German>
-            <Japanese>創面を洗浄</Japanese>
+            <Japanese>創面を灌注</Japanese>
             <Spanish>Irrigar herida</Spanish>
             <Portuguese>Irrigar ferida</Portuguese>
         </Key>
@@ -436,7 +436,7 @@
             <French>Irriguation</French>
             <Korean>세척 중</Korean>
             <German>Spülen</German>
-            <Japanese>洗浄中</Japanese>
+            <Japanese>灌注中</Japanese>
             <Spanish>Irrigando</Spanish>
             <Portuguese>Irrigando</Portuguese>
         </Key>
@@ -475,7 +475,7 @@
             <French>Débrider les plaies</French>
             <Korean>괴사조직 제거</Korean>
             <German>Wunde debridieren</German>
-            <Japanese>デブリードマン(創面切除)</Japanese>
+            <Japanese>創縁切除</Japanese>
             <Spanish>Desbridar heridas</Spanish>
             <Portuguese>Desbridar feridas</Portuguese>
         </Key>
@@ -488,7 +488,7 @@
             <French>Débridement</French>
             <Korean>제거 중</Korean>
             <German>Debridement</German>
-            <Japanese>創面切除中</Japanese>
+            <Japanese>創縁切除中</Japanese>
             <Spanish>Desbridando</Spanish>
             <Portuguese>Desbridando</Portuguese>
         </Key>
@@ -501,7 +501,7 @@
             <French>Pansement sous vide</French>
             <Korean>진공 드레싱</Korean>
             <German>Vakuumverband</German>
-            <Japanese>吸引ドレッシング (NPWT)</Japanese>
+            <Japanese>吸引被覆 (NPWT)</Japanese>
             <Spanish>Vendaje al vacío</Spanish>
             <Portuguese>Bandagem a vácuo</Portuguese>
         </Key>
@@ -527,7 +527,7 @@
             <French>Appliquer un pansement par pression négative</French>
             <Korean>음압상처치료 적용</Korean>
             <German>NPWT-Verband anlegen</German>
-            <Japanese>吸引ドレッシング(NPWT)を使う</Japanese>
+            <Japanese>吸引被覆(NPWT)を行う</Japanese>
             <Spanish>Colocar vendaje al vacío</Spanish>
             <Portuguese>Aplicar curativo NPWT</Portuguese>
         </Key>
@@ -785,7 +785,7 @@
             <French>Règle le temps nécessaire pour effectuer des actions chirurgicales intermédiaires, comme exposer ou irriguer</French>
             <Korean>노출 및 세척같은 중간 수술 조치를 수행하는 데 걸리는 시간을 설정합니다.</Korean>
             <German>Legt fest, wie lange es dauert, chirurgische Zwischenschritte wie Freilegung und Spülung durchzuführen</German>
-            <Japanese>露出や洗浄などの中間の外科的処置を実行するのにかかる時間を設定します</Japanese>
+            <Japanese>露出や灌注などの中間の外科的処置を実行するのにかかる時間を設定します</Japanese>
             <Spanish>Establece cuanto tiempo tarda realizar acciones quirúrgicas como exponer o irrigar.</Spanish>
             <Portuguese>Estabelece quanto tempo leva para realizar ações cirúrgicas, como expor ou irrigar.</Portuguese>
         </Key>
@@ -980,7 +980,7 @@
             <French>Temps pour débrider un patient</French>
             <Korean>환자의 상처 제거 시간</Korean>
             <German>Zeit für die Debridierung eines Patienten</German>
-            <Japanese>デブリードマンの所要時間</Japanese>
+            <Japanese>創縁切除の所要時間</Japanese>
             <Spanish>Tiempo para desbridar un paciente</Spanish>
             <Portuguese>Duração do desbridamento de um paciente</Portuguese>
         </Key>
@@ -993,14 +993,14 @@
             <French>Temps pour appliquer un pansement par pression négative</French>
             <Korean>음압상처치료 적용 시간</Korean>
             <German>Zeit zum Anlegen eines NPWT-Verbandes</German>
-            <Japanese>NPWTドレッシングの使用時間</Japanese>
+            <Japanese>NPWT被覆の使用時間</Japanese>
             <Spanish>Tiempo para colocar un vendaje al vacío</Spanish>
             <Portuguese>Duração do aplique de curativo a vácuo</Portuguese>
         </Key>
         <Key ID="STR_KAT_Surgery_SETTING_DebridementAction_MedLevel">
             <English>Allow Debridement</English>
             <Spanish>Permitir desbridamiento</Spanish>
-            <Japanese>デブリードマンの許可</Japanese>
+            <Japanese>創縁切除の許可</Japanese>
             <German>Benötigter medizinischer Grad, um Debridement &amp; NPWT-Verband zu nutzen</German>
             <French>Autoriser le débridement</French>
             <Korean>괴사조직 제거 허용</Korean>
@@ -1009,7 +1009,7 @@
         <Key ID="STR_KAT_Surgery_SETTING_DebridementAction_Location">
             <English>Locations Debridement</English>
             <Spanish>Lugares para el desbridamiento</Spanish>
-            <Japanese>デブリードマンの使用可能場所</Japanese>
+            <Japanese>創縁切除の使用可能場所</Japanese>
             <German>Ort für die durchführung von Debridement &amp; NPWT-Verband</German>
             <French>Lieux permettant le débridement</French>
             <Korean>괴사조직 위치</Korean>

--- a/addons/zeus/stringtable.xml
+++ b/addons/zeus/stringtable.xml
@@ -237,6 +237,7 @@
             <English>Unit must be an AI</English>
             <French>L'unité doit être une IA</French>
             <Korean>유닛은 반드시 AI여야 합니다</Korean>
+            <Japanese>ユニットはAIである必要があります</Japanese>
         </Key>
         <Key ID="STR_KAT_Zeus_sliderFormat13was23">
             <English>%1%3 (was %2%3)</English>
@@ -258,11 +259,13 @@
             <English>Toggle Instant AI Death</English>
             <French>Activer/Désactiver la mort instantanée de l'IA</French>
             <Korean>인공지능 즉사 토글</Korean>
+            <Japanese>AIの即死を切り替え</Japanese>
         </Key>
         <Key ID="STR_KAT_Zeus_toggleAIDeath_Module_Toggled">
             <English>Instant AI Death %1 for unit</English>
             <French>Mort instantanée de l'IA %1 pour l'unité</French>
             <Korean>유닛에 AI 즉사 %1</Korean>
+            <Japanese>このAIユニットの即死は %1 になりました</Japanese>
         </Key>
     </Package>
 </Project>


### PR DESCRIPTION
**When merged this pull request will:**
- _Fill in missing strings._
- _Change the wording of "rhythm" to the wording used by actual Japanese doctors._

From: https://jams.med.or.jp/dic/mdic.html (Japanese Medical Association Medical Terminology Dictionary)

### IMPORTANT

- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
