### PR TITLE
Circulation - Fix blood poisoning not causing cardiac arrest

### DIFF
--- a/addons/circulation/XEH_postInit.sqf
+++ b/addons/circulation/XEH_postInit.sqf
@@ -25,3 +25,9 @@ GVAR(AEDX_MonitorTarget) = objNull;
     [QACEGVAR(medical,FatalVitals), _unit] call CBA_fnc_localEvent;
     _unit setVariable [QGVAR(cardiacArrestType), 1, true];
 }] call CBA_fnc_addEventHandler;
+
+[QGVAR(bloodPoisoning), {
+    params ["_unit"];
+    
+    [QACEGVAR(medical,FatalVitals), _unit] call CBA_fnc_localEvent;
+}] call CBA_fnc_addEventHandler;

--- a/addons/circulation/functions/fnc_treatmentAdvanced_IV.sqf
+++ b/addons/circulation/functions/fnc_treatmentAdvanced_IV.sqf
@@ -16,11 +16,25 @@
  * Public: No
  */
 
-params ["_className", "_target"];
+params ["_className", "_unit"];
 
 //unit, adjustment, time
 private _volume = getNumber (configFile >> "ACE_Medical_Treatment" >> "IV" >> _className >> "volume");
 
-private _hradjust = -(_volume / 4);
+private _hradjust = -_volume;
 
-[_target, "BloodPoisoning", 150, 300, _hradjust, 0, -10] call ACEFUNC(medical_status,addMedicationAdjustment);
+[_unit, "BloodPoisoning", 150, 300, _hradjust, 0, -10] call ACEFUNC(medical_status,addMedicationAdjustment);
+
+[{
+    params ["_unit"];
+
+    if !(_unit getVariable [VAR_CRDC_ARRST, false]) then {
+        private _medicationArray = _unit getVariable [QACEGVAR(medical,medications), []];
+        private _index = _medicationArray findIf {(_x select 0) isEqualTo "BloodPoisoning"};
+
+        if (_index > -1) then {
+            [QGVAR(bloodPoisoning), _unit, _unit] call CBA_fnc_targetEvent;
+        };
+    };
+    
+}, [_unit], 150] call CBA_fnc_waitAndExecute;


### PR DESCRIPTION
**When merged this pull request will:**
- Make it so blood poisoning always causes cardiac arrest, either due to low HR or forcefully within 2.5 minutes.

### IMPORTANT

- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
