### PR TITLE
Airway/Misc - Fixes for surgical kit autoclosing menu, weapon sway, recovery position

### DIFF
--- a/addons/airway/ACE_Medical_Treatment_Actions.hpp
+++ b/addons/airway/ACE_Medical_Treatment_Actions.hpp
@@ -12,7 +12,8 @@ class ACE_Medical_Treatment_Actions {
         condition = QUOTE(!([_patient] call ACEFUNC(common,isAwake)) && (missionNamespace getVariable [ARR_2(QQGVAR(enable),true)]) && !(_patient getVariable [ARR_2(QQGVAR(airway_item),'')] == 'Larynxtubus') && !(_patient getVariable [ARR_2(QQGVAR(airway_item),'')] == 'Guedeltubus'));
         callbackSuccess = QUOTE([ARR_3(_medic,_patient,(_patient getVariable [ARR_2(QQGVAR(occluded),false)]))] call FUNC(handleRecoveryPosition); [ARR_6(_medic,_patient,_bodyPart,_className,objNull,_usedItem)] call FUNC(treatmentAdvanced_airway););
         callbackFailure = "";
-        callbackProgress = QUOTE(!([(_args select 1)] call ACEFUNC(common,isAwake)) && !((_args select 1) getVariable [ARR_2(QQGVAR(airway_item),'')] == 'Larynxtubus') && !((_args select 1) getVariable [ARR_2(QQGVAR(airway_item),'')] == 'Guedeltubus'));
+        callbackProgress = "";
+        callbackCondition = "useCondition";
         consumeItem = 1;
         animationPatient = "";
         animationPatientUnconscious = "AinjPpneMstpSnonWrflDnon_rolltoback";
@@ -74,7 +75,8 @@ class ACE_Medical_Treatment_Actions {
         icon = "";
         condition = QUOTE(!([_patient] call ACEFUNC(common,isAwake)) && !(_patient getVariable [ARR_2(QQGVAR(overstretch),false)]) && !(_patient getVariable [ARR_2(QQGVAR(recovery),false)]) && (missionNamespace getVariable [ARR_2(QQGVAR(enable),true)]) && !(_patient getVariable [ARR_2(QQGVAR(airway_item),'')] == 'Guedeltubus') && !(_patient getVariable [ARR_2(QQGVAR(airway_item),'')] == 'Larynxtubus'));
         callbackSuccess = QFUNC(treatmentAdvanced_hyperextendHead);
-        callbackProgress = QUOTE(!([(_args select 1)] call ACEFUNC(common,isAwake)) && !((_args select 1) getVariable [ARR_2(QQGVAR(overstretch),false)]) && !((_args select 1) getVariable [ARR_2(QQGVAR(recovery),false)]) && !((_args select 1) getVariable [ARR_2(QQGVAR(airway_item),'')] == 'Guedeltubus') && !((_args select 1) getVariable [ARR_2(QQGVAR(airway_item),'')] == 'Larynxtubus'));
+        callbackProgress = "";
+        callbackCondition = "useCondition";
     };
     class BeginHeadTurning: Larynxtubus {
         displayName = CSTRING(headTurning_begin);
@@ -99,7 +101,8 @@ class ACE_Medical_Treatment_Actions {
         condition = QUOTE((!([_patient] call ACEFUNC(common,isAwake)) && (missionNamespace getVariable [ARR_2(QQGVAR(enable),true)]) && !(_patient getVariable [ARR_2(QQGVAR(recovery),false)])) && [ARR_2(_medic,_patient)] call FUNC(checkRecovery));
         icon = "";
         callbackSuccess = QFUNC(treatmentAdvanced_RecoveryPosition);
-        callbackProgress = QUOTE(!([(_args select 1)] call ACEFUNC(common,isAwake) && !((_args select 1) getVariable [ARR_2(QQGVAR(recovery),false)])) && [ARR_2((_args select 0),(_args select 1))] call FUNC(checkRecovery));
+        callbackProgress = "";
+        callbackCondition = "useCondition";
         animationPatientUnconsciousExcludeOn[] = {"ainjppnemstpsnonwrfldnon", "kat_recoveryposition"};
     };
     class CancelRecoveryPosition: Larynxtubus {
@@ -113,7 +116,8 @@ class ACE_Medical_Treatment_Actions {
         condition = QUOTE(!([_patient] call ACEFUNC(common,isAwake)) && (missionNamespace getVariable [ARR_2(QQGVAR(enable),true)]) && (_patient getVariable [ARR_2(QQGVAR(recovery),false)]));
         icon = "";
         callbackSuccess = QUOTE([ARR_2(_medic,_patient)] call FUNC(treatmentAdvanced_CancelRecoveryPosition));
-        callbackProgress = QUOTE(!([(_args select 1)] call ACEFUNC(common,isAwake)) && ((_args select 1) getVariable [ARR_2(QQGVAR(recovery),false)]));
+        callbackProgress = "";
+        callbackCondition = "useCondition";
         animationPatientUnconscious = "";
         animationPatientUnconsciousExcludeOn[] = {"ainjppnemstpsnonwrfldnon"};
     };

--- a/addons/airway/functions/fnc_treatmentAdvanced_RecoveryPositionLocal.sqf
+++ b/addons/airway/functions/fnc_treatmentAdvanced_RecoveryPositionLocal.sqf
@@ -26,7 +26,7 @@ private _output = LLSTRING(RecoveryPosition_Ready);
 
 _patient setVariable [QGVAR(wasOccluded), (_patient getVariable [QGVAR(occluded), false])];
 
-if (GVAR(RecoveryPosition_TimeToDrain) > 0 && GVAR(wasOccluded)) then {
+if (GVAR(RecoveryPosition_TimeToDrain) > 0 && _patient getVariable [QGVAR(wasOccluded), false]) then {
     [{
         params ["_patient"];
 

--- a/addons/misc/XEH_postInit.sqf
+++ b/addons/misc/XEH_postInit.sqf
@@ -66,6 +66,6 @@ call FUNC(FAK_updateContents);
 ["multiplier", {
     private _activeTourniquets = GET_TOURNIQUETS(ACE_player);
     if (ACE_player getVariable [QGVAR(Tourniquet_ArmNecrosis), 0] > 0) then {
-        (ACE_player getVariable [QGVAR(Tourniquet_ArmNecrosis), 0]) / 10
-    } else {0};
+        1 max (ACE_player getVariable [QGVAR(Tourniquet_ArmNecrosis), 0]) / 10
+    } else {1};
 }, QUOTE(ADDON)] call ACEFUNC(common,addSwayFactor);

--- a/addons/misc/functions/fnc_fullHealLocal.sqf
+++ b/addons/misc/functions/fnc_fullHealLocal.sqf
@@ -69,6 +69,7 @@ _unit setVariable [QACEGVAR(medical,fractures), [0,0,0,0,0,0], true];
 
 //KAT Airway
 _unit setVariable [QEGVAR(airway,occluded), false, true];
+_unit setVariable [QEGVAR(airway,wasOccluded), false];
 _unit setVariable [QEGVAR(airway,obstruction), false, true];
 _unit setVariable [QEGVAR(airway,recovery), false, true];
 _unit setVariable [QEGVAR(airway,overstretch), false, true];

--- a/addons/misc/functions/fnc_handleRespawn.sqf
+++ b/addons/misc/functions/fnc_handleRespawn.sqf
@@ -27,6 +27,7 @@ _unit setVariable [QEGVAR(airway,obstruction), false, true];
 _unit setVariable [QEGVAR(airway,airway), false, true];
 _unit setVariable [QEGVAR(airway,occluded), false, true];
 _unit setVariable [QEGVAR(airway,overstretch), false, true];
+_unit setVariable [QEGVAR(airway,wasOccluded), false];
 KAT_forceWakeup = false;
 _unit setVariable [QEGVAR(airway,recovery), false, true];
 _unit setVariable [QEGVAR(airway,airway_item), "", true];

--- a/addons/misc/functions/fnc_treatmentSuccess.sqf
+++ b/addons/misc/functions/fnc_treatmentSuccess.sqf
@@ -41,8 +41,22 @@ if (!isNil QACEGVAR(advanced_fatigue,setAnimExclusions)) then {
     ACEGVAR(advanced_fatigue,setAnimExclusions) deleteAt (ACEGVAR(advanced_fatigue,setAnimExclusions) find QUOTE(ACE_ADDON(medical_treatment)));
 };
 
-GET_FUNCTION(_condition,configFile >> QACEGVAR(medical_treatment,actions) >> _classname >> "condition");
-if !(_args call _condition) exitWith {};
+private _callbackCondition = true;
+
+GET_FUNCTION(_callbackCondition,configFile >> QACEGVAR(medical_treatment,actions) >> _classname >> "callbackCondition");
+if (_callbackCondition isEqualType {}) then {
+    if ((getText (configFile >> QACEGVAR(medical_treatment,actions) >> _classname >> "callbackCondition")) isEqualTo "useCondition") then {
+        GET_FUNCTION(_condition,configFile >> QACEGVAR(medical_treatment,actions) >> _classname >> "condition");
+        _callbackCondition = _condition;
+    };
+    
+    if (_callbackCondition isEqualTo {}) exitWith {
+        _callbackCondition = true;
+    };
+    _callbackCondition = call _callbackCondition;
+};
+
+if !(_callbackCondition) exitWith {};
 
 // Call treatment specific success callback
 GET_FUNCTION(_callbackSuccess,configFile >> QACEGVAR(medical_treatment,actions) >> _classname >> "callbackSuccess");


### PR DESCRIPTION
**When merged this pull request will:**
- Modify treatmentSuccess extra check to make it work as intended with callbackProgress, prevent surgical kit finishing from closing medical menu
- Fix tourniquet sway factor multiplier removing all sway when tourniquet wasn't applied
- Fix recovery position not clearing occlusion as intended

### IMPORTANT

- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
