### PR TITLE
Pharma - Add EACA clear trauma setting

### DIFF
--- a/addons/pharma/XEH_preInit.sqf
+++ b/addons/pharma/XEH_preInit.sqf
@@ -470,6 +470,15 @@ PREP_RECOMPILE_END;
     true
 ] call CBA_Settings_fnc_init;
 
+[
+    QGVAR(eacaClearTrauma),
+    "CHECKBOX",
+    [LLSTRING(SETTING_EACA_Trauma), LLSTRING(SETTING_EACA_Trauma_DESC)],
+    [CBA_SETTINGS_CAT, LSTRING(SubCategory_EACA)],
+    [false],
+    true
+] call CBA_Settings_fnc_init;
+
 //Ketamine Settings Category
 [
     QGVAR(medLvl_Ketamine),
@@ -613,15 +622,6 @@ PREP_RECOMPILE_END;
     QGVAR(staminaMedication),
     "CHECKBOX",
     [LLSTRING(SETTING_staminaMedication), LLSTRING(SETTING_staminaMedication_DESC)],
-    CBA_SETTINGS_CAT,
-    [false],
-    true
-] call CBA_Settings_fnc_init;
-
-[
-    QGVAR(eacaClearTrauma),
-    "CHECKBOX",
-    [LLSTRING(SETTING_EACA_Trauma), LLSTRING(SETTING_EACA_Trauma_DESC)],
     CBA_SETTINGS_CAT,
     [false],
     true

--- a/addons/pharma/XEH_preInit.sqf
+++ b/addons/pharma/XEH_preInit.sqf
@@ -619,10 +619,10 @@ PREP_RECOMPILE_END;
 ] call CBA_Settings_fnc_init;
 
 [
-    QGVAR(eacaTrauma),
+    QGVAR(eacaClearTrauma),
     "CHECKBOX",
-    [LLSTRING(SETTING_Eaca_Trauma), LLSTRING(SETTING_Eaca_Trauma_DESC)],
-    [CBA_SETTINGS_CAT],
+    [LLSTRING(SETTING_EACA_Trauma), LLSTRING(SETTING_EACA_Trauma_DESC)],
+    CBA_SETTINGS_CAT,
     [false],
     true
 ] call CBA_Settings_fnc_init;

--- a/addons/pharma/XEH_preInit.sqf
+++ b/addons/pharma/XEH_preInit.sqf
@@ -618,4 +618,13 @@ PREP_RECOMPILE_END;
     true
 ] call CBA_Settings_fnc_init;
 
+[
+    QGVAR(eacaTrauma),
+    "CHECKBOX",
+    [LLSTRING(SETTING_Eaca_Trauma), LLSTRING(SETTING_Eaca_Trauma_DESC)],
+    [CBA_SETTINGS_CAT],
+    [false],
+    true
+] call CBA_Settings_fnc_init;
+
 ADDON = true;

--- a/addons/pharma/functions/fnc_treatmentAdvanced_EACALocal.sqf
+++ b/addons/pharma/functions/fnc_treatmentAdvanced_EACALocal.sqf
@@ -85,7 +85,7 @@ if (_IVactual > 1) then {
 
                 _patient setVariable [VAR_BANDAGED_WOUNDS, _bandagedWounds, true];
 
-                if !(GVAR(eacaTrauma)) then {
+                if (GVAR(eacaTrauma)) then {
                 private _partIndex = ALL_BODY_PARTS find _targetBodyPart;
                 private _bodyPartDamage = _patient getVariable [QACEGVAR(medical,bodyPartDamage), []];
                 private _damage = (_bodyPartDamage select _partIndex) - (_damageOf * _amountOf);

--- a/addons/pharma/functions/fnc_treatmentAdvanced_EACALocal.sqf
+++ b/addons/pharma/functions/fnc_treatmentAdvanced_EACALocal.sqf
@@ -84,7 +84,8 @@ if (_IVactual > 1) then {
                 _bandagedWounds set [_targetBodyPart, _bandagedWoundsOnPart];
 
                 _patient setVariable [VAR_BANDAGED_WOUNDS, _bandagedWounds, true];
-                
+
+                if !(GVAR(eacaTrauma)) then {
                 private _partIndex = ALL_BODY_PARTS find _targetBodyPart;
                 private _bodyPartDamage = _patient getVariable [QACEGVAR(medical,bodyPartDamage), []];
                 private _damage = (_bodyPartDamage select _partIndex) - (_damageOf * _amountOf);
@@ -93,8 +94,8 @@ if (_IVactual > 1) then {
                 } else {
                     _bodyPartDamage set [_partIndex, _damage];
                 };
-                _patient setVariable [QACEGVAR(medical,bodyPartDamage), _bodyPartDamage, true];
-
+                _patient setVariable [QACEGVAR(medical,bodyPartDamage), _bodyPartDamage, true]; };
+                else exitWith {};
                 _exit = false;
             };
         } forEach ALL_BODY_PARTS_PRIORITY;

--- a/addons/pharma/functions/fnc_treatmentAdvanced_EACALocal.sqf
+++ b/addons/pharma/functions/fnc_treatmentAdvanced_EACALocal.sqf
@@ -95,7 +95,7 @@ if (_IVactual > 1) then {
                     _bodyPartDamage set [_partIndex, _damage];
                 };
                 _patient setVariable [QACEGVAR(medical,bodyPartDamage), _bodyPartDamage, true]; };
-                else exitWith {};
+                
                 _exit = false;
             };
         } forEach ALL_BODY_PARTS_PRIORITY;

