### PR TITLE
Airway - Change recovery position & reword check airway hints

### DIFF
--- a/addons/airway/ACE_Medical_Treatment_Actions.hpp
+++ b/addons/airway/ACE_Medical_Treatment_Actions.hpp
@@ -67,7 +67,7 @@ class ACE_Medical_Treatment_Actions {
     class Overstretch: Larynxtubus {
         displayName = CSTRING(overstretch);
         displayNameProgress = CSTRING(overstretching);
-        treatmentTime = QGVAR(Overstretch_time);
+        treatmentTime = QGVAR(Hyperextend_Time);
         medicRequired = 0;
         items[] = {};
         icon = "";

--- a/addons/airway/ACE_Medical_Treatment_Actions.hpp
+++ b/addons/airway/ACE_Medical_Treatment_Actions.hpp
@@ -9,8 +9,8 @@ class ACE_Medical_Treatment_Actions {
         medicRequired = QGVAR(medLvl_Larynxtubus);
         treatmentTime = QGVAR(Larynxtubus_time);
         items[] = {"kat_larynx"};
-        condition = QUOTE(!([_patient] call ACEFUNC(common,isAwake)) && (missionNamespace getVariable [ARR_2(QQGVAR(enable),true)]) && !(_patient getVariable [ARR_2(QQGVAR(recovery),false)]) && !(_patient getVariable [ARR_2(QQGVAR(airway_item),'')] == 'Larynxtubus') && !(_patient getVariable [ARR_2(QQGVAR(airway_item),'')] == 'Guedeltubus'));
-        callbackSuccess = QFUNC(treatmentAdvanced_airway);
+        condition = QUOTE(!([_patient] call ACEFUNC(common,isAwake)) && (missionNamespace getVariable [ARR_2(QQGVAR(enable),true)]) && !(_patient getVariable [ARR_2(QQGVAR(airway_item),'')] == 'Larynxtubus') && !(_patient getVariable [ARR_2(QQGVAR(airway_item),'')] == 'Guedeltubus'));
+        callbackSuccess = QUOTE([ARR_6(_medic,_patient,_bodyPart,_className,objNull,_usedItem)] call FUNC(treatmentAdvanced_airway); [ARR_2(_medic,_patient)] call FUNC(handleRecoveryPosition););
         callbackFailure = "";
         callbackProgress = "";
         consumeItem = 1;
@@ -37,10 +37,10 @@ class ACE_Medical_Treatment_Actions {
         displayName = CSTRING(Guedeltubus_Display);
         medicRequired = QGVAR(medLvl_Guedeltubus);
         treatmentTime = QGVAR(Guedeltubus_time);
-        condition = QUOTE(!([_patient] call ACEFUNC(common,isAwake)) && missionNamespace getVariable [ARR_2(QQGVAR(enable),true)] && !(_patient getVariable [ARR_2(QQGVAR(recovery),false)]) && !(_patient getVariable [ARR_2(QQGVAR(airway_item),'')] == 'Guedeltubus') && !(_patient getVariable [ARR_2(QQGVAR(airway_item),'')] == 'Larynxtubus'));
+        condition = QUOTE(!([_patient] call ACEFUNC(common,isAwake)) && missionNamespace getVariable [ARR_2(QQGVAR(enable),true)] && !(_patient getVariable [ARR_2(QQGVAR(airway_item),'')] == 'Guedeltubus') && !(_patient getVariable [ARR_2(QQGVAR(airway_item),'')] == 'Larynxtubus'));
         items[] = {"kat_guedel"};
         icon = QPATHTOF(ui\guedel.paa);
-        callbackSuccess = QFUNC(treatmentAdvanced_airway);
+        callbackSuccess = QUOTE([ARR_6(_medic,_patient,_bodyPart,_className,objNull,_usedItem)] call FUNC(treatmentAdvanced_airway); [ARR_2(_medic,_patient)] call FUNC(handleRecoveryPosition););
     };
     class RemoveGuedeltubus: RemoveLarynxtubus {
         displayName = CSTRING(Cancel_Guedeltubus);

--- a/addons/airway/ACE_Medical_Treatment_Actions.hpp
+++ b/addons/airway/ACE_Medical_Treatment_Actions.hpp
@@ -64,15 +64,15 @@ class ACE_Medical_Treatment_Actions {
         callbackSuccess = QFUNC(treatmentAdvanced_accuvac);
         sounds[] = {{QPATHTO_R(sounds\accuvac.wav),6,1,15}};
     };
-    class Overstretch: Larynxtubus {
-        displayName = CSTRING(overstretch);
-        displayNameProgress = CSTRING(overstretching);
+    class HyperextendHead: Larynxtubus {
+        displayName = CSTRING(Hyperextend_diplayName);
+        displayNameProgress = CSTRING(Hyperextend_progress);
         treatmentTime = QGVAR(Hyperextend_Time);
         medicRequired = 0;
         items[] = {};
         icon = "";
         condition = QUOTE(!([_patient] call ACEFUNC(common,isAwake)) && !(_patient getVariable [ARR_2(QQGVAR(overstretch),false)]) && !(_patient getVariable [ARR_2(QQGVAR(recovery),false)]) && (missionNamespace getVariable [ARR_2(QQGVAR(enable),true)]) && !(_patient getVariable [ARR_2(QQGVAR(airway_item),'')] == 'Guedeltubus') && !(_patient getVariable [ARR_2(QQGVAR(airway_item),'')] == 'Larynxtubus'));
-        callbackSuccess = QFUNC(treatmentAdvanced_overstretchHead);
+        callbackSuccess = QFUNC(treatmentAdvanced_hyperextendHead);
     };
     class BeginHeadTurning: Larynxtubus {
         displayName = CSTRING(headTurning_begin);

--- a/addons/airway/ACE_Medical_Treatment_Actions.hpp
+++ b/addons/airway/ACE_Medical_Treatment_Actions.hpp
@@ -10,7 +10,7 @@ class ACE_Medical_Treatment_Actions {
         treatmentTime = QGVAR(Larynxtubus_time);
         items[] = {"kat_larynx"};
         condition = QUOTE(!([_patient] call ACEFUNC(common,isAwake)) && (missionNamespace getVariable [ARR_2(QQGVAR(enable),true)]) && !(_patient getVariable [ARR_2(QQGVAR(airway_item),'')] == 'Larynxtubus') && !(_patient getVariable [ARR_2(QQGVAR(airway_item),'')] == 'Guedeltubus'));
-        callbackSuccess = QUOTE([ARR_6(_medic,_patient,_bodyPart,_className,objNull,_usedItem)] call FUNC(treatmentAdvanced_airway); [ARR_2(_medic,_patient)] call FUNC(handleRecoveryPosition););
+        callbackSuccess = QUOTE([ARR_3(_medic,_patient,(_patient getVariable [ARR_2(QQGVAR(occluded),false)]))] call FUNC(handleRecoveryPosition); [ARR_6(_medic,_patient,_bodyPart,_className,objNull,_usedItem)] call FUNC(treatmentAdvanced_airway););
         callbackFailure = "";
         callbackProgress = "";
         consumeItem = 1;
@@ -40,7 +40,7 @@ class ACE_Medical_Treatment_Actions {
         condition = QUOTE(!([_patient] call ACEFUNC(common,isAwake)) && missionNamespace getVariable [ARR_2(QQGVAR(enable),true)] && !(_patient getVariable [ARR_2(QQGVAR(airway_item),'')] == 'Guedeltubus') && !(_patient getVariable [ARR_2(QQGVAR(airway_item),'')] == 'Larynxtubus'));
         items[] = {"kat_guedel"};
         icon = QPATHTOF(ui\guedel.paa);
-        callbackSuccess = QUOTE([ARR_6(_medic,_patient,_bodyPart,_className,objNull,_usedItem)] call FUNC(treatmentAdvanced_airway); [ARR_2(_medic,_patient)] call FUNC(handleRecoveryPosition););
+        callbackSuccess = QUOTE([ARR_3(_medic,_patient,(_patient getVariable [ARR_2(QQGVAR(occluded),false)]))] call FUNC(handleRecoveryPosition); [ARR_6(_medic,_patient,_bodyPart,_className,objNull,_usedItem)] call FUNC(treatmentAdvanced_airway););
     };
     class RemoveGuedeltubus: RemoveLarynxtubus {
         displayName = CSTRING(Cancel_Guedeltubus);
@@ -108,7 +108,7 @@ class ACE_Medical_Treatment_Actions {
         items[] = {};
         condition = QUOTE((!([_patient] call ACEFUNC(common,isAwake)) && (missionNamespace getVariable [ARR_2(QQGVAR(enable),true)]) && (_patient getVariable [ARR_2(QQGVAR(recovery),false)])));
         icon = "";
-        callbackSuccess = QFUNC(treatmentAdvanced_CancelRecoveryPosition);
+        callbackSuccess = QUOTE([ARR_2(_medic,_patient)] call FUNC(treatmentAdvanced_CancelRecoveryPosition));
         animationPatientUnconscious = "";
         animationPatientUnconsciousExcludeOn[] = {"ainjppnemstpsnonwrfldnon"};
     };

--- a/addons/airway/ACE_Medical_Treatment_Actions.hpp
+++ b/addons/airway/ACE_Medical_Treatment_Actions.hpp
@@ -12,7 +12,7 @@ class ACE_Medical_Treatment_Actions {
         condition = QUOTE(!([_patient] call ACEFUNC(common,isAwake)) && (missionNamespace getVariable [ARR_2(QQGVAR(enable),true)]) && !(_patient getVariable [ARR_2(QQGVAR(airway_item),'')] == 'Larynxtubus') && !(_patient getVariable [ARR_2(QQGVAR(airway_item),'')] == 'Guedeltubus'));
         callbackSuccess = QUOTE([ARR_3(_medic,_patient,(_patient getVariable [ARR_2(QQGVAR(occluded),false)]))] call FUNC(handleRecoveryPosition); [ARR_6(_medic,_patient,_bodyPart,_className,objNull,_usedItem)] call FUNC(treatmentAdvanced_airway););
         callbackFailure = "";
-        callbackProgress = "";
+        callbackProgress = QUOTE(!([(_args select 1)] call ACEFUNC(common,isAwake)) && !((_args select 1) getVariable [ARR_2(QQGVAR(airway_item),'')] == 'Larynxtubus') && !((_args select 1) getVariable [ARR_2(QQGVAR(airway_item),'')] == 'Guedeltubus'));
         consumeItem = 1;
         animationPatient = "";
         animationPatientUnconscious = "AinjPpneMstpSnonWrflDnon_rolltoback";
@@ -32,12 +32,12 @@ class ACE_Medical_Treatment_Actions {
         items[] = {};
         condition = QUOTE(!([_patient] call ACEFUNC(common,isAwake)) && (missionNamespace getVariable [ARR_2(QQGVAR(enable),true)]) && (_patient getVariable [ARR_2(QQGVAR(airway_item),'')] == 'Larynxtubus'));
         callbackSuccess = QFUNC(treatmentAdvanced_RemoveAirwayItem);
+        callbackProgress = "";
     };
     class Guedeltubus: Larynxtubus {
         displayName = CSTRING(Guedeltubus_Display);
         medicRequired = QGVAR(medLvl_Guedeltubus);
         treatmentTime = QGVAR(Guedeltubus_time);
-        condition = QUOTE(!([_patient] call ACEFUNC(common,isAwake)) && missionNamespace getVariable [ARR_2(QQGVAR(enable),true)] && !(_patient getVariable [ARR_2(QQGVAR(airway_item),'')] == 'Guedeltubus') && !(_patient getVariable [ARR_2(QQGVAR(airway_item),'')] == 'Larynxtubus'));
         items[] = {"kat_guedel"};
         icon = QPATHTOF(ui\guedel.paa);
         callbackSuccess = QUOTE([ARR_3(_medic,_patient,(_patient getVariable [ARR_2(QQGVAR(occluded),false)]))] call FUNC(handleRecoveryPosition); [ARR_6(_medic,_patient,_bodyPart,_className,objNull,_usedItem)] call FUNC(treatmentAdvanced_airway););
@@ -62,6 +62,7 @@ class ACE_Medical_Treatment_Actions {
         medicRequired = QGVAR(medLvl_Accuvac);
         callbackStart = QFUNC(treatmentAdvanced_AccuvacStart);
         callbackSuccess = QFUNC(treatmentAdvanced_accuvac);
+        callbackProgress = "";
         sounds[] = {{QPATHTO_R(sounds\accuvac.wav),6,1,15}};
     };
     class HyperextendHead: Larynxtubus {
@@ -73,6 +74,7 @@ class ACE_Medical_Treatment_Actions {
         icon = "";
         condition = QUOTE(!([_patient] call ACEFUNC(common,isAwake)) && !(_patient getVariable [ARR_2(QQGVAR(overstretch),false)]) && !(_patient getVariable [ARR_2(QQGVAR(recovery),false)]) && (missionNamespace getVariable [ARR_2(QQGVAR(enable),true)]) && !(_patient getVariable [ARR_2(QQGVAR(airway_item),'')] == 'Guedeltubus') && !(_patient getVariable [ARR_2(QQGVAR(airway_item),'')] == 'Larynxtubus'));
         callbackSuccess = QFUNC(treatmentAdvanced_hyperextendHead);
+        callbackProgress = QUOTE(!([(_args select 1)] call ACEFUNC(common,isAwake)) && !((_args select 1) getVariable [ARR_2(QQGVAR(overstretch),false)]) && !((_args select 1) getVariable [ARR_2(QQGVAR(recovery),false)]) && !((_args select 1) getVariable [ARR_2(QQGVAR(airway_item),'')] == 'Guedeltubus') && !((_args select 1) getVariable [ARR_2(QQGVAR(airway_item),'')] == 'Larynxtubus'));
     };
     class BeginHeadTurning: Larynxtubus {
         displayName = CSTRING(headTurning_begin);
@@ -83,6 +85,7 @@ class ACE_Medical_Treatment_Actions {
         icon = "";
         condition = QUOTE(!([_patient] call ACEFUNC(common,isAwake)) && (missionNamespace getVariable [ARR_2(QQGVAR(enable),true)]) && !(_patient getVariable [ARR_2(QQGVAR(recovery),false)]) && !(_patient getVariable [ARR_2(QQGVAR(airway_item),'')] == 'Larynxtubus') && (!(_patient getVariable [ARR_2(QQGVAR(airway_item),'')] == 'Guedeltubus') || !(missionNamespace getVariable [ARR_2(QQGVAR(block_headTurning_ifAirwayItem),true)])));
         callbackSuccess = QFUNC(startHeadTurning);
+        callbackProgress = "";
         sounds[] = {};
     };
     class RecoveryPosition: Larynxtubus {
@@ -93,9 +96,10 @@ class ACE_Medical_Treatment_Actions {
         allowedSelections[] = {"Body"};
         medicRequired = 0;
         items[] = {};
-        condition = QUOTE((!([_patient] call ACEFUNC(common,isAwake)) && (missionNamespace getVariable [ARR_2(QQGVAR(enable),true)]) && !(_patient getVariable [ARR_2(QQGVAR(recovery),false)])) && FUNC(checkRecovery));
+        condition = QUOTE((!([_patient] call ACEFUNC(common,isAwake)) && (missionNamespace getVariable [ARR_2(QQGVAR(enable),true)]) && !(_patient getVariable [ARR_2(QQGVAR(recovery),false)])) && [ARR_2(_medic,_patient)] call FUNC(checkRecovery));
         icon = "";
         callbackSuccess = QFUNC(treatmentAdvanced_RecoveryPosition);
+        callbackProgress = QUOTE(!([(_args select 1)] call ACEFUNC(common,isAwake) && !((_args select 1) getVariable [ARR_2(QQGVAR(recovery),false)])) && [ARR_2((_args select 0),(_args select 1))] call FUNC(checkRecovery));
         animationPatientUnconsciousExcludeOn[] = {"ainjppnemstpsnonwrfldnon", "kat_recoveryposition"};
     };
     class CancelRecoveryPosition: Larynxtubus {
@@ -106,9 +110,10 @@ class ACE_Medical_Treatment_Actions {
         allowedSelections[] = {"Body"};
         medicRequired = 0;
         items[] = {};
-        condition = QUOTE((!([_patient] call ACEFUNC(common,isAwake)) && (missionNamespace getVariable [ARR_2(QQGVAR(enable),true)]) && (_patient getVariable [ARR_2(QQGVAR(recovery),false)])));
+        condition = QUOTE(!([_patient] call ACEFUNC(common,isAwake)) && (missionNamespace getVariable [ARR_2(QQGVAR(enable),true)]) && (_patient getVariable [ARR_2(QQGVAR(recovery),false)]));
         icon = "";
         callbackSuccess = QUOTE([ARR_2(_medic,_patient)] call FUNC(treatmentAdvanced_CancelRecoveryPosition));
+        callbackProgress = QUOTE(!([(_args select 1)] call ACEFUNC(common,isAwake)) && ((_args select 1) getVariable [ARR_2(QQGVAR(recovery),false)]));
         animationPatientUnconscious = "";
         animationPatientUnconsciousExcludeOn[] = {"ainjppnemstpsnonwrfldnon"};
     };

--- a/addons/airway/XEH_PREP.hpp
+++ b/addons/airway/XEH_PREP.hpp
@@ -2,6 +2,7 @@ PREP(checkAirway);
 PREP(checkRecovery);
 PREP(handleAirway);
 PREP(handlePuking);
+PREP(handleRecoveryPosition);
 PREP(init);
 PREP(startHeadTurning);
 PREP(treatmentAdvanced_Accuvac);

--- a/addons/airway/XEH_PREP.hpp
+++ b/addons/airway/XEH_PREP.hpp
@@ -12,7 +12,7 @@ PREP(treatmentAdvanced_airway);
 PREP(treatmentAdvanced_airwayLocal);
 PREP(treatmentAdvanced_CancelRecoveryPosition);
 PREP(treatmentAdvanced_CancelRecoveryPositionLocal);
-PREP(treatmentAdvanced_overstretchHead);
+PREP(treatmentAdvanced_hyperextendHead);
 PREP(treatmentAdvanced_RecoveryPosition);
 PREP(treatmentAdvanced_RecoveryPositionLocal);
 PREP(treatmentAdvanced_RemoveAirwayItem);

--- a/addons/airway/XEH_postInit.sqf
+++ b/addons/airway/XEH_postInit.sqf
@@ -12,7 +12,7 @@ if !(GVAR(enable)) exitWith {};
 
 [QGVAR(airwayFeedback), {
     params ["_medic","_output"];
-    [_output, 1.5, _medic] call ACEFUNC(common,displayTextStructured);
+    [_output, 2, _medic] call ACEFUNC(common,displayTextStructured);
 }] call CBA_fnc_addEventHandler;
 
 ["ace_unconscious", {

--- a/addons/airway/XEH_preInit.sqf
+++ b/addons/airway/XEH_preInit.sqf
@@ -200,10 +200,10 @@ In real life, this will happen sometimes, not quiet often.
 
 // Settable action time for Head overstretching
 [
-    QGVAR(Overstretch_time),
+    QGVAR(Hyperextend_Time),
     "SLIDER",
-    [LLSTRING(TIME_OVERSTRETCH),LLSTRING(TIME_OVERSTRETCH_DESC)],
-    [CBA_SETTINGS_CAT, LSTRING(SubCategory_RecoveryPositionOverstretch)],
+    [LLSTRING(Hyperextend_Time), LLSTRING(Hyperextend_Time_DESC)],
+    [CBA_SETTINGS_CAT, LSTRING(SubCategory_RecoveryPositionHyperextend)],
     [1, 10, 3, 0],
     true
 ] call CBA_Settings_fnc_init;
@@ -212,9 +212,9 @@ In real life, this will happen sometimes, not quiet often.
 [
     QGVAR(RecoveryPosition_Time),
     "SLIDER",
-    [LLSTRING(TIME_RECOVERY),LLSTRING(TIME_RECOVERY_DESC)],
-    [CBA_SETTINGS_CAT, LSTRING(SubCategory_RecoveryPositionOverstretch)],
-    [1, 120, 6, 0],
+    [LLSTRING(SETTING_RecoveryPosition_Time), LLSTRING(SETTING_RecoveryPosition_Time_DESC)],
+    [CBA_SETTINGS_CAT, LSTRING(SubCategory_RecoveryPositionHyperextend)],
+    [1, 60, 6, 0],
     true
 ] call CBA_Settings_fnc_init;
 
@@ -222,9 +222,19 @@ In real life, this will happen sometimes, not quiet often.
 [
     QGVAR(CancelRecoveryPosition_Time),
     "SLIDER",
-    [LLSTRING(TIME_CANCELRECOVERY),LLSTRING(TIME_CANCELRECOVERY_DESC)],
-    [CBA_SETTINGS_CAT, LSTRING(SubCategory_RecoveryPositionOverstretch)],
-    [1, 120, 6, 0],
+    [LLSTRING(SETTING_CancelRecoveryPosition_Time), LLSTRING(SETTING_CancelRecoveryPosition_Time_DESC)],
+    [CBA_SETTINGS_CAT, LSTRING(SubCategory_RecoveryPositionHyperextend)],
+    [1, 60, 3, 0],
+    true
+] call CBA_Settings_fnc_init;
+
+// Settable maximum time required for occlusion to be cleared from patient in recovery position
+[
+    QGVAR(RecoveryPosition_TimeToDrain),
+    "SLIDER",
+    [LLSTRING(SETTING_RecoveryPosition_TimeToDrain), LLSTRING(SETTING_RecoveryPosition_TimeToDrain_DESC)],
+    [CBA_SETTINGS_CAT, LSTRING(SubCategory_RecoveryPositionHyperextend)],
+    [0, 30, 10, 0],
     true
 ] call CBA_Settings_fnc_init;
 

--- a/addons/airway/functions/fnc_checkAirway.sqf
+++ b/addons/airway/functions/fnc_checkAirway.sqf
@@ -18,31 +18,43 @@
 
 params ["_medic", "_patient"];
 
-private _messageairwayobstruction = LLSTRING(message_obstruction_no);
-private _messageairwayOccluded = LLSTRING(message_Occluded_no);
-private _obstruction = LSTRING(noObstruction);
-private _occluded = LSTRING(noOccluded);
+private _hintAirwayObstruction = LLSTRING(AirwayStatus_noObstruction);
+private _hintAirwayOcclusion = LLSTRING(AirwayStatus_noOcclusion);
+private _obstruction = LSTRING(AirwayStatus_noObstruction_short);
+private _occlusion = LSTRING(AirwayStatus_noOcclusion_short);
+
+private _hintWidth = 14;
+private _hintSize = 2;
 
 if (_patient getVariable [QGVAR(obstruction), false]) then {
-    _messageairwayobstruction = LLSTRING(message_obstruction_yes);
-    _obstruction = LSTRING(obstruction);
+    _hintWidth = 17;
+    _hintAirwayObstruction = LLSTRING(AirwayStatus_Obstruction);
+    _obstruction = LSTRING(AirwayStatus_Obstruction_short);
     if (_patient getVariable [QGVAR(overstretch), false]) then {
-        _messageairwayobstruction = LLSTRING(message_obstructionTemporarilyMitigated);
-        _obstruction = LLSTRING(mitigatedObstruction);
+        _hintAirwayObstruction = LLSTRING(AirwayStatus_mitigatedObstruction);
+        _obstruction = LLSTRING(AirwayStatus_mitigatedObstruction_short);
     };
     if (GVAR(autoTriage)) then {
         _patient setVariable [QACEGVAR(medical,triageLevel), 3, true];
     };
 };
 if (_patient getVariable [QGVAR(occluded), false]) then {
-    _messageairwayOccluded = LLSTRING(message_Occluded_yes);
-    _occluded = LSTRING(Occluded);
+    _hintAirwayOcclusion = LLSTRING(AirwayStatus_Occlusion);
+    _occlusion = LSTRING(AirwayStatus_Occlusion_short);
     if (GVAR(autoTriage)) then {
         _patient setVariable [QACEGVAR(medical,triageLevel), 3, true];
     };
 };
 if (!(_patient getVariable [QGVAR(occluded), false] && _patient getVariable [QGVAR(obstruction), false]) && GVAR(autoTriage)) then {_patient setVariable [QACEGVAR(medical,triageLevel), 0, true]};
-private _message = format ["%1, %2", _messageairwayobstruction, _messageairwayOccluded];
-[_message, 2, _medic] call ACEFUNC(common,displayTextStructured);
 
-[_patient, "activity", LSTRING(checkAirway_log), [[_medic] call ACEFUNC(common,getName), _obstruction, _occluded]] call ACEFUNC(medical_treatment,addToLog);
+private _message = format ["%1<br />%2", _hintAirwayObstruction, _hintAirwayOcclusion];
+
+if (!(_patient getVariable [QGVAR(occluded), false]) && !(_patient getVariable [QGVAR(obstruction), false])) then {
+    _message = LLSTRING(AirwayStatus_Clear);
+    _hintSize = 1.5;
+    _hintWidth = 10;
+};
+
+[_message, _hintSize, _medic, _hintWidth] call ACEFUNC(common,displayTextStructured);
+
+[_patient, "activity", LSTRING(checkAirway_log), [[_medic] call ACEFUNC(common,getName), _obstruction, _occlusion]] call ACEFUNC(medical_treatment,addToLog);

--- a/addons/airway/functions/fnc_handleRecoveryPosition.sqf
+++ b/addons/airway/functions/fnc_handleRecoveryPosition.sqf
@@ -6,6 +6,7 @@
  * Arguments:
  * 0: Medic <OBJECT>
  * 1: Patient <OBJECT>
+ * 2: Hint is delayed? <BOOL>
  *
  * Return Value:
  * None
@@ -16,8 +17,8 @@
  * Public: No
  */
 
-params ["_medic", "_patient"];
+params ["_medic", "_patient", ["_delayed", false]];
 
 if (_patient getVariable [QGVAR(recovery), false]) then {
-    [_medic, _patient] call FUNC(treatmentAdvanced_CancelRecoveryPosition);
+    [_medic, _patient, _delayed] call FUNC(treatmentAdvanced_CancelRecoveryPosition);
 };

--- a/addons/airway/functions/fnc_handleRecoveryPosition.sqf
+++ b/addons/airway/functions/fnc_handleRecoveryPosition.sqf
@@ -1,0 +1,23 @@
+#include "..\script_component.hpp"
+/*
+ * Author: Blue
+ * Handle cancelling recovery position if patient is in one
+ *
+ * Arguments:
+ * 0: Medic <OBJECT>
+ * 1: Patient <OBJECT>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [player, cursorTarget, false] call kat_airway_fnc_handleRecoveryPosition;
+ *
+ * Public: No
+ */
+
+params ["_medic", "_patient"];
+
+if (_patient getVariable [QGVAR(recovery), false]) then {
+    [_medic, _patient] call FUNC(treatmentAdvanced_CancelRecoveryPosition);
+};

--- a/addons/airway/functions/fnc_treatmentAdvanced_CancelRecoveryPosition.sqf
+++ b/addons/airway/functions/fnc_treatmentAdvanced_CancelRecoveryPosition.sqf
@@ -6,17 +6,20 @@
  * Arguments:
  * 0: Medic <OBJECT>
  * 1: Patient <OBJECT>
+ * 2: Hint is delayed? <BOOL>
  *
  * Return Value:
  * None
  *
  * Example:
- * [player, cursorTarget] call kat_airway_fnc_RecoveryPosition
+ * [player, cursorTarget] call kat_airway_fnc_treatmentAdvanced_CancelRecoveryPosition;
  *
  * Public: No
  */
 
-params ["_medic", "_patient"];
+params ["_medic", "_patient", ["_delayed", false]];
 
-[QGVAR(cancelRecoveryPositionLocal), [_medic, _patient], _patient] call CBA_fnc_targetEvent;
+[_patient, "activity", LSTRING(CancelRecoveryPosition_Log), [[_medic] call ACEFUNC(common,getName)]] call ACEFUNC(medical_treatment,addToLog);
+
+[QGVAR(cancelRecoveryPositionLocal), [_medic, _patient, _delayed], _patient] call CBA_fnc_targetEvent;
 [_patient, "ainjppnemstpsnonwrfldnon", 2] call ACEFUNC(common,doAnimation);

--- a/addons/airway/functions/fnc_treatmentAdvanced_CancelRecoveryPositionLocal.sqf
+++ b/addons/airway/functions/fnc_treatmentAdvanced_CancelRecoveryPositionLocal.sqf
@@ -6,21 +6,32 @@
  * Arguments:
  * 0: Medic <OBJECT>
  * 1: Patient <OBJECT>
+ * 2: Hint is delayed? <BOOL>
  *
  * Return Value:
  * None
  *
  * Example:
- * [player, cursorTarget] call kat_airway_fnc_CancelRecoveryPositionLocal
+ * [player, cursorTarget] call kat_airway_fnc_treatmentAdvanced_CancelRecoveryPositionLocal;
  *
  * Public: No
  */
 
-params ["_medic", "_patient"];
+params ["_medic", "_patient", ["_delayed", false]];
 
 _patient setVariable [QGVAR(recovery), false, true];
 _patient setVariable [QGVAR(overstretch), false, true];
+_patient setVariable [QGVAR(occluded), (_patient getVariable [QGVAR(wasOccluded), false]), true];
 _patient call FUNC(handlePuking);
 
 private _output = LLSTRING(RecoveryPosition_Cancel);
-[_output, 1.5, _medic] call ACEFUNC(common,displayTextStructured);
+
+if (_delayed) then {
+    [{
+        params ["_medic", "_output"];
+
+        [_output, 1.5, _medic] call ACEFUNC(common,displayTextStructured);
+    }, [_medic, _output], 2.5] call CBA_fnc_waitAndExecute;
+} else {
+    [_output, 1.5, _medic] call ACEFUNC(common,displayTextStructured);
+};

--- a/addons/airway/functions/fnc_treatmentAdvanced_CancelRecoveryPositionLocal.sqf
+++ b/addons/airway/functions/fnc_treatmentAdvanced_CancelRecoveryPositionLocal.sqf
@@ -22,5 +22,5 @@ _patient setVariable [QGVAR(recovery), false, true];
 _patient setVariable [QGVAR(overstretch), false, true];
 _patient call FUNC(handlePuking);
 
-private _output = LLSTRING(Recovery_Cancel);
+private _output = LLSTRING(RecoveryPosition_Cancel);
 [_output, 1.5, _medic] call ACEFUNC(common,displayTextStructured);

--- a/addons/airway/functions/fnc_treatmentAdvanced_RecoveryPosition.sqf
+++ b/addons/airway/functions/fnc_treatmentAdvanced_RecoveryPosition.sqf
@@ -11,7 +11,7 @@
  * None
  *
  * Example:
- * [player, cursorTarget] call kat_airway_fnc_RecoveryPosition
+ * [player, cursorTarget] call kat_airway_fnc_treatmentAdvanced_RecoveryPosition;
  *
  * Public: No
  */

--- a/addons/airway/functions/fnc_treatmentAdvanced_RecoveryPositionLocal.sqf
+++ b/addons/airway/functions/fnc_treatmentAdvanced_RecoveryPositionLocal.sqf
@@ -20,26 +20,44 @@ params ["_medic", "_patient"];
 
 _patient setVariable [QGVAR(recovery), true, true];
 _patient setVariable [QGVAR(overstretch), true, true];
-_patient setVariable [QGVAR(occluded), false, true];
 
 private _output = LLSTRING(Recovery_Info);
 [_output, 2, _medic] call ACEFUNC(common,displayTextStructured);
 
+GVAR(wasOccluded) = _patient getVariable [QGVAR(occluded), false];
+
+if (GVAR(RecoveryPosition_TimeToDrain) > 0) then {
+    [{
+        params ["_patient"];
+
+        _patient setVariable [QGVAR(occluded), false, true];
+        GVAR(wasOccluded) = false;
+    }, [_patient], (random GVAR(RecoveryPosition_TimeToDrain) max 1)] call CBA_fnc_waitAndExecute;
+} else {
+    _patient setVariable [QGVAR(occluded), false, true];
+    GVAR(wasOccluded) = false;
+};
+
 [{
     params ["_medic", "_patient"];
+
     _patient call ACEFUNC(medical_status,isBeingDragged) || _patient call ACEFUNC(medical_status,isBeingCarried) || !(isNull objectParent _patient);
 }, {
     params ["_medic", "_patient"];
+
     _patient setVariable [QGVAR(recovery), false, true];
     _patient setVariable [QGVAR(overstretch), false, true];
+    _patient setVariable [QGVAR(occluded), GVAR(wasOccluded), true];
 
-    _output = LLSTRING(Recovery_Cancel);
+    _output = LLSTRING(RecoveryPosition_Cancel);
     [_output, 1.5, _medic] call ACEFUNC(common,displayTextStructured);
-}, [_medic, _patient], 3600, {
+}, [_medic, _patient, _wasOccluded], 3600, {
     params ["_medic", "_patient"];
+
     _patient setVariable [QGVAR(recovery), false, true];
     _patient setVariable [QGVAR(overstretch), false, true];
+    _patient setVariable [QGVAR(occluded), GVAR(wasOccluded), true];
 
-    _output = LLSTRING(Recovery_Cancel);
+    _output = LLSTRING(RecoveryPosition_Cancel);
     [_output, 1.5, _medic] call ACEFUNC(common,displayTextStructured);
 }] call CBA_fnc_waitUntilAndExecute;

--- a/addons/airway/functions/fnc_treatmentAdvanced_RecoveryPositionLocal.sqf
+++ b/addons/airway/functions/fnc_treatmentAdvanced_RecoveryPositionLocal.sqf
@@ -21,12 +21,12 @@ params ["_medic", "_patient"];
 _patient setVariable [QGVAR(recovery), true, true];
 _patient setVariable [QGVAR(overstretch), true, true];
 
-private _output = LLSTRING(Recovery_Info);
+private _output = LLSTRING(RecoveryPosition_Ready);
 [_output, 2, _medic] call ACEFUNC(common,displayTextStructured);
 
 GVAR(wasOccluded) = _patient getVariable [QGVAR(occluded), false];
 
-if (GVAR(RecoveryPosition_TimeToDrain) > 0) then {
+if (GVAR(RecoveryPosition_TimeToDrain) > 0 && GVAR(wasOccluded)) then {
     [{
         params ["_patient"];
 
@@ -51,7 +51,7 @@ if (GVAR(RecoveryPosition_TimeToDrain) > 0) then {
 
     _output = LLSTRING(RecoveryPosition_Cancel);
     [_output, 1.5, _medic] call ACEFUNC(common,displayTextStructured);
-}, [_medic, _patient, _wasOccluded], 3600, {
+}, [_medic, _patient], 3600, {
     params ["_medic", "_patient"];
 
     _patient setVariable [QGVAR(recovery), false, true];

--- a/addons/airway/functions/fnc_treatmentAdvanced_RecoveryPositionLocal.sqf
+++ b/addons/airway/functions/fnc_treatmentAdvanced_RecoveryPositionLocal.sqf
@@ -11,7 +11,7 @@
  * None
  *
  * Example:
- * [player, cursorTarget] call kat_airway_fnc_RecoveryPositionLocal
+ * [player, cursorTarget] call kat_airway_fnc_treatmentAdvanced_RecoveryPositionLocal;
  *
  * Public: No
  */
@@ -24,40 +24,32 @@ _patient setVariable [QGVAR(overstretch), true, true];
 private _output = LLSTRING(RecoveryPosition_Ready);
 [_output, 2, _medic] call ACEFUNC(common,displayTextStructured);
 
-GVAR(wasOccluded) = _patient getVariable [QGVAR(occluded), false];
+_patient setVariable [QGVAR(wasOccluded), (_patient getVariable [QGVAR(occluded), false])];
 
 if (GVAR(RecoveryPosition_TimeToDrain) > 0 && GVAR(wasOccluded)) then {
     [{
         params ["_patient"];
 
         _patient setVariable [QGVAR(occluded), false, true];
-        GVAR(wasOccluded) = false;
+        _patient setVariable [QGVAR(wasOccluded), false];
     }, [_patient], (random GVAR(RecoveryPosition_TimeToDrain) max 1)] call CBA_fnc_waitAndExecute;
 } else {
     _patient setVariable [QGVAR(occluded), false, true];
-    GVAR(wasOccluded) = false;
+    _patient setVariable [QGVAR(wasOccluded), false];
 };
 
 [{
     params ["_medic", "_patient"];
 
-    _patient call ACEFUNC(medical_status,isBeingDragged) || _patient call ACEFUNC(medical_status,isBeingCarried) || !(isNull objectParent _patient);
+    _patient call ACEFUNC(medical_status,isBeingDragged) || _patient call ACEFUNC(medical_status,isBeingCarried) || !(_patient getVariable [QGVAR(recovery), false]) || !(isNull objectParent _patient);
 }, {
     params ["_medic", "_patient"];
 
-    _patient setVariable [QGVAR(recovery), false, true];
-    _patient setVariable [QGVAR(overstretch), false, true];
-    _patient setVariable [QGVAR(occluded), GVAR(wasOccluded), true];
-
-    _output = LLSTRING(RecoveryPosition_Cancel);
-    [_output, 1.5, _medic] call ACEFUNC(common,displayTextStructured);
-}, [_medic, _patient], 3600, {
-    params ["_medic", "_patient"];
+    if (_patient getVariable [QGVAR(recovery), false]) then {
+        [LLSTRING(RecoveryPosition_Cancel), 1.5, _medic] call ACEFUNC(common,displayTextStructured);
+    };
 
     _patient setVariable [QGVAR(recovery), false, true];
     _patient setVariable [QGVAR(overstretch), false, true];
-    _patient setVariable [QGVAR(occluded), GVAR(wasOccluded), true];
-
-    _output = LLSTRING(RecoveryPosition_Cancel);
-    [_output, 1.5, _medic] call ACEFUNC(common,displayTextStructured);
-}] call CBA_fnc_waitUntilAndExecute;
+    _patient setVariable [QGVAR(occluded), (_patient getVariable [QGVAR(wasOccluded), false]), true];
+}, [_medic, _patient], 3600, {}] call CBA_fnc_waitUntilAndExecute;

--- a/addons/airway/functions/fnc_treatmentAdvanced_airwayLocal.sqf
+++ b/addons/airway/functions/fnc_treatmentAdvanced_airwayLocal.sqf
@@ -21,7 +21,7 @@
 params ["_medic", "_patient","_classname", "_usedItem"];
 
 if (_patient getVariable [QGVAR(occluded), false]) exitWith {
-    [QGVAR(airwayFeedback), [_medic, LLSTRING(Airway_NotClearForItem)], _medic] call CBA_fnc_targetEvent;
+    [QGVAR(airwayFeedback), [_medic, LLSTRING(AirwayStatus_NotClearForItem)], _medic] call CBA_fnc_targetEvent;
     [_medic, _usedItem] call ACEFUNC(common,addToInventory);
 };
 

--- a/addons/airway/functions/fnc_treatmentAdvanced_hyperextendHead.sqf
+++ b/addons/airway/functions/fnc_treatmentAdvanced_hyperextendHead.sqf
@@ -19,18 +19,15 @@
 params ["_medic", "_patient"];
 
 if (_patient getVariable [QGVAR(overstretch), false]) exitWith {
-    private _output = LLSTRING(Hyperextend_already);
-    [_output, 2, _medic] call ACEFUNC(common,displayTextStructured);
+    [LLSTRING(Hyperextend_already), 1.5, _medic] call ACEFUNC(common,displayTextStructured);
 };
 if !(_patient getVariable [QGVAR(obstruction), false]) exitWith {
-    private _output = LLSTRING(AirwayStatus_Clear);
-    [_output, 2, _medic] call ACEFUNC(common,displayTextStructured);
+    [LLSTRING(AirwayStatus_noObstruction), 1.5, _medic] call ACEFUNC(common,displayTextStructured);
 };
 
 _patient setVariable [QGVAR(overstretch), true, true];
 
-private _output = LLSTRING(Hyperextend_Warning);
-[_output, 2, _medic] call ACEFUNC(common,displayTextStructured);
+[LLSTRING(Hyperextend_Ready), 1.5, _medic, 11] call ACEFUNC(common,displayTextStructured);
 
 [{
     params ["_medic", "_patient"];
@@ -39,12 +36,10 @@ private _output = LLSTRING(Hyperextend_Warning);
     params ["_medic", "_patient"];
     if (_patient getVariable [QGVAR(recovery), false]) exitWith {};
     _patient setVariable [QGVAR(overstretch), false, true];
-    _output = LLSTRING(Hyperextend_Cancel);
-    [_output, 1.5, _medic] call ACEFUNC(common,displayTextStructured);
+    [LLSTRING(Hyperextend_Cancel), 1.5, _medic] call ACEFUNC(common,displayTextStructured);
 }, [_medic, _patient], 3600, {
     params ["_medic", "_patient"];
     if (_patient getVariable [QGVAR(recovery), false]) exitWith {};
     _patient setVariable [QGVAR(overstretch), false, true];
-    _output = LLSTRING(Hyperextend_Cancel);
-    [_output, 1.5, _medic] call ACEFUNC(common,displayTextStructured);
+    [LLSTRING(Hyperextend_Cancel), 1.5, _medic] call ACEFUNC(common,displayTextStructured);
 }] call CBA_fnc_waitUntilAndExecute;

--- a/addons/airway/functions/fnc_treatmentAdvanced_hyperextendHead.sqf
+++ b/addons/airway/functions/fnc_treatmentAdvanced_hyperextendHead.sqf
@@ -11,7 +11,7 @@
  * Succesful treatment <BOOL>
  *
  * Example:
- * [player, cursorTarget] call kat_airway_fnc_treatmentAdvanced_overstretchHead;
+ * [player, cursorTarget] call kat_airway_fnc_treatmentAdvanced_hyperextendHead;
  *
  * Public: No
  */
@@ -19,17 +19,17 @@
 params ["_medic", "_patient"];
 
 if (_patient getVariable [QGVAR(overstretch), false]) exitWith {
-    private _output = LLSTRING(Airway_already);
+    private _output = LLSTRING(Hyperextend_already);
     [_output, 2, _medic] call ACEFUNC(common,displayTextStructured);
 };
 if !(_patient getVariable [QGVAR(obstruction), false]) exitWith {
-    private _output = LLSTRING(Airway_NA);
+    private _output = LLSTRING(AirwayStatus_Clear);
     [_output, 2, _medic] call ACEFUNC(common,displayTextStructured);
 };
 
 _patient setVariable [QGVAR(overstretch), true, true];
 
-private _output = LLSTRING(overstretch_info);
+private _output = LLSTRING(Hyperextend_Warning);
 [_output, 2, _medic] call ACEFUNC(common,displayTextStructured);
 
 [{
@@ -39,12 +39,12 @@ private _output = LLSTRING(overstretch_info);
     params ["_medic", "_patient"];
     if (_patient getVariable [QGVAR(recovery), false]) exitWith {};
     _patient setVariable [QGVAR(overstretch), false, true];
-    _output = LLSTRING(overstretch_cancel);
+    _output = LLSTRING(Hyperextend_Cancel);
     [_output, 1.5, _medic] call ACEFUNC(common,displayTextStructured);
 }, [_medic, _patient], 3600, {
     params ["_medic", "_patient"];
     if (_patient getVariable [QGVAR(recovery), false]) exitWith {};
     _patient setVariable [QGVAR(overstretch), false, true];
-    _output = LLSTRING(overstretch_cancel);
+    _output = LLSTRING(Hyperextend_Cancel);
     [_output, 1.5, _medic] call ACEFUNC(common,displayTextStructured);
 }] call CBA_fnc_waitUntilAndExecute;

--- a/addons/airway/stringtable.xml
+++ b/addons/airway/stringtable.xml
@@ -135,7 +135,7 @@
             <Norwegian>Felleskapet kalt "Keko" hadde en tilleggsfunksjon for AFK-spillere. De ble gjort bevisstløse slik at andre kunne dra dem bort. Dette utløste muligheter for luftveisproblemer. Denne strengen forhindrer at det skjer når de blir bevisstløse av det AFK-tillegget.</Norwegian>
         </Key>
         <Key ID="STR_KAT_Airway_checkAirway">
-            <English>Check Airways</English>
+            <English>Check Airway</English>
             <German>Überprüfe Atemwege</German>
             <Polish>Sprawdź drogi oddechowe</Polish>
             <Spanish>Comprobar vías aéreas</Spanish>
@@ -183,7 +183,7 @@
             <Portuguese>%1 intubou com %2</Portuguese>
             <Norwegian>%1 satte inn en %2.</Norwegian>
         </Key>
-        <Key ID="STR_KAT_Airway_Occluded">
+        <Key ID="STR_KAT_Airway_AirwayStatus_Occlusion_short">
             <English>Occluded</English>
             <German>Verstopft</German>
             <Polish>Zator</Polish>
@@ -200,7 +200,7 @@
             <Portuguese>Ocluída</Portuguese>
             <Norwegian>Okkludert</Norwegian>
         </Key>
-        <Key ID="STR_KAT_Airway_obstruction">
+        <Key ID="STR_KAT_Airway_AirwayStatus_Obstruction_short">
             <English>Obstruction</English>
             <German>Obstruktion</German>
             <Polish>Niedrożne</Polish>
@@ -217,7 +217,7 @@
             <Portuguese>Obstruída</Portuguese>
             <Norwegian>Obstruksjon</Norwegian>
         </Key>
-        <Key ID="STR_KAT_Airway_mitigatedObstruction">
+        <Key ID="STR_KAT_Airway_AirwayStatus_mitigatedObstruction_short">
             <English>Mitigated obstruction</English>
             <Polish>Ręcznie udrożnione</Polish>
             <Japanese>閉塞軽減中</Japanese>
@@ -231,7 +231,39 @@
             <Portuguese>Obstrução mitigada</Portuguese>
             <Norwegian>Reduserte obstruksjonen</Norwegian>
         </Key>
-        <Key ID="STR_KAT_Airway_message_obstructionTemporarilyMitigated">
+        <Key ID="STR_KAT_Airway_AirwayStatus_noObstruction_short">
+            <English>Not obstructed</English>
+            <German>Nicht obstruiert</German>
+            <Polish>Drożne</Polish>
+            <Spanish>No obstruída</Spanish>
+            <Chinese>無 阻塞</Chinese>
+            <Czech>Bez obstrukce</Czech>
+            <Korean>혀에 의해 막히지 않음</Korean>
+            <French>Non obstruées</French>
+            <Turkish>Değil Kapanma</Turkish>
+            <Italian>No ostruita</Italian>
+            <Japanese>閉塞無し</Japanese>
+            <Chinesesimp>无阻塞</Chinesesimp>
+            <Portuguese>Não obstruída</Portuguese>
+            <Norwegian>Ikke blokkert</Norwegian>
+        </Key>
+        <Key ID="STR_KAT_Airway_AirwayStatus_noOcclusion_short">
+            <English>Not occluded</English>
+            <German>Nicht verstopft</German>
+            <Polish>Brak zatoru</Polish>
+            <Spanish>No ocluída</Spanish>
+            <Chinese>無 閉塞</Chinese>
+            <Czech>Není ucpáno</Czech>
+            <Korean>구토에 의해 막히지 않음</Korean>
+            <French>Non occludées</French>
+            <Turkish>Değil Tıkalı</Turkish>
+            <Italian>No occlusa</Italian>
+            <Japanese>異物無し</Japanese>
+            <Chinesesimp>无闭塞</Chinesesimp>
+            <Portuguese>Não ocluída</Portuguese>
+            <Norwegian>Ikke okkludert</Norwegian>
+        </Key>
+        <Key ID="STR_KAT_Airway_AirwayStatus_mitigatedObstruction">
             <English>Obstruction is temporarily mitigated</English>
             <Polish>Drogi oddechowe są ręcznie udrożnione</Polish>
             <French>L'obstruction a été temporairement atténuée</French>
@@ -244,93 +276,20 @@
             <Portuguese>Obstrução temporariamente mitigada</Portuguese>
             <Norwegian>Obstruksjon er midlertidig redusert</Norwegian>
         </Key>
-        <Key ID="STR_KAT_Airway_message_obstruction_no">
-            <English>Airways are clear</English>
-            <German>Atemwege sind frei</German>
-            <Polish>Drogi oddechowe są czyste</Polish>
-            <Spanish>Vías aéreas despejadas</Spanish>
-            <Chinese>航線暢通</Chinese>
-            <Chinesesimp>气道通畅</Chinesesimp>
-            <Czech>Dýchací cesty jsou volné</Czech>
-            <Korean>기도 막히지 않음</Korean>
-            <French>Les voies aériennes sont dégagées</French>
-            <Turkish>Havayolları temiz</Turkish>
-            <Italian>Le vie aeree sono libere</Italian>
-            <Russian>Дыхательные пути чисты</Russian>
-            <Japanese>気道はクリアです</Japanese>
-            <Portuguese>Vias aéreas limpas</Portuguese>
-            <Norwegian>Luftveier er frie</Norwegian>
+        <Key ID="STR_KAT_Airway_AirwayStatus_noObstruction">
+            <English>Airway is not obstructed</English>
         </Key>
-        <Key ID="STR_KAT_Airway_message_Occluded_no">
-            <English>No medical suction needed</English>
-            <German>Absaugen nicht notwendig</German>
-            <Polish>Brak konieczności odsysania</Polish>
-            <Spanish>No se necesita succión médica</Spanish>
-            <Chinese>不需要醫療抽吸</Chinese>
-            <Chinesesimp>不需要医疗抽吸</Chinesesimp>
-            <Czech>Není třeba nic odsát</Czech>
-            <Korean>기도의 구토 제거 불필요</Korean>
-            <French>Pas d'aspiration médicale requise</French>
-            <Turkish>Tıbbi aspirasyona gerek yok</Turkish>
-            <Italian>Aspirazione medica non necessaria</Italian>
-            <Russian>Всасывание не требуется</Russian>
-            <Japanese>医療吸引は必要ありません</Japanese>
-            <Portuguese>Sucção médica não necessária</Portuguese>
-            <Norwegian>Ingen behov for medisinsk suging</Norwegian>
+        <Key ID="STR_KAT_Airway_AirwayStatus_noOcclusion">
+            <English>Airway is not occluded</English>
         </Key>
-        <Key ID="STR_KAT_Airway_message_obstruction_yes">
-            <English>Airway management needed</English>
-            <German>Atemwegsmanagement erforderlich</German>
-            <Polish>Potrzebne udrażnianie dróg oddechowych</Polish>
-            <Spanish>Hay que desobstruir las vías aéreas</Spanish>
-            <Chinese>需要呼吸道控制</Chinese>
-            <Chinesesimp>需要气道管理</Chinesesimp>
-            <Czech>Je třeba se postarat o dýchací cesty</Czech>
-            <Korean>기도 확보 필요</Korean>
-            <French>Gestion des voies aériennes requise</French>
-            <Turkish>Havayolu yönetimi gerekli</Turkish>
-            <Italian>Gestione delle vie aeree necessaria</Italian>
-            <Russian>Необходимо управление дыхательными путями</Russian>
-            <Japanese>気道管理が必要です</Japanese>
-            <Portuguese>Gerenciamento das vias aéreas necessário</Portuguese>
-            <Norwegian>Behov for luftveishåndtering</Norwegian>
+        <Key ID="STR_KAT_Airway_AirwayStatus_Obstruction">
+            <English>Airway is obstructed, airway management needed</English>
         </Key>
-        <Key ID="STR_KAT_Airway_message_Occluded_yes">
-            <English>Medical suction needed</English>
-            <German>Absaugen notwendig</German>
-            <Polish>Potrzebne odsysanie</Polish>
-            <Spanish>Requiere succión médica</Spanish>
-            <Chinese>需要醫療抽吸</Chinese>
-            <Chinesesimp>需要医疗抽吸</Chinesesimp>
-            <Czech>Je třeba odsávání</Czech>
-            <Korean>기도의 구토 제거 필요</Korean>
-            <French>Aspiration médicale requise</French>
-            <Turkish>Tıbbi aspirasyon gerekli</Turkish>
-            <Italian>Aspirazione medica necessaria</Italian>
-            <Russian>всасывание необходимо</Russian>
-            <Japanese>医療吸引が必要です</Japanese>
-            <Portuguese>Sucção médica necessária</Portuguese>
-            <Norwegian>Behov for medisinsk suging</Norwegian>
+        <Key ID="STR_KAT_Airway_AirwayStatus_Occlusion">
+            <English>Airway is occluded, medical suction needed</English>
         </Key>
-        <Key ID="STR_KAT_Airway_Airway_already">
-            <English>Airway management has already been performed</English>
-            <German>Atemwegsmanagement wurde bereits durchgeführt</German>
-            <Polish>Drogi oddechowe są udrażniane</Polish>
-            <Spanish>El manejo de vías aéreas ya se ha llevado a cabo</Spanish>
-            <Chinese>已經做好呼吸道控制</Chinese>
-            <Chinesesimp>气道管理已完成</Chinesesimp>
-            <Czech>Péče o dýchací cesty již byla provedena</Czech>
-            <Korean>이미 기도관리 완료됨</Korean>
-            <French>La gestion des voies aériennes a déjà été effectuée</French>
-            <Turkish>Havayolu yönetimi zaten gerçekleştirildi</Turkish>
-            <Italian>Gestione delle vie aeree già eseguita</Italian>
-            <Russian>Всасывание необходимо</Russian>
-            <Japanese>気道管理はすでに行われています</Japanese>
-            <Portuguese>O gerenciamento das vias aéreas já realizado</Portuguese>
-            <Norwegian>Luftveishåndtering er allerede utført</Norwegian>
-        </Key>
-        <Key ID="STR_KAT_Airway_Airway_NA">
-            <English>Airways are clear</English>
+        <Key ID="STR_KAT_Airway_AirwayStatus_Clear">
+            <English>Airway is clear</English>
             <German>Atemwege sind frei</German>
             <Polish>Drogi oddechowe są czyste</Polish>
             <Spanish>Las vías aéreas están despejadas</Spanish>
@@ -346,7 +305,7 @@
             <Portuguese>Vias aéreas limpas</Portuguese>
             <Norwegian>Luftveiene er frie</Norwegian>
         </Key>
-        <Key ID="STR_KAT_Airway_Airway_NotClearForItem">
+        <Key ID="STR_KAT_Airway_AirwayStatus_NotClearForItem">
             <English>Item could not be used, airways are not clear</English>
             <German>Gegenstand konnte nicht verwendet werden, Atemwege sind nicht frei</German>
             <Polish>Przedmiot nie może zostać użyty, drogi oddechowe nie są czyste</Polish>
@@ -363,7 +322,7 @@
             <Portuguese>O item não pôde ser usado, vias aéreas bloqueadas</Portuguese>
             <Norwegian>Gjenstanden kunne ikke brukes, luftveiene er ikke frie</Norwegian>
         </Key>
-        <Key ID="STR_KAT_Airway_overstretch">
+        <Key ID="STR_KAT_Airway_Hyperextend_diplayName">
             <English>Hyperextending Head</English>
             <German>Kopf überstrecken</German>
             <Polish>Odchyl głowę</Polish>
@@ -380,7 +339,7 @@
             <Portuguese>Hiperextensão de cabeça</Portuguese>
             <Norwegian>Hyperforlengelse av hode</Norwegian>
         </Key>
-        <Key ID="STR_KAT_Airway_overstretched">
+        <Key ID="STR_KAT_Airway_Hyperextended">
             <English>Hyperextended Head</English>
             <German>Kopf überstreckt</German>
             <Polish>Głowa odchylona</Polish>
@@ -397,7 +356,10 @@
             <Portuguese>Cabeça hiperestendida</Portuguese>
             <Norwegian>Hode er overekstendert</Norwegian>
         </Key>
-        <Key ID="STR_KAT_Airway_overstretching">
+        <Key ID="STR_KAT_Airway_Hyperextend_already">
+            <English>Patient's head is already hyperextended</English>
+        </Key>
+        <Key ID="STR_KAT_Airway_Hyperextend_progress">
             <English>Extending</English>
             <German>Kopf überstrecken</German>
             <Polish>Odchylanie głowy</Polish>
@@ -414,8 +376,8 @@
             <Portuguese>Estendendo</Portuguese>
             <Norwegian>Forlenger</Norwegian>
         </Key>
-        <Key ID="STR_KAT_Airway_overstretch_cancel">
-            <English>Hyperextending Head canceled</English>
+        <Key ID="STR_KAT_Airway_Hyperextend_Cancel">
+            <English>Hyperextending Head cancelled</English>
             <German>Kopf überstrecken abgebrochen</German>
             <Polish>Przestałeś odchylać głowę</Polish>
             <Spanish>Hiperextensión cancelada</Spanish>
@@ -431,22 +393,8 @@
             <Portuguese>Hiperextensão cancelada</Portuguese>
             <Norwegian>Hyperforlengelse av hode er avbrutt</Norwegian>
         </Key>
-        <Key ID="STR_KAT_Airway_overstretch_info">
-            <English>Don't run away, you're saving a life!</English>
-            <German>Renne nicht weg, du rettest ein Leben!</German>
-            <Polish>Nie uciekaj, ratujesz życie!</Polish>
-            <Spanish>¡No huyas, estás salvando una vida!</Spanish>
-            <Chinese>不要跑，你正在拯救性命！</Chinese>
-            <Chinesesimp>不要离开,你正在确保气道通畅</Chinesesimp>
-            <Czech>Nevzdaluj se od pacienta, zachraňuješ mu život!</Czech>
-            <Korean>도망치지 마십시오! 당신은 생명을 구하는 중입니다!</Korean>
-            <French>Ne partez pas, vous êtes en train de sauver une vie!</French>
-            <Turkish>Kaçma, bir hayat kurtarıyorsun!</Turkish>
-            <Italian>Non andartene, stai salvando una vita!</Italian>
-            <Russian>Не убегай, ты спасаешь жизнь!</Russian>
-            <Japanese>離れないでください、 あなたは命を繋いでいます!</Japanese>
-            <Portuguese>Não vá embora, você está salvando uma vida!</Portuguese>
-            <Norwegian>Ikke løp vekk, du redder et liv!</Norwegian>
+        <Key ID="STR_KAT_Airway_Hyperextend_Warning">
+            <English>Stay close to patient to keep head hyperextended</English>
         </Key>
         <Key ID="STR_KAT_Airway_headTurning_info">
             <English>Head turn performed, airways are still not clear</English>
@@ -581,7 +529,7 @@
             <Norwegian>Larynkstube</Norwegian>
         </Key>
         <Key ID="STR_KAT_Airway_Larynx_Desc_Short">
-            <English>The King LT is used to save the airways</English>
+            <English>The King LT is used to maintain the airway</English>
             <German>Der Larynxtubus ist ein Hilfsmittel zur Atemwegssicherung</German>
             <Polish>Rurka krtaniowa służy do ratowania dróg oddechowych</Polish>
             <Spanish>El tubo laríngeo previene obstrucciones y oclusiones</Spanish>
@@ -615,7 +563,7 @@
             <Norwegian>Guedel Tube</Norwegian>
         </Key>
         <Key ID="STR_KAT_Airway_Guedel_Desc_Short">
-            <English>The Guedel Tube is used to save the airways</English>
+            <English>The Guedel Tube is used to maintain the airway</English>
             <German>Der Guedeltubus ist ein Hilfsmittel zur Atemwegssicherung</German>
             <Polish>Rurka ustno-gardłowa zabezpiecza drogi oddechowe</Polish>
             <Spanish>La cánula de Guedel impide obstrucciones</Spanish>
@@ -802,7 +750,7 @@
             <Norwegian>Opplæringsnivået som kreves for å bruke en Accuvac</Norwegian>
         </Key>
         <Key ID="STR_KAT_Airway_TIME_CHECKAIRWAY">
-            <English>Time to check Airways</English>
+            <English>Time to check Airway</English>
             <German>Zeit um Atemwege zu prüfen</German>
             <Polish>Czas sprawdzenia dróg oddechowych</Polish>
             <Spanish>Tiempo para revisar las vías aéreas</Spanish>
@@ -819,7 +767,7 @@
             <Norwegian>Tid for å sjekke luftveiene</Norwegian>
         </Key>
         <Key ID="STR_KAT_Airway_TIME_CHECKAIRWAY_DESC">
-            <English>How long it will take to check Airways</English>
+            <English>How long it will take to check Airway</English>
             <German>Wie lange es dauert, um die Atemwege zu prüfen</German>
             <Polish>Ile czasu zajmie sprawdzenie dróg oddechowych</Polish>
             <Spanish>Cuánto tiempo tomará revisar las vías aéreas</Spanish>
@@ -1046,7 +994,7 @@
             <Portuguese>Estabelecendo posição de recuperação</Portuguese>
             <Norwegian>Legger i stabilt sideleie</Norwegian>
         </Key>
-        <Key ID="STR_KAT_Airway_Recovery_Info">
+        <Key ID="STR_KAT_Airway_RecoveryPosition_Ready">
             <English>Recovery position established successfully</English>
             <German>Erfolgreich in die stabile Seitenlage gelegt</German>
             <Polish>Pomyślnie ułożono w pozycji bezpiecznej</Polish>
@@ -1175,38 +1123,6 @@
         <Key ID="STR_KAT_Airway_SETTING_RecoveryPosition_TimeToDrain_DESC">
             <English>Maximum time required for patient in recovery position to be drained of occlusion.</English>
         </Key>
-        <Key ID="STR_KAT_Airway_noObstruction">
-            <English>Not obstructed</English>
-            <German>Nicht obstruiert</German>
-            <Polish>Drożne</Polish>
-            <Spanish>No obstruída</Spanish>
-            <Chinese>無 阻塞</Chinese>
-            <Czech>Bez obstrukce</Czech>
-            <Korean>혀에 의해 막히지 않음</Korean>
-            <French>Non obstruées</French>
-            <Turkish>Değil Kapanma</Turkish>
-            <Italian>No ostruita</Italian>
-            <Japanese>閉塞無し</Japanese>
-            <Chinesesimp>无阻塞</Chinesesimp>
-            <Portuguese>Não obstruída</Portuguese>
-            <Norwegian>Ikke blokkert</Norwegian>
-        </Key>
-        <Key ID="STR_KAT_Airway_noOccluded">
-            <English>Not occluded</English>
-            <German>Nicht verstopft</German>
-            <Polish>Brak zatoru</Polish>
-            <Spanish>No ocluída</Spanish>
-            <Chinese>無 閉塞</Chinese>
-            <Czech>Není ucpáno</Czech>
-            <Korean>구토에 의해 막히지 않음</Korean>
-            <French>Non occludées</French>
-            <Turkish>Değil Tıkalı</Turkish>
-            <Italian>No occlusa</Italian>
-            <Japanese>異物無し</Japanese>
-            <Chinesesimp>无闭塞</Chinesesimp>
-            <Portuguese>Não ocluída</Portuguese>
-            <Norwegian>Ikke okkludert</Norwegian>
-        </Key>
         <Key ID="STR_KAT_Airway_SubCategory_RecoveryPositionHyperextend">
             <English>Recovery Position + Head Hyperextend Settings</English>
         </Key>
@@ -1309,7 +1225,7 @@
             <Portuguese>%1 removeu a Cânula de Guedel</Portuguese>
         </Key>
         <Key ID="STR_KAT_Airway_AutoTriage">
-            <English>Auto Triage Airways</English>
+            <English>Auto Triage Airway</English>
             <Japanese>気道状態による自動トリアージ</Japanese>
             <German>Auto Triage Atemwege</German>
             <French>Triage automatique des voies aériennes</French>

--- a/addons/airway/stringtable.xml
+++ b/addons/airway/stringtable.xml
@@ -835,7 +835,7 @@
             <Portuguese>Quanto tempo levará para verificar as vias aéreas</Portuguese>
             <Norwegian>Hvor lang tid det vil ta å sjekke luftveiene</Norwegian>
         </Key>
-        <Key ID="STR_KAT_Airway_TIME_OVERSTRETCH">
+        <Key ID="STR_KAT_Airway_Hyperextend_Time">
             <English>Time for overstretch the head</English>
             <German>Zeit um den Kopf zu überstrecken</German>
             <Polish>Czas na odchylenie głowy</Polish>
@@ -852,7 +852,7 @@
             <Portuguese>Tempo para hiperestender a cabeça</Portuguese>
             <Norwegian>Tid for å overstrekke hode</Norwegian>
         </Key>
-        <Key ID="STR_KAT_Airway_TIME_OVERSTRETCH_DESC">
+        <Key ID="STR_KAT_Airway_Hyperextend_Time_DESC">
             <English>How long it will take to overstretch the head</English>
             <German>Wie lange es dauert, um den Kopf zu überstrecken</German>
             <Polish>Ile czasu zajmie odchylenie głowy</Polish>
@@ -1061,7 +1061,7 @@
             <Portuguese>Posição de recuperação estabelecida com sucesso</Portuguese>
             <Norwegian>Lagt i stabilt sideleie</Norwegian>
         </Key>
-        <Key ID="STR_KAT_Airway_Recovery_Cancel">
+        <Key ID="STR_KAT_Airway_RecoveryPosition_Cancel">
             <English>Recovery position cancelled</English>
             <German>Stabile Seitenlage abgebrochen</German>
             <Polish>Przerwano pozycję bezpieczną</Polish>
@@ -1091,7 +1091,7 @@
             <Portuguese>%1 estabeleceu a posição de recuperação</Portuguese>
             <Norwegian>%1 la dem i stabilt sideleie</Norwegian>
         </Key>
-        <Key ID="STR_KAT_Airway_TIME_RECOVERY">
+        <Key ID="STR_KAT_Airway_SETTING_RecoveryPosition_Time">
             <English>Time for recovery position</English>
             <German>Zeit für die stabile Seitenlage</German>
             <Polish>Czas na ułożenie w pozycji bezpiecznej</Polish>
@@ -1106,7 +1106,7 @@
             <Portuguese>Tempo para estabelecer a posição de recuperação</Portuguese>
             <Norwegian>Tid for å legge i stabilt sideleie</Norwegian>
         </Key>
-        <Key ID="STR_KAT_Airway_TIME_RECOVERY_DESC">
+        <Key ID="STR_KAT_Airway_SETTING_RecoveryPosition_Time_DESC">
             <English>How long it will take to establish recovery position</English>
             <German>Die Zeit, wie lange es dauert, eine erfolgreiche stabile Seitenlage durchzuführen</German>
             <Polish>Jak długo potrwa ułożenie w pozycji bocznej bezpiecznej</Polish>
@@ -1151,7 +1151,7 @@
             <Portuguese>Cancelando posição de recuperação</Portuguese>
             <Norwegian>Avbrytter stabilt sideleie</Norwegian>
         </Key>
-        <Key ID="STR_KAT_Airway_TIME_CANCELRECOVERY">
+        <Key ID="STR_KAT_Airway_SETTING_CancelRecoveryPosition_Time">
             <English>Time for cancelling recovery position</English>
             <German>Die Zeit, wie lange es dauert, eine stabile Seitenlage abzubrechen</German>
             <Polish>Czas na przerwanie pozycji bezpiecznej</Polish>
@@ -1166,20 +1166,14 @@
             <Portuguese>Tempo para cancelamento de posição de recuperação</Portuguese>
             <Norwegian>Tid for å avbryte stabilt sideleie</Norwegian>
         </Key>
-        <Key ID="STR_KAT_Airway_TIME_CANCELRECOVERY_DESC">
-            <English>How long it will take to establish recovery position</English>
-            <German>Die Zeit, wie lange es dauert, eine stabile Seitenlage abzubrechen</German>
-            <Polish>Jak długo potrwa przerwanie pozycji bocznej bezpiecznej</Polish>
-            <Chinesesimp>取消恢复体态的所需时间</Chinesesimp>
-            <Japanese>回復体位を崩すのにどのくらい時間がかかるか設定します</Japanese>
-            <Korean>회복자세 교정을 취소하는 데 걸리는 시간입니다</Korean>
-            <French>Temps nécessaire pour annuler la position latérale de sécurité</French>
-            <Turkish>Kurtarma pozisyonunun oluşturulması ne kadar sürer?</Turkish>
-            <Italian>Tempo necessario per annullare la posizione laterale di sicurezza </Italian>
-            <Czech>Jak dlouho potrvá zavést stabilizovanou polohu</Czech>
-            <Spanish>Cuanto tiempo tomará cancelar la posición lateral de seguridad</Spanish>
-            <Portuguese>Quanto tempo demora para cancelar a posição de recuperação</Portuguese>
-            <Norwegian>Hvor lang tid vil det ta for å legge i stabilt sideleie</Norwegian>
+        <Key ID="STR_KAT_Airway_SETTING_CancelRecoveryPosition_Time_DESC">
+            <English>How long it will take to manually cancel recovery position</English>
+        </Key>
+        <Key ID="STR_KAT_Airway_SETTING_RecoveryPosition_TimeToDrain">
+            <English>Recovery Position time to drain occlusion</English>
+        </Key>
+        <Key ID="STR_KAT_Airway_SETTING_RecoveryPosition_TimeToDrain_DESC">
+            <English>Maximum time required for patient in recovery position to be drained of occlusion.</English>
         </Key>
         <Key ID="STR_KAT_Airway_noObstruction">
             <English>Not obstructed</English>
@@ -1213,19 +1207,8 @@
             <Portuguese>Não ocluída</Portuguese>
             <Norwegian>Ikke okkludert</Norwegian>
         </Key>
-        <Key ID="STR_KAT_Airway_SubCategory_RecoveryPositionOverstretch">
-            <English>Recovery position + Overstretch Settings</English>
-            <Italian>Impostazioni posizione laterale di sicurezza e stiramento</Italian>
-            <Czech>Nastavení stabilizované polohy a narovnávání hlavy</Czech>
-            <French>Paramètres de position latérale de sécurité + hyperextension</French>
-            <Korean>회복 자세 + 머리 젖히기 설정</Korean>
-            <German>Einstellungen der stabilen Seitenlage + Überstreckung</German>
-            <Chinesesimp>恢复体态设置</Chinesesimp>
-            <Japanese>回復体位設定</Japanese>
-            <Spanish>Parámetros de posición lateral de seguridad e hiperextensión de cabeza</Spanish>
-            <Portuguese>Configurações de posição de recuperação + hiperextensão de cabeça</Portuguese>
-            <Polish>Ustawienia Pozycji bezpiecznej i Odchylania głowy</Polish>
-            <Norwegian>Instillinger for stabilt sideleie + Overstrekk</Norwegian>
+        <Key ID="STR_KAT_Airway_SubCategory_RecoveryPositionHyperextend">
+            <English>Recovery Position + Head Hyperextend Settings</English>
         </Key>
         <Key ID="STR_KAT_Airway_SubCategory_Items">
             <English>Airway items Settings</English>

--- a/addons/airway/stringtable.xml
+++ b/addons/airway/stringtable.xml
@@ -360,7 +360,7 @@
             <English>Patient's head is already hyperextended</English>
         </Key>
         <Key ID="STR_KAT_Airway_Hyperextend_progress">
-            <English>Extending</English>
+            <English>Hyperextending head</English>
             <German>Kopf überstrecken</German>
             <Polish>Odchylanie głowy</Polish>
             <Spanish>Hiperextendiendo cabeza</Spanish>
@@ -377,7 +377,7 @@
             <Norwegian>Forlenger</Norwegian>
         </Key>
         <Key ID="STR_KAT_Airway_Hyperextend_Cancel">
-            <English>Hyperextending Head cancelled</English>
+            <English>Hyperextending head cancelled</English>
             <German>Kopf überstrecken abgebrochen</German>
             <Polish>Przestałeś odchylać głowę</Polish>
             <Spanish>Hiperextensión cancelada</Spanish>
@@ -393,8 +393,8 @@
             <Portuguese>Hiperextensão cancelada</Portuguese>
             <Norwegian>Hyperforlengelse av hode er avbrutt</Norwegian>
         </Key>
-        <Key ID="STR_KAT_Airway_Hyperextend_Warning">
-            <English>Stay close to patient to keep head hyperextended</English>
+        <Key ID="STR_KAT_Airway_Hyperextend_Ready">
+            <English>Head hyperextended successfully</English>
         </Key>
         <Key ID="STR_KAT_Airway_headTurning_info">
             <English>Head turn performed, airways are still not clear</English>

--- a/addons/airway/stringtable.xml
+++ b/addons/airway/stringtable.xml
@@ -1039,6 +1039,9 @@
             <Portuguese>%1 estabeleceu a posição de recuperação</Portuguese>
             <Norwegian>%1 la dem i stabilt sideleie</Norwegian>
         </Key>
+        <Key ID="STR_KAT_Airway_CancelRecoveryPosition_Log">
+            <English>%1 cancelled recovery position</English>
+        </Key>
         <Key ID="STR_KAT_Airway_SETTING_RecoveryPosition_Time">
             <English>Time for recovery position</English>
             <German>Zeit für die stabile Seitenlage</German>

--- a/addons/breathing/ACE_Medical_Treatment_Actions.hpp
+++ b/addons/breathing/ACE_Medical_Treatment_Actions.hpp
@@ -9,7 +9,7 @@ class ACE_Medical_Treatment_Actions {
         category = "airway";
         medicRequired = 0;
         consumeItem = 0;
-        callbackStart = QUOTE(_medic setVariable [ARR_3(QQGVAR(usingStethoscope),true,true)]; [ARR_2(_medic,_patient)] spawn FUNC(listenLungs));
+        callbackStart = QUOTE(_medic setVariable [ARR_3(QQGVAR(usingStethoscope),true,true)]; [ARR_2(_medic,_patient)] call FUNC(listenLungs));
         callbackSuccess = QUOTE(_medic setVariable [ARR_3(QQGVAR(usingStethoscope),false,true)]);
         callbackProgress = "";
         callbackFailure = QUOTE(_medic setVariable [ARR_3(QQGVAR(usingStethoscope),false,true)]);
@@ -44,8 +44,8 @@ class ACE_Medical_Treatment_Actions {
         allowedSelections[] = {"Body"};
         allowSelfTreatment = 0;
         medicRequired = QGVAR(inspectChest_medLvl);
-        callbackSuccess = QFUNC(inspectChest);
-        condition = QUOTE(!([_patient] call ACEFUNC(common,isAwake)) && !(_patient getVariable [ARR_2(QQEGVAR(airway,recovery),false)]) && (missionNamespace getVariable [ARR_2(QQGVAR(enable),true)]) && (missionNamespace getVariable [ARR_2(QQGVAR(inspectChest_enable),0)] > 0));
+        condition = QUOTE(!([_patient] call ACEFUNC(common,isAwake)) && (missionNamespace getVariable [ARR_2(QQGVAR(enable),true)]) && (missionNamespace getVariable [ARR_2(QQGVAR(inspectChest_enable),0)] > 0));
+        callbackSuccess = QUOTE([ARR_2(_medic,_patient)] call FUNC(inspectChest); [ARR_2(_medic,_patient)] call EFUNC(airway,handleRecoveryPosition););
         animationPatientUnconscious = "AinjPpneMstpSnonWrflDnon_rolltoback";
         animationPatientUnconsciousExcludeOn[] = {"ainjppnemstpsnonwrfldnon"};
         animationMedic = "AinvPknlMstpSnonWnonDr_medic4";
@@ -108,8 +108,8 @@ class ACE_Medical_Treatment_Actions {
         medicRequired = QGVAR(medLvl_Chestseal);
         treatmentTime = 7;
         items[] = {"kat_chestSeal"};
-        condition = QUOTE(!(_patient getVariable [ARR_2(QQEGVAR(airway,recovery),false)]));
-        callbackSuccess = QFUNC(treatmentAdvanced_chestSeal);
+        condition = "true";
+        callbackSuccess = QUOTE([ARR_6(_medic,_patient,_bodyPart,_className,objNull,_usedItem)] call FUNC(treatmentAdvanced_chestSeal); [ARR_2(_medic,_patient)] call EFUNC(airway,handleRecoveryPosition););
         callbackFailure = "";
         callbackProgress = "";
         consumeItem = 1;
@@ -132,8 +132,8 @@ class ACE_Medical_Treatment_Actions {
         medicRequired = QGVAR(medLvl_hemopneumothoraxTreatment);
         treatmentTime = 7;
         items[] = {"kat_aatKit"};
-        condition = QUOTE(!(_patient getVariable [ARR_2(QQEGVAR(airway,recovery),false)]));
-        callbackSuccess = QFUNC(treatmentAdvanced_hemopneumothorax);
+        condition = "true";
+        callbackSuccess = QUOTE([ARR_6(_medic,_patient,_bodyPart,_className,objNull,_usedItem)] call FUNC(treatmentAdvanced_hemopneumothorax); [ARR_2(_medic,_patient)] call EFUNC(airway,handleRecoveryPosition););
         callbackFailure = "";
         callbackProgress = "";
         consumeItem = 1;
@@ -156,8 +156,8 @@ class ACE_Medical_Treatment_Actions {
         medicRequired = QGVAR(medLvl_hemopneumothoraxTreatment);
         treatmentTime = 7;
         items[] = {"kat_aatKit"};
-        condition = QUOTE(!(_patient getVariable [ARR_2(QQEGVAR(airway,recovery),false)]));
-        callbackSuccess = QFUNC(treatmentAdvanced_tensionpneumothorax);
+        condition = "true";
+        callbackSuccess = QUOTE([ARR_6(_medic,_patient,_bodyPart,_className,objNull,_usedItem)] call FUNC(treatmentAdvanced_tensionpneumothorax); [ARR_2(_medic,_patient)] call EFUNC(airway,handleRecoveryPosition););
         callbackFailure = "";
         callbackProgress = "";
         consumeItem = 1;
@@ -180,8 +180,8 @@ class ACE_Medical_Treatment_Actions {
         medicRequired = QGVAR(medLvl_hemopneumothoraxTreatment);
         treatmentTime = 7;
         items[] = {"kat_ncdKit"};
-        condition = QUOTE(!(_patient getVariable [ARR_2(QQEGVAR(airway,recovery),false)]));
-        callbackSuccess = QFUNC(treatmentAdvanced_tensionpneumothorax);
+        condition = "true";
+        callbackSuccess = QUOTE([ARR_6(_medic,_patient,_bodyPart,_className,objNull,_usedItem)] call FUNC(treatmentAdvanced_tensionpneumothorax); [ARR_2(_medic,_patient)] call EFUNC(airway,handleRecoveryPosition););
         callbackFailure = "";
         callbackProgress = "";
         consumeItem = 1;
@@ -231,7 +231,7 @@ class ACE_Medical_Treatment_Actions {
         items[] = {"kat_BVM"};
         condition = QUOTE(_patient call FUNC(canUseBVM));
         callbackStart = "";
-        callbackSuccess = QUOTE([ARR_2(_medic,_patient)] call FUNC(useBVM));
+        callbackSuccess = QUOTE([ARR_2(_medic,_patient)] call FUNC(useBVM); [ARR_2(_medic,_patient)] call EFUNC(airway,handleRecoveryPosition););
         callbackFailure = "";
         callbackProgress = "";
         animationPatient = "";
@@ -247,27 +247,27 @@ class ACE_Medical_Treatment_Actions {
         medicRequired = QGVAR(medLvl_PocketBVM);
         items[] = {"kat_pocketBVM"};
         condition = QUOTE(_patient call FUNC(canUseBVM));
-        callbackSuccess = QUOTE([ARR_4(_medic,_patient,true,false)] call FUNC(useBVM));
+        callbackSuccess = QUOTE([ARR_4(_medic,_patient,true,false)] call FUNC(useBVM); [ARR_2(_medic,_patient)] call EFUNC(airway,handleRecoveryPosition););
     };
     class UseBVMPortableOxygen: UseBVM {
         displayName = CSTRING(UseBVM_PortableOxygen);
         medicRequired = QGVAR(medLvl_BVM_Oxygen);
         items[] = {"kat_BVM"};
         condition = QUOTE(_patient call FUNC(canUseBVM) && _medic call FUNC(hasOxygenTank) && (GVAR(locationProvideOxygen) isEqualTo 0 || !((GVAR(locationProvideOxygen) in [ARR_2(2,3)] && _patient call ACEFUNC(medical_treatment,isInMedicalFacility)) || ((GVAR(locationProvideOxygen) in [ARR_2(1,3)] && _patient call ACEFUNC(medical_treatment,isInMedicalVehicle))))));
-        callbackSuccess = QUOTE([ARR_5(_medic,_patient,false,true,1)] call FUNC(useBVM));
+        callbackSuccess = QUOTE([ARR_5(_medic,_patient,false,true,1)] call FUNC(useBVM); [ARR_2(_medic,_patient)] call EFUNC(airway,handleRecoveryPosition););
     };
     class UseBVMPortableOxygenVehicle: UseBVM {
         displayName = CSTRING(UseBVM_PortableOxygen_Vehicle);
         medicRequired = QGVAR(medLvl_BVM_Oxygen);
         items[] = {"kat_BVM"};
         condition = QUOTE(_patient call FUNC(canUseBVM) && [ARR_2((vehicle _medic),true)] call FUNC(hasOxygenTank) && ((vehicle _medic) != _medic) && (vehicle _medic) isEqualTo (vehicle _patient));
-        callbackSuccess = QUOTE([ARR_5(_medic,_patient,false,true,2)] call FUNC(useBVM));
+        callbackSuccess = QUOTE([ARR_5(_medic,_patient,false,true,2)] call FUNC(useBVM); [ARR_2(_medic,_patient)] call EFUNC(airway,handleRecoveryPosition););
     };
     class UseBVMOxygen: UseBVM {
         displayName = CSTRING(UseBVM_Oxygen);
         medicRequired = QGVAR(medLvl_BVM_Oxygen);
         items[] = {"kat_BVM"};
         condition = QUOTE(_patient call FUNC(canUseBVM) && ((GVAR(locationProvideOxygen) in [ARR_2(2,3)] && _patient call ACEFUNC(medical_treatment,isInMedicalFacility)) || (GVAR(locationProvideOxygen) in [ARR_2(1,3)] && _patient call ACEFUNC(medical_treatment,isInMedicalVehicle))));
-        callbackSuccess = QUOTE([ARR_4(_medic,_patient,false,true)] call FUNC(useBVM));
+        callbackSuccess = QUOTE([ARR_4(_medic,_patient,false,true)] call FUNC(useBVM); [ARR_2(_medic,_patient)] call EFUNC(airway,handleRecoveryPosition););
     };
 };

--- a/addons/breathing/ACE_Medical_Treatment_Actions.hpp
+++ b/addons/breathing/ACE_Medical_Treatment_Actions.hpp
@@ -45,7 +45,7 @@ class ACE_Medical_Treatment_Actions {
         allowSelfTreatment = 0;
         medicRequired = QGVAR(inspectChest_medLvl);
         condition = QUOTE(!([_patient] call ACEFUNC(common,isAwake)) && (missionNamespace getVariable [ARR_2(QQGVAR(enable),true)]) && (missionNamespace getVariable [ARR_2(QQGVAR(inspectChest_enable),0)] > 0));
-        callbackSuccess = QUOTE([ARR_2(_medic,_patient)] call FUNC(inspectChest); [ARR_2(_medic,_patient)] call EFUNC(airway,handleRecoveryPosition););
+        callbackSuccess = QUOTE([ARR_3(_medic,_patient,true)] call EFUNC(airway,handleRecoveryPosition); [ARR_2(_medic,_patient)] call FUNC(inspectChest););
         animationPatientUnconscious = "AinjPpneMstpSnonWrflDnon_rolltoback";
         animationPatientUnconsciousExcludeOn[] = {"ainjppnemstpsnonwrfldnon"};
         animationMedic = "AinvPknlMstpSnonWnonDr_medic4";
@@ -109,7 +109,7 @@ class ACE_Medical_Treatment_Actions {
         treatmentTime = 7;
         items[] = {"kat_chestSeal"};
         condition = "true";
-        callbackSuccess = QUOTE([ARR_6(_medic,_patient,_bodyPart,_className,objNull,_usedItem)] call FUNC(treatmentAdvanced_chestSeal); [ARR_2(_medic,_patient)] call EFUNC(airway,handleRecoveryPosition););
+        callbackSuccess = QUOTE([ARR_2(_medic,_patient)] call EFUNC(airway,handleRecoveryPosition); [ARR_6(_medic,_patient,_bodyPart,_className,objNull,_usedItem)] call FUNC(treatmentAdvanced_chestSeal););
         callbackFailure = "";
         callbackProgress = "";
         consumeItem = 1;
@@ -133,7 +133,7 @@ class ACE_Medical_Treatment_Actions {
         treatmentTime = 7;
         items[] = {"kat_aatKit"};
         condition = "true";
-        callbackSuccess = QUOTE([ARR_6(_medic,_patient,_bodyPart,_className,objNull,_usedItem)] call FUNC(treatmentAdvanced_hemopneumothorax); [ARR_2(_medic,_patient)] call EFUNC(airway,handleRecoveryPosition););
+        callbackSuccess = QUOTE([ARR_2(_medic,_patient)] call EFUNC(airway,handleRecoveryPosition); [ARR_6(_medic,_patient,_bodyPart,_className,objNull,_usedItem)] call FUNC(treatmentAdvanced_hemopneumothorax););
         callbackFailure = "";
         callbackProgress = "";
         consumeItem = 1;
@@ -157,7 +157,7 @@ class ACE_Medical_Treatment_Actions {
         treatmentTime = 7;
         items[] = {"kat_aatKit"};
         condition = "true";
-        callbackSuccess = QUOTE([ARR_6(_medic,_patient,_bodyPart,_className,objNull,_usedItem)] call FUNC(treatmentAdvanced_tensionpneumothorax); [ARR_2(_medic,_patient)] call EFUNC(airway,handleRecoveryPosition););
+        callbackSuccess = QUOTE([ARR_2(_medic,_patient)] call EFUNC(airway,handleRecoveryPosition); [ARR_6(_medic,_patient,_bodyPart,_className,objNull,_usedItem)] call FUNC(treatmentAdvanced_tensionpneumothorax););
         callbackFailure = "";
         callbackProgress = "";
         consumeItem = 1;
@@ -181,7 +181,7 @@ class ACE_Medical_Treatment_Actions {
         treatmentTime = 7;
         items[] = {"kat_ncdKit"};
         condition = "true";
-        callbackSuccess = QUOTE([ARR_6(_medic,_patient,_bodyPart,_className,objNull,_usedItem)] call FUNC(treatmentAdvanced_tensionpneumothorax); [ARR_2(_medic,_patient)] call EFUNC(airway,handleRecoveryPosition););
+        callbackSuccess = QUOTE([ARR_2(_medic,_patient)] call EFUNC(airway,handleRecoveryPosition); [ARR_6(_medic,_patient,_bodyPart,_className,objNull,_usedItem)] call FUNC(treatmentAdvanced_tensionpneumothorax););
         callbackFailure = "";
         callbackProgress = "";
         consumeItem = 1;
@@ -231,7 +231,7 @@ class ACE_Medical_Treatment_Actions {
         items[] = {"kat_BVM"};
         condition = QUOTE(_patient call FUNC(canUseBVM));
         callbackStart = "";
-        callbackSuccess = QUOTE([ARR_2(_medic,_patient)] call FUNC(useBVM); [ARR_2(_medic,_patient)] call EFUNC(airway,handleRecoveryPosition););
+        callbackSuccess = QUOTE([ARR_3(_medic,_patient,true)] call EFUNC(airway,handleRecoveryPosition); [ARR_2(_medic,_patient)] call FUNC(useBVM););
         callbackFailure = "";
         callbackProgress = "";
         animationPatient = "";
@@ -247,27 +247,27 @@ class ACE_Medical_Treatment_Actions {
         medicRequired = QGVAR(medLvl_PocketBVM);
         items[] = {"kat_pocketBVM"};
         condition = QUOTE(_patient call FUNC(canUseBVM));
-        callbackSuccess = QUOTE([ARR_4(_medic,_patient,true,false)] call FUNC(useBVM); [ARR_2(_medic,_patient)] call EFUNC(airway,handleRecoveryPosition););
+        callbackSuccess = QUOTE([ARR_3(_medic,_patient,true)] call EFUNC(airway,handleRecoveryPosition); [ARR_4(_medic,_patient,true,false)] call FUNC(useBVM););
     };
     class UseBVMPortableOxygen: UseBVM {
         displayName = CSTRING(UseBVM_PortableOxygen);
         medicRequired = QGVAR(medLvl_BVM_Oxygen);
         items[] = {"kat_BVM"};
         condition = QUOTE(_patient call FUNC(canUseBVM) && _medic call FUNC(hasOxygenTank) && (GVAR(locationProvideOxygen) isEqualTo 0 || !((GVAR(locationProvideOxygen) in [ARR_2(2,3)] && _patient call ACEFUNC(medical_treatment,isInMedicalFacility)) || ((GVAR(locationProvideOxygen) in [ARR_2(1,3)] && _patient call ACEFUNC(medical_treatment,isInMedicalVehicle))))));
-        callbackSuccess = QUOTE([ARR_5(_medic,_patient,false,true,1)] call FUNC(useBVM); [ARR_2(_medic,_patient)] call EFUNC(airway,handleRecoveryPosition););
+        callbackSuccess = QUOTE([ARR_3(_medic,_patient,true)] call EFUNC(airway,handleRecoveryPosition); [ARR_5(_medic,_patient,false,true,1)] call FUNC(useBVM););
     };
     class UseBVMPortableOxygenVehicle: UseBVM {
         displayName = CSTRING(UseBVM_PortableOxygen_Vehicle);
         medicRequired = QGVAR(medLvl_BVM_Oxygen);
         items[] = {"kat_BVM"};
         condition = QUOTE(_patient call FUNC(canUseBVM) && [ARR_2((vehicle _medic),true)] call FUNC(hasOxygenTank) && ((vehicle _medic) != _medic) && (vehicle _medic) isEqualTo (vehicle _patient));
-        callbackSuccess = QUOTE([ARR_5(_medic,_patient,false,true,2)] call FUNC(useBVM); [ARR_2(_medic,_patient)] call EFUNC(airway,handleRecoveryPosition););
+        callbackSuccess = QUOTE([ARR_3(_medic,_patient,true)] call EFUNC(airway,handleRecoveryPosition); [ARR_5(_medic,_patient,false,true,2)] call FUNC(useBVM););
     };
     class UseBVMOxygen: UseBVM {
         displayName = CSTRING(UseBVM_Oxygen);
         medicRequired = QGVAR(medLvl_BVM_Oxygen);
         items[] = {"kat_BVM"};
         condition = QUOTE(_patient call FUNC(canUseBVM) && ((GVAR(locationProvideOxygen) in [ARR_2(2,3)] && _patient call ACEFUNC(medical_treatment,isInMedicalFacility)) || (GVAR(locationProvideOxygen) in [ARR_2(1,3)] && _patient call ACEFUNC(medical_treatment,isInMedicalVehicle))));
-        callbackSuccess = QUOTE([ARR_4(_medic,_patient,false,true)] call FUNC(useBVM); [ARR_2(_medic,_patient)] call EFUNC(airway,handleRecoveryPosition););
+        callbackSuccess = QUOTE([ARR_3(_medic,_patient,true)] call EFUNC(airway,handleRecoveryPosition); [ARR_4(_medic,_patient,false,true)] call FUNC(useBVM););
     };
 };

--- a/addons/breathing/functions/fnc_canUseBVM.sqf
+++ b/addons/breathing/functions/fnc_canUseBVM.sqf
@@ -17,4 +17,4 @@
 
 params ["_patient"];
 
-!(_patient call ACEFUNC(common,isAwake)) && !(_patient getVariable [QGVAR(BVMInUse), false] && !(_patient getVariable [QEGVAR(airway,recovery), false]) && {["",_patient] call ACEFUNC(medical_treatment,canCPR)});
+!(_patient call ACEFUNC(common,isAwake)) && !(_patient getVariable [QGVAR(BVMInUse), false] && {["",_patient] call ACEFUNC(medical_treatment,canCPR)});

--- a/addons/breathing/functions/fnc_lowSpO2pp.sqf
+++ b/addons/breathing/functions/fnc_lowSpO2pp.sqf
@@ -11,7 +11,7 @@
  * None
  *
  * Example:
- * [player] call kat_breathing_fnc_lowSpO2pp
+ * [player] call kat_breathing_fnc_lowSpO2pp;
  *
  * Public: No
  */

--- a/addons/breathing/functions/fnc_treatmentAdvanced_tensionpneumothorax.sqf
+++ b/addons/breathing/functions/fnc_treatmentAdvanced_tensionpneumothorax.sqf
@@ -16,7 +16,7 @@
  * None
  *
  * Example:
- * [player, cursorObject, "Body", "TensionpneumothoraxTreatment", objNull, "kat_aatKit"] call kat_breathing_fnc_treatmentAdvanced_hemopneumothorax;
+ * [player, cursorObject, "Body", "TensionpneumothoraxTreatment", objNull, "kat_aatKit"] call kat_breathing_fnc_treatmentAdvanced_tensionpneumothorax;
  *
  * Public: No
  */

--- a/addons/circulation/ACE_Medical_Treatment_Actions.hpp
+++ b/addons/circulation/ACE_Medical_Treatment_Actions.hpp
@@ -8,7 +8,7 @@ class ACE_Medical_Treatment_Actions {
         callbackStart = "";
         callbackProgress = "";
         callbackFailure = "";
-        callbackSuccess = QUOTE([ARR_2(_medic,_patient)] call FUNC(CPRStart); [ARR_2(_medic,_patient)] call EFUNC(airway,handleRecoveryPosition););
+        callbackSuccess = QUOTE([ARR_2(_medic,_patient)] call EFUNC(airway,handleRecoveryPosition); [ARR_2(_medic,_patient)] call FUNC(CPRStart););
         condition = QACEFUNC(medical_treatment,canCPR);
         animationPatientUnconscious = "AinjPpneMstpSnonWrflDnon_rolltoback";
         animationPatientUnconsciousExcludeOn[] = {"ainjppnemstpsnonwrfldnon"};
@@ -113,7 +113,7 @@ class ACE_Medical_Treatment_Actions {
         consumeItem = 0;
         callbackStart = "";
         callbackProgress = "";
-        callbackSuccess = QUOTE([ARR_4(_medic,_patient,0,'kat_AED')] call FUNC(Defibrillator_AttachPads));
+        callbackSuccess = QUOTE([ARR_2(_medic,_patient)] call EFUNC(airway,handleRecoveryPosition); [ARR_4(_medic,_patient,0,'kat_AED')] call FUNC(Defibrillator_AttachPads););
         callbackFailure = "";
         animationMedic = "AinvPknlMstpSnonWnonDr_medic0";
         treatmentLocations = QGVAR(useLocation_AED);
@@ -126,7 +126,7 @@ class ACE_Medical_Treatment_Actions {
         displayName = CSTRING(AEDStation_Action_PlacePads);
         items[] = {};
         condition = QUOTE([ARR_5(_medic,_patient,1,'kat_AED',_extraArgs)] call FUNC(Defibrillator_Pads_CheckCondition));
-        callbackSuccess = QUOTE([ARR_5(_medic,_patient,1,'kat_AED',_extraArgs)] call FUNC(Defibrillator_AttachPads));
+        callbackSuccess = QUOTE([ARR_2(_medic,_patient)] call EFUNC(airway,handleRecoveryPosition); [ARR_5(_medic,_patient,1,'kat_AED',_extraArgs)] call FUNC(Defibrillator_AttachPads));
     };
     class AEDVehiclePlacePads: AEDPlacePads {
         displayName = CSTRING(AEDVehicle_Action_PlacePads);
@@ -151,15 +151,15 @@ class ACE_Medical_Treatment_Actions {
         displayNameProgress = CSTRING(Defibrillator_Action_PlacePads_Progress);
         items[] = {"kat_X_AED"};
         condition = QUOTE([ARR_4(_medic,_patient,0,'kat_X_AED')] call FUNC(Defibrillator_Pads_CheckCondition));
-        callbackSuccess = QUOTE([ARR_4(_medic,_patient,0,'kat_X_AED')] call FUNC(Defibrillator_AttachPads));
+        callbackSuccess = QUOTE([ARR_2(_medic,_patient)] call EFUNC(airway,handleRecoveryPosition); [ARR_4(_medic,_patient,0,'kat_X_AED')] call FUNC(Defibrillator_AttachPads));
         medicRequired = QGVAR(medLvl_AED_X);
         icon = QPATHTOF(ui\icon_aedx.paa);
     };
     class AEDXStationPlacePads: AEDXPlacePads {
         displayName = CSTRING(AEDXStation_Action_PlacePads);
         items[] = {};
-        condition = QUOTE([ARR_5(_medic,_patient,1,'kat_X_AED',_extraArgs)] call FUNC(Defibrillator_Pads_CheckCondition));
-        callbackSuccess = QUOTE([ARR_5(_medic,_patient,1,'kat_X_AED',_extraArgs)] call FUNC(Defibrillator_AttachPads));
+        condition = QUOTE([ARR_5(_medic,_patient,1,'kat_X_AED',_extraArgs)] call FUNC(Defibrillator_Pads_CheckCondition););
+        callbackSuccess = QUOTE([ARR_2(_medic,_patient)] call EFUNC(airway,handleRecoveryPosition); [ARR_5(_medic,_patient,1,'kat_X_AED',_extraArgs)] call FUNC(Defibrillator_AttachPads));
     };
     class AEDXVehiclePlacePads: AEDXPlacePads {
         displayName = CSTRING(AEDXVehicle_Action_PlacePads);

--- a/addons/circulation/ACE_Medical_Treatment_Actions.hpp
+++ b/addons/circulation/ACE_Medical_Treatment_Actions.hpp
@@ -8,8 +8,8 @@ class ACE_Medical_Treatment_Actions {
         callbackStart = "";
         callbackProgress = "";
         callbackFailure = "";
-        callbackSuccess = QFUNC(CPRStart);
-        condition = QUOTE(([ARR_2(_medic,_patient)] call ACEFUNC(medical_treatment,canCPR)) && !(_patient getVariable [ARR_2(QQEGVAR(airway,recovery),false)]));
+        callbackSuccess = QUOTE([ARR_2(_medic,_patient)] call FUNC(CPRStart); [ARR_2(_medic,_patient)] call EFUNC(airway,handleRecoveryPosition););
+        condition = QACEFUNC(medical_treatment,canCPR);
         animationPatientUnconscious = "AinjPpneMstpSnonWrflDnon_rolltoback";
         animationPatientUnconsciousExcludeOn[] = {"ainjppnemstpsnonwrfldnon"};
     };

--- a/addons/circulation/functions/fnc_AEDXPlaced_CheckCondition.sqf
+++ b/addons/circulation/functions/fnc_AEDXPlaced_CheckCondition.sqf
@@ -55,4 +55,4 @@ switch (_check) do {
     };
 };
 
-_condition && [_medic, GVAR(medLvl_AED_X)] call ACEFUNC(medical_treatment,isMedic) && {!(_patient getVariable [QEGVAR(airway,recovery), false]) && {["",_patient] call ACEFUNC(medical_treatment,canCPR)}};
+_condition && [_medic, GVAR(medLvl_AED_X)] call ACEFUNC(medical_treatment,isMedic) && {["",_patient] call ACEFUNC(medical_treatment,canCPR)};

--- a/addons/circulation/functions/fnc_Defibrillator_CheckCondition.sqf
+++ b/addons/circulation/functions/fnc_Defibrillator_CheckCondition.sqf
@@ -37,4 +37,4 @@ switch (_defibProvider select 1) do {
     };
 };
 
-_condition && (_allowInUse || !(_patient getVariable [QGVAR(DefibrillatorInUse), false])) && _patient getVariable [QGVAR(DefibrillatorPads_Connected), false] && {!(_patient getVariable [QEGVAR(airway,recovery), false]) && {["",_patient] call ACEFUNC(medical_treatment,canCPR)}};
+_condition && (_allowInUse || !(_patient getVariable [QGVAR(DefibrillatorInUse), false])) && _patient getVariable [QGVAR(DefibrillatorPads_Connected), false] && {["",_patient] call ACEFUNC(medical_treatment,canCPR)};

--- a/addons/circulation/functions/fnc_Defibrillator_Pads_CheckCondition.sqf
+++ b/addons/circulation/functions/fnc_Defibrillator_Pads_CheckCondition.sqf
@@ -10,7 +10,7 @@
  *   0: Medic
  *   1: Placed
  *   2: Vehicle
- * 3: AED classname <STRING
+ * 3: AED classname <STRING>
  * 4: Extra Arguments <ARRAY>
  *   0: Placed AED <OBJECT>
  *
@@ -50,4 +50,4 @@ switch (_AEDOrigin) do {
 };
 
 if (_exit) exitWith {false};
-_condition && !(_patient getVariable [QGVAR(DefibrillatorPads_Connected), false]) && !(_patient getVariable [QEGVAR(airway,recovery), false]) && {["",_patient] call ACEFUNC(medical_treatment,canCPR)};
+_condition && !(_patient getVariable [QGVAR(DefibrillatorPads_Connected), false]) && {["",_patient] call ACEFUNC(medical_treatment,canCPR)};

--- a/addons/gui/functions/fnc_updateInjuryList.sqf
+++ b/addons/gui/functions/fnc_updateInjuryList.sqf
@@ -239,7 +239,7 @@ if (EGVAR(breathing,showCyanosis) && _selectionN in [0,2,3]) then {
 
 // Airway State
 if (_target getVariable [QEGVAR(airway,overstretch), false] && _selectionN isEqualTo 0) then {
-    _entries pushback [LELSTRING(airway,overstretched), [0.1, 1, 1, 1]];
+    _entries pushback [LELSTRING(airway,Hyperextended), [0.1, 1, 1, 1]];
 };
 
 if (_target getVariable [QEGVAR(airway,airway), false] && _selectionN isEqualTo 0) then {

--- a/addons/misc/functions/fnc_treatmentSuccess.sqf
+++ b/addons/misc/functions/fnc_treatmentSuccess.sqf
@@ -41,6 +41,9 @@ if (!isNil QACEGVAR(advanced_fatigue,setAnimExclusions)) then {
     ACEGVAR(advanced_fatigue,setAnimExclusions) deleteAt (ACEGVAR(advanced_fatigue,setAnimExclusions) find QUOTE(ACE_ADDON(medical_treatment)));
 };
 
+GET_FUNCTION(_condition,configFile >> QACEGVAR(medical_treatment,actions) >> _classname >> "condition");
+if !(_args call _condition) exitWith {};
+
 // Call treatment specific success callback
 GET_FUNCTION(_callbackSuccess,configFile >> QACEGVAR(medical_treatment,actions) >> _classname >> "callbackSuccess");
 

--- a/addons/pharma/ACE_Medical_Treatment_Actions.hpp
+++ b/addons/pharma/ACE_Medical_Treatment_Actions.hpp
@@ -302,9 +302,9 @@ class ACE_Medical_Treatment_Actions {
         category = "advanced";
         allowedSelections[] = {"Body"};
         items[] = {"kat_IO_FAST"};
-        condition = QUOTE(!([ARR_3(_player,_patient,_bodyPart)] call FUNC(removeIV)) && !(_patient getVariable [ARR_2(QQEGVAR(airway,recovery),false)]));
+        condition = QUOTE(!([ARR_3(_player,_patient,_bodyPart)] call FUNC(removeIV)));
         treatmentTime = QGVAR(treatmentTime_ApplyIO);
-        callbackSuccess = QUOTE([ARR_4(_player,_patient,_bodyPart,'kat_IO_FAST')] call FUNC(applyIV));
+        callbackSuccess = QUOTE([ARR_2(_medic,_patient)] call EFUNC(airway,handleRecoveryPosition); [ARR_4(_player,_patient,_bodyPart,'kat_IO_FAST')] call FUNC(applyIV););
         litter[] = {};
         sounds[] = {};
     };

--- a/addons/zeus/stringtable.xml
+++ b/addons/zeus/stringtable.xml
@@ -130,7 +130,7 @@
             <Portuguese>Volume de sangue:</Portuguese>
         </Key>
         <Key ID="STR_KAT_Zeus_manageAirway_Module_displayname">
-            <English>Manage Airways</English>
+            <English>Manage Airway</English>
             <German>Atemwege verwalten</German>
             <Czech>Upravit dýchací cesty</Czech>
             <French>Gestion des voies aériennes</French>


### PR DESCRIPTION
**When merged this pull request will:**
- Make recovery position clear occlusions over time
- Make it so an established recovery position is cancelled when attempting to do actions that are incompatible with it
- Reword check airway hints

### IMPORTANT

- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
