### PR TITLE
Feedback - Fix incorrect bool in feedback addon

### DIFF
--- a/addons/feedback/functions/fnc_effectLowSpO2.sqf
+++ b/addons/feedback/functions/fnc_effectLowSpO2.sqf
@@ -20,7 +20,7 @@
 params ["_enable", "_intensity"];
 
 if ((!_enable) || {_intensity == 0}) exitWith {
-    if (GVAR(lowSpO2) != -1) then { GVAR(lowSpO2) ppEffectEnable true; };
+    if (GVAR(lowSpO2) != -1) then { GVAR(lowSpO2) ppEffectEnable false; };
 };
 if (GVAR(lowSpO2) != -1) then { GVAR(lowSpO2) ppEffectEnable true; };
 


### PR DESCRIPTION
**When merged this pull request will:**
There's currently a bug in the feedback addon which prevents the low spo2 effect from disappearing properly during unconsciousness. This bug is not visible to the user at the moment because of how unconsciousness is handled but should be fixed anyway.