### PR TITLE
Pharma - Fix negative blood volume by blood loss

### DIFF
--- a/addons/pharma/functions/fnc_getBloodVolumeChange.sqf
+++ b/addons/pharma/functions/fnc_getBloodVolumeChange.sqf
@@ -26,8 +26,8 @@ private _enableFluidShift = EGVAR(vitals,enableFluidShift);
 private _fluidVolume = GET_BODY_FLUID(_unit);
 _fluidVolume params ["_ECB","_ECP","_SRBC","_ISP","_fullVolume"];
 
-_ECP = _ECP + (_lossVolumeChange * LITERS_TO_ML) / 2;
-_ECB = _ECB + (_lossVolumeChange * LITERS_TO_ML) / 2;
+_ECP = (_ECP + (_lossVolumeChange * LITERS_TO_ML) / 2) max 0.1;
+_ECB = (_ECB + (_lossVolumeChange * LITERS_TO_ML) / 2) max 0.1;
 
 if (!isNil {_unit getVariable [QACEGVAR(medical,ivBags),[]]}) then {
     private _bloodBags = _unit getVariable [QACEGVAR(medical,ivBags), []];

--- a/addons/pharma/functions/fnc_getBloodVolumeChange.sqf
+++ b/addons/pharma/functions/fnc_getBloodVolumeChange.sqf
@@ -26,8 +26,8 @@ private _enableFluidShift = EGVAR(vitals,enableFluidShift);
 private _fluidVolume = GET_BODY_FLUID(_unit);
 _fluidVolume params ["_ECB","_ECP","_SRBC","_ISP","_fullVolume"];
 
-_ECP = (_ECP + (_lossVolumeChange * LITERS_TO_ML) / 2) max 0.1;
-_ECB = (_ECB + (_lossVolumeChange * LITERS_TO_ML) / 2) max 0.1;
+_ECP = (_ECP + (_lossVolumeChange * LITERS_TO_ML) / 2) max 100;
+_ECB = (_ECB + (_lossVolumeChange * LITERS_TO_ML) / 2) max 100;
 
 if (!isNil {_unit getVariable [QACEGVAR(medical,ivBags),[]]}) then {
     private _bloodBags = _unit getVariable [QACEGVAR(medical,ivBags), []];


### PR DESCRIPTION
**When merged this pull request will:**
- _Set a floor to the calculated ECP & ECB, so you aren't able to bleed into the negatives with `bleedout during cardiac arrest` disabled* anymore_
- _Floor is set to 100ml to be safe against scheduling shenanigans_

### IMPORTANT

- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.

*Edit: changed enabled to disabled