### PR TITLE
Breathing - Fix deepPenetratingInjury occurred if chance is 0%

### DIFF
--- a/addons/breathing/functions/fnc_handlePulmoHit.sqf
+++ b/addons/breathing/functions/fnc_handlePulmoHit.sqf
@@ -55,8 +55,10 @@ if (floor (random 100) <= (GVAR(pneumothoraxChance) + _chanceIncrease)) then {
         };
     };
 } else { // Damage threshold was passed but no pneumothorax given, try to just give injury instead
-    if (floor (random 100) <= GVAR(deepPenetratingInjuryChance)) then {
-        _unit setVariable [QGVAR(deepPenetratingInjury), true, true];
-        _unit setVariable [QGVAR(activeChestSeal), false, true];
+    if (GVAR(deepPenetratingInjuryChance) > 0) then (
+        if (floor (random 100) <= GVAR(deepPenetratingInjuryChance)) then {
+            _unit setVariable [QGVAR(deepPenetratingInjury), true, true];
+            _unit setVariable [QGVAR(activeChestSeal), false, true];
+        };
     };
 };

--- a/addons/breathing/functions/fnc_handlePulmoHit.sqf
+++ b/addons/breathing/functions/fnc_handlePulmoHit.sqf
@@ -55,7 +55,7 @@ if (floor (random 100) <= (GVAR(pneumothoraxChance) + _chanceIncrease)) then {
         };
     };
 } else { // Damage threshold was passed but no pneumothorax given, try to just give injury instead
-    if (GVAR(deepPenetratingInjuryChance) > 0) then (
+    if (GVAR(deepPenetratingInjuryChance) > 0) then {
         if (floor (random 100) <= GVAR(deepPenetratingInjuryChance)) then {
             _unit setVariable [QGVAR(deepPenetratingInjury), true, true];
             _unit setVariable [QGVAR(activeChestSeal), false, true];

--- a/addons/breathing/functions/fnc_handlePulmoHit.sqf
+++ b/addons/breathing/functions/fnc_handlePulmoHit.sqf
@@ -55,10 +55,8 @@ if (floor (random 100) <= (GVAR(pneumothoraxChance) + _chanceIncrease)) then {
         };
     };
 } else { // Damage threshold was passed but no pneumothorax given, try to just give injury instead
-    if (GVAR(deepPenetratingInjuryChance) > 0) then {
-        if (floor (random 100) <= GVAR(deepPenetratingInjuryChance)) then {
-            _unit setVariable [QGVAR(deepPenetratingInjury), true, true];
-            _unit setVariable [QGVAR(activeChestSeal), false, true];
-        };
+    if (floor (random 100) < GVAR(deepPenetratingInjuryChance)) then {
+        _unit setVariable [QGVAR(deepPenetratingInjury), true, true];
+        _unit setVariable [QGVAR(activeChestSeal), false, true];
     };
 };


### PR DESCRIPTION
**When merged this pull request will:**
- _Fixed an issue where deepPenetratedInjury occurred even when deepPenetratedInjuryChance was 0%._

### IMPORTANT

- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
