### PR TITLE
Misc - Add default meta.cpp for Steam Workshop association

### DIFF
--- a/meta.cpp
+++ b/meta.cpp
@@ -1,0 +1,2 @@
+protocol = 1;
+publishedid = 2020940806;


### PR DESCRIPTION
**When merged this pull request will:**
Make sure servers running this mod will associate it with the Steam Workshop item for easier download while joining with the Arma 3 Launcher or other third party tools.

### IMPORTANT

- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
