### PR TITLE
Pharma/Vitals - Fix negative ECP & ECB volumes and o2Sat calculations at low ECB values

### DIFF
--- a/addons/pharma/functions/fnc_getBloodVolumeChange.sqf
+++ b/addons/pharma/functions/fnc_getBloodVolumeChange.sqf
@@ -26,8 +26,8 @@ private _enableFluidShift = EGVAR(vitals,enableFluidShift);
 private _fluidVolume = GET_BODY_FLUID(_unit);
 _fluidVolume params ["_ECB","_ECP","_SRBC","_ISP","_fullVolume"];
 
-_ECP = _ECP + (_lossVolumeChange * LITERS_TO_ML) / 2;
-_ECB = _ECB + (_lossVolumeChange * LITERS_TO_ML) / 2;
+_ECP = (_ECP + (_lossVolumeChange * LITERS_TO_ML) / 2) max 0.1;
+_ECB = (_ECB + (_lossVolumeChange * LITERS_TO_ML) / 2) max 0.1;
 
 if (!isNil {_unit getVariable [QACEGVAR(medical,ivBags),[]]}) then {
     private _bloodBags = _unit getVariable [QACEGVAR(medical,ivBags), []];

--- a/addons/pharma/functions/fnc_getBloodVolumeChange.sqf
+++ b/addons/pharma/functions/fnc_getBloodVolumeChange.sqf
@@ -26,8 +26,8 @@ private _enableFluidShift = EGVAR(vitals,enableFluidShift);
 private _fluidVolume = GET_BODY_FLUID(_unit);
 _fluidVolume params ["_ECB","_ECP","_SRBC","_ISP","_fullVolume"];
 
-_ECP = (_ECP + (_lossVolumeChange * LITERS_TO_ML) / 2) max 0.1;
-_ECB = (_ECB + (_lossVolumeChange * LITERS_TO_ML) / 2) max 0.1;
+_ECP = (_ECP + (_lossVolumeChange * LITERS_TO_ML) / 2) max 100;
+_ECB = (_ECB + (_lossVolumeChange * LITERS_TO_ML) / 2) max 100;
 
 if (!isNil {_unit getVariable [QACEGVAR(medical,ivBags),[]]}) then {
     private _bloodBags = _unit getVariable [QACEGVAR(medical,ivBags), []];

--- a/addons/pharma/functions/fnc_getBloodVolumeChange.sqf
+++ b/addons/pharma/functions/fnc_getBloodVolumeChange.sqf
@@ -26,8 +26,8 @@ private _enableFluidShift = EGVAR(vitals,enableFluidShift);
 private _fluidVolume = GET_BODY_FLUID(_unit);
 _fluidVolume params ["_ECB","_ECP","_SRBC","_ISP","_fullVolume"];
 
-_ECP = (_ECP + (_lossVolumeChange * LITERS_TO_ML) / 2) max 100;
-_ECB = (_ECB + (_lossVolumeChange * LITERS_TO_ML) / 2) max 100;
+_ECP = (_ECP + (_lossVolumeChange * LITERS_TO_ML) / 2) max 0;
+_ECB = (_ECB + (_lossVolumeChange * LITERS_TO_ML) / 2) max 0;
 
 if (!isNil {_unit getVariable [QACEGVAR(medical,ivBags),[]]}) then {
     private _bloodBags = _unit getVariable [QACEGVAR(medical,ivBags), []];

--- a/addons/pharma/functions/fnc_getBloodVolumeChange.sqf
+++ b/addons/pharma/functions/fnc_getBloodVolumeChange.sqf
@@ -26,8 +26,8 @@ private _enableFluidShift = EGVAR(vitals,enableFluidShift);
 private _fluidVolume = GET_BODY_FLUID(_unit);
 _fluidVolume params ["_ECB","_ECP","_SRBC","_ISP","_fullVolume"];
 
-_ECP = (_ECP + (_lossVolumeChange * LITERS_TO_ML) / 2) max 0;
-_ECB = (_ECB + (_lossVolumeChange * LITERS_TO_ML) / 2) max 0;
+_ECP = (_ECP + (_lossVolumeChange * LITERS_TO_ML) / 2) max 100;
+_ECB = (_ECB + (_lossVolumeChange * LITERS_TO_ML) / 2) max 100;
 
 if (!isNil {_unit getVariable [QACEGVAR(medical,ivBags),[]]}) then {
     private _bloodBags = _unit getVariable [QACEGVAR(medical,ivBags), []];

--- a/addons/vitals/functions/fnc_handleOxygenFunction.sqf
+++ b/addons/vitals/functions/fnc_handleOxygenFunction.sqf
@@ -92,7 +92,7 @@ private _fio2 = switch (true) do {
 private _pALVo2 = ((_fio2 * (_baroPressure - 47)) - (_paco2 / _anerobicPressure)) max 1;
 
 // PaO2 cannot be higher than PALVO2 and comes from ventilation shortage multipled by RBC volume
-private _pao2 = (DEFAULT_PAO2 - ((DEFAULT_ECB / ((GET_BODY_FLUID(_unit) select 0) max 100)) * ((_demandVentilation - _actualVentilation) / 120))) min _pALVo2;
+private _pao2 = (DEFAULT_PAO2 - ((DEFAULT_ECB / ((GET_BODY_FLUID(_unit) select 0) max 500)) * ((_demandVentilation - _actualVentilation) / 120))) min _pALVo2;
 
 // PaO2 moves in controlled steps to prevent hard movements when Ventilation Demand spikes
 _pao2 = if (_previousCyclePao2 != _pao2) then { ([ (_previousCyclePao2 - ((PAO2_MAX_CHANGE * EGVAR(breathing,SpO2_MultiplyNegative)) * _deltaT)) , (_previousCyclePao2 + ((PAO2_MAX_CHANGE * EGVAR(breathing,SpO2_MultiplyPositive)) * _deltaT))] select ((_previousCyclePao2 - _pao2) < 0)) } else { _pao2 };


### PR DESCRIPTION
**When merged this pull request will:**
- _Closes PR #636_
- _Set a floor at `100` to the calculated `ECP` & `ECB`, so you aren't able to bleed into the negatives with `bleedout during cardiac arrest` disabled anymore_
- _Change floor of `(GET_BODY_FLUID(_unit) select 0)` to be `500` instead of `100` in `_pao2` calculations, as it currently results in the `_o2Sat` formula possibly using imaginary numbers and therefore breaking when the patient has the conditions to have a `_fiO2` of `0.21`_

### IMPORTANT

- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
