### PR TITLE
Surgery - Fix Unconsciousness Required for Surgery setting

### DIFF
--- a/addons/surgery/XEH_preInit.sqf
+++ b/addons/surgery/XEH_preInit.sqf
@@ -161,7 +161,7 @@ PREP_RECOMPILE_END;
     "LIST",
     [LLSTRING(SETTING_ConsciousnessRequirement), LLSTRING(SETTING_ConsciousnessRequirement_DESC)],
     [CBA_SETTINGS_CAT, LSTRING(SubCategory_SurgicalActions)],
-    [[0, 1, 2, 3], [LLSTRING(SETTING_Causes_Unconsciousness), LLSTRING(SETTING_Unconsciousness_Required), LLSTRING(SETTING_No_Unconsciousness), LLSTRING(SETTING_Anesthesia)], 1],
+    [[0, 1, 2, 3], [LLSTRING(SETTING_Causes_Unconsciousness), LLSTRING(SETTING_Unconsciousness_Required), LLSTRING(SETTING_No_Unconsciousness), LLSTRING(SETTING_Anesthesia)], 0],
     true
 ] call CBA_Settings_fnc_init;
 

--- a/addons/surgery/functions/fnc_incisionLocal.sqf
+++ b/addons/surgery/functions/fnc_incisionLocal.sqf
@@ -51,7 +51,7 @@ _patient setVariable [QGVAR(fractures), _fractureArray, true];
         [_idPFH] call CBA_fnc_removePerFrameHandler;
     };
 
-    if ((GVAR(Surgery_ConsciousnessRequirement) == 0 && (!(IS_UNCONSCIOUS(_patient)) || _count == 0)) || (GVAR(Surgery_ConsciousnessRequirement) == 3 && _count == 0)) exitWith {
+    if (((GVAR(Surgery_ConsciousnessRequirement) in [0,1]) && (!(IS_UNCONSCIOUS(_patient)) || _count == 0)) || (GVAR(Surgery_ConsciousnessRequirement) == 3 && _count == 0)) exitWith {
         [_patient, "Pain", 10, 40, 200, 0, 40] call ACEFUNC(medical_status,addMedicationAdjustment);
         [_patient, true] call ACEFUNC(medical,setUnconscious);
     };


### PR DESCRIPTION
**When merged this pull request will:**
- Make Etomidate a requirement with the `Unconsciousness Required for Surgery` setting
- Set `Surgery Causes Unconsciousness` as default

### IMPORTANT

- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
