### PR TITLE
Circulation - Fix random deteriorate time for advanced rhythm

### DIFF
--- a/addons/circulation/functions/fnc_handleCardiacArrest.sqf
+++ b/addons/circulation/functions/fnc_handleCardiacArrest.sqf
@@ -57,10 +57,10 @@ if (_initial) then {
 if (GVAR(AdvRhythm_canDeteriorate)) then {
     private _timeToDeteriorate = 0;
 
-    if (GVAR(AdvRhythm_deteriorateTimeWeight) < GVAR(AdvRhythm_deteriorateTimeWeight)) then {
-        _timeToDeteriorate = random [20, GVAR(AdvRhythm_deteriorateTimeWeight), GVAR(AdvRhythm_deteriorateTimeWeight)];
+    if (GVAR(AdvRhythm_deteriorateTimeWeight) < GVAR(AdvRhythm_deteriorateTimeMax)) then {
+        _timeToDeteriorate = random [20, GVAR(AdvRhythm_deteriorateTimeWeight), GVAR(AdvRhythm_deteriorateTimeMax)];
     } else {
-        _timeToDeteriorate = random [20, GVAR(AdvRhythm_deteriorateTimeWeight) / 2, GVAR(AdvRhythm_deteriorateTimeWeight)];
+        _timeToDeteriorate = random [20, GVAR(AdvRhythm_deteriorateTimeMax) / 2, GVAR(AdvRhythm_deteriorateTimeMax)];
     };
 
     switch (_cardiacArrestType) do {


### PR DESCRIPTION
Changed ''AdvRhythm_deteriorateTimeWeight'' to ''AdvRhythm_deteriorateTimeMax'' when applicable. This should fix the bell curve to implement both values instead of just the setting regarding ''AdvRhythm_deteriorateTimeWeight''.

**When merged this pull request will:**
- _Describe what this pull request will do_
- _Each change in a separate line_

### IMPORTANT

- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
