### PR TITLE
Pharma - Changed Max Dosages

### DIFF
--- a/addons/pharma/ACE_Medical_Treatment.hpp
+++ b/addons/pharma/ACE_Medical_Treatment.hpp
@@ -7,7 +7,8 @@ class ACE_ADDON(Medical_Treatment) {
             hrIncreaseHigh[] = {10, 40};
             timeInSystem = 120;
             timeTillMaxEffect = 10;
-            maxDose = 10;
+            maxDose = 6;
+            maxDoseDeviation = 4;
             incompatibleMedication[] = {};
             alphaFactor = 0.15;
             onOverDose = "";
@@ -56,7 +57,8 @@ class ACE_ADDON(Medical_Treatment) {
             hrIncreaseHigh[] = {-10, -15};
             timeInSystem = 360;
             timeTillMaxEffect = 15;
-            maxDose = 12;
+            maxDose = 6;
+            maxDoseDeviation = 4;
             incompatibleMedication[] = {};
             viscosityChange = 50;
             alphaFactor = -0.5;
@@ -69,7 +71,8 @@ class ACE_ADDON(Medical_Treatment) {
             hrIncreaseHigh[] = {10, 15};
             timeInSystem = 360;
             timeTillMaxEffect = 15;
-            maxDose = 12;
+            maxDose = 6;
+            maxDoseDeviation = 4;
             incompatibleMedication[] = {};
             viscosityChange = -25;
             alphaFactor = 0.3;
@@ -82,8 +85,8 @@ class ACE_ADDON(Medical_Treatment) {
             hrIncreaseHigh[] = {-20, -10};
             timeInSystem = 900;
             timeTillMaxEffect = 20;
-            maxDose = 2;
-            maxDoseDeviation = 0;
+            maxDose = 1;
+            maxDoseDeviation = 1;
             incompatibleMedication[] = {};
             viscosityChange = -10;
             onOverDose = "";
@@ -95,7 +98,7 @@ class ACE_ADDON(Medical_Treatment) {
             hrIncreaseHigh[] = {10, 15};
             timeInSystem = 900;
             timeTillMaxEffect = 15;
-            maxDose = 4;
+            maxDose = 2;
             maxDoseDeviation = 2;
             incompatibleMedication[] = {};
             viscosityChange = 10;
@@ -108,8 +111,8 @@ class ACE_ADDON(Medical_Treatment) {
             hrIncreaseHigh[] = {-15, -5};
             timeInSystem = 900;
             timeTillMaxEffect = 30;
-            maxDose = 4;
-            maxDoseDeviation = 1;
+            maxDose = 2;
+            maxDoseDeviation = 2;
             incompatibleMedication[] = {};
             viscosityChange = -5;
             onOverDose = "";
@@ -121,7 +124,7 @@ class ACE_ADDON(Medical_Treatment) {
             hrIncreaseHigh[] = {5, 15};
             timeInSystem = 600;
             timeTillMaxEffect = 90;
-            maxDose = 10;
+            maxDose = 6;
             maxDoseDeviation = 4;
             incompatibleMedication[] = {};
             viscosityChange = -5;
@@ -158,7 +161,8 @@ class ACE_ADDON(Medical_Treatment) {
             hrIncreaseHigh[] = {0, 0, 0};
             timeInSystem = 120;
             timeTillMaxEffect = 30;
-            maxDose = 4;
+            maxDose = 2;
+            maxDoseDeviation = 4;
             incompatibleMedication[]= {};
             onOverDose = "";
         };
@@ -230,7 +234,8 @@ class ACE_ADDON(Medical_Treatment) {
             hrIncreaseHigh[] = {5, 15};
             timeInSystem = 1800;
             timeTillMaxEffect = 5;
-            maxDose = 6;
+            maxDose = 4;
+            maxDoseDeviation = 4;
             incompatibleMedication[] = {};
             viscosityChange = 0;
             onOverDose = "";

--- a/addons/pharma/ACE_Medical_Treatment.hpp
+++ b/addons/pharma/ACE_Medical_Treatment.hpp
@@ -83,6 +83,7 @@ class ACE_ADDON(Medical_Treatment) {
             timeInSystem = 900;
             timeTillMaxEffect = 20;
             maxDose = 2;
+            maxDoseDeviation = 0;
             incompatibleMedication[] = {};
             viscosityChange = -10;
             onOverDose = "";
@@ -95,6 +96,7 @@ class ACE_ADDON(Medical_Treatment) {
             timeInSystem = 900;
             timeTillMaxEffect = 15;
             maxDose = 4;
+            maxDoseDeviation = 2;
             incompatibleMedication[] = {};
             viscosityChange = 10;
             onOverDose = "";
@@ -107,6 +109,7 @@ class ACE_ADDON(Medical_Treatment) {
             timeInSystem = 900;
             timeTillMaxEffect = 30;
             maxDose = 4;
+            maxDoseDeviation = 1;
             incompatibleMedication[] = {};
             viscosityChange = -5;
             onOverDose = "";
@@ -119,6 +122,7 @@ class ACE_ADDON(Medical_Treatment) {
             timeInSystem = 600;
             timeTillMaxEffect = 90;
             maxDose = 10;
+            maxDoseDeviation = 4;
             incompatibleMedication[] = {};
             viscosityChange = -5;
             onOverDose = "";
@@ -214,6 +218,7 @@ class ACE_ADDON(Medical_Treatment) {
             timeInSystem = 600;
             timeTillMaxEffect = 5;
             maxDose = 2;
+            maxDoseDeviation = 1;
             incompatibleMedication[] = {};
             viscosityChange = 5;
             onOverDose = "";


### PR DESCRIPTION
**When merged this pull request will:**
- With the recent ace update, overdose calculations were changed to be variable, with a chance to suffer an overdose based on the max dose deviation https://github.com/acemod/ACE3/pull/9746
- with this PR it will change the default deviation of 2 to more realistic values depending on the medication, eg, fentanyl is now a 1, so any dose over 2 will send then into OD

### IMPORTANT

- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
