### PR TITLE
Circulation - AED pick up action use addToInventory

### DIFF
--- a/addons/circulation/functions/fnc_placeAED_PickUpAction.sqf
+++ b/addons/circulation/functions/fnc_placeAED_PickUpAction.sqf
@@ -66,11 +66,10 @@ _pickUpText,
     };
 
     deleteVehicle _AED;
-    if (_medic canAddItemToUniform _AEDClassName || _medic canAddItemToVest _AEDClassName || _medic canAddItemToBackpack _AEDClassName) then {
-        _medic addItem _AEDClassName;
-    } else {
-        private _droppedAED = createVehicle ["Weapon_Empty", getPosATL _medic, [], 0, "CAN_COLLIDE"];
-        _droppedAED addItemCargo [_AEDClassName, 1];
+
+    private _added = (([_medic, _AEDClassName] call ACEFUNC(common,addToInventory)) select 0);
+
+    if !(_added) then {
         [ACELLSTRING(Common,Inventory_Full), 1.5, _medic] call ACEFUNC(common,displayTextStructured);
     };
 },


### PR DESCRIPTION
**When merged this pull request will:**
- Make the AED pick up action use the addToInventory function to avoid issues when player is "overweight" but has space in inventory

### IMPORTANT

- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