--- a/addons/pharma/functions/fnc_treatmentAdvanced_EACALocal.sqf
+++ b/addons/pharma/functions/fnc_treatmentAdvanced_EACALocal.sqf
@@ -85,16 +85,17 @@ if (_IVactual > 1) then {
 
                 _patient setVariable [VAR_BANDAGED_WOUNDS, _bandagedWounds, true];
 
-                if (GVAR(eacaTrauma)) then {
-                private _partIndex = ALL_BODY_PARTS find _targetBodyPart;
-                private _bodyPartDamage = _patient getVariable [QACEGVAR(medical,bodyPartDamage), []];
-                private _damage = (_bodyPartDamage select _partIndex) - (_damageOf * _amountOf);
-                if (_damage < 0.05) then {
-                    _bodyPartDamage set [_partIndex, 0];
-                } else {
-                    _bodyPartDamage set [_partIndex, _damage];
+                if (GVAR(eacaClearTrauma)) then {
+                    private _partIndex = ALL_BODY_PARTS find _targetBodyPart;
+                    private _bodyPartDamage = _patient getVariable [QACEGVAR(medical,bodyPartDamage), []];
+                    private _damage = (_bodyPartDamage select _partIndex) - (_damageOf * _amountOf);
+                    if (_damage < 0.05) then {
+                        _bodyPartDamage set [_partIndex, 0];
+                    } else {
+                        _bodyPartDamage set [_partIndex, _damage];
+                    };
+                    _patient setVariable [QACEGVAR(medical,bodyPartDamage), _bodyPartDamage, true];
                 };
-                _patient setVariable [QACEGVAR(medical,bodyPartDamage), _bodyPartDamage, true]; };
                 
                 _exit = false;
             };

--- a/addons/pharma/stringtable.xml
+++ b/addons/pharma/stringtable.xml
@@ -3217,5 +3217,11 @@
             <Finnish>Salli tiettyjen lääkkeiden muuttaa kestävyyttä (vanilja/edistynyt väsymys) sivuvaikutuksena</Finnish>
             <Russian>Позволяют определенным лекарствам изменять выносливость (ваниль/повышенная утомляемость) в качестве побочного эффекта</Russian>
         </Key>
+        <Key ID="STR_KAT_Pharma_SETTING_Eaca_Trauma">
+            <English>EACA Clears Trauma</English>
+        </Key>
+        <Key ID="STR_KAT_Pharma_SETTING_Eaca_Trauma_Desc">
+            <English>Allows Trauma to be cleared by EACA in addition to stitching</English>
+        </Key>
     </Package>
 </Project>

--- a/addons/pharma/stringtable.xml
+++ b/addons/pharma/stringtable.xml
@@ -3217,10 +3217,10 @@
             <Finnish>Salli tiettyjen lääkkeiden muuttaa kestävyyttä (vanilja/edistynyt väsymys) sivuvaikutuksena</Finnish>
             <Russian>Позволяют определенным лекарствам изменять выносливость (ваниль/повышенная утомляемость) в качестве побочного эффекта</Russian>
         </Key>
-        <Key ID="STR_KAT_Pharma_SETTING_Eaca_Trauma">
+        <Key ID="STR_KAT_Pharma_SETTING_EACA_Trauma">
             <English>EACA Clears Trauma</English>
         </Key>
-        <Key ID="STR_KAT_Pharma_SETTING_Eaca_Trauma_Desc">
+        <Key ID="STR_KAT_Pharma_SETTING_EACA_Trauma_Desc">
             <English>Allows Trauma to be cleared by EACA in addition to stitching</English>
         </Key>
     </Package>


### PR DESCRIPTION
**When merged this pull request will:**
- Adds a checkbox in settings to allow EACA to remove trauma or just stitch wounds
- 
### IMPORTANT

- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
