### PR TITLE
Pharma/Surgery - Tweak open reduction PFH and etomidate time

### DIFF
--- a/addons/pharma/ACE_Medical_Treatment.hpp
+++ b/addons/pharma/ACE_Medical_Treatment.hpp
@@ -257,7 +257,7 @@ class ACE_ADDON(Medical_Treatment) {
             hrIncreaseLow[] = {-5, -10};
             hrIncreaseNormal[] = {-15, -20};
             hrIncreaseHigh[] = {-20, -30};
-            timeInSystem = 45;
+            timeInSystem = 60;
             timeTillMaxEffect = 5;
             maxDose = 10;
             incompatibleMedication[] = {};

--- a/addons/surgery/XEH_preInit.sqf
+++ b/addons/surgery/XEH_preInit.sqf
@@ -63,15 +63,6 @@ PREP_RECOMPILE_END;
 ] call CBA_Settings_fnc_init;
 
 [
-    QGVAR(etomidateTime),
-    "SLIDER",
-    [LLSTRING(ETOMIDATE_TIMER), LLSTRING(ETOMIDATE_TIMER_DESC)],
-    [CBA_SETTINGS_CAT, LSTRING(SubCategory_SurgicalActions)],
-    [0,100,45,0],
-    true
-] call CBA_Settings_fnc_init;
-
-[
     QGVAR(closedTime),
     "SLIDER",
     LLSTRING(CLOSED_TIMER),

--- a/addons/surgery/functions/fnc_incisionLocal.sqf
+++ b/addons/surgery/functions/fnc_incisionLocal.sqf
@@ -49,16 +49,20 @@ _patient setVariable [QGVAR(fractures), _fractureArray, true];
 
     if ((!_alive) || (_liveFracture == 0)) exitWith {
         [_idPFH] call CBA_fnc_removePerFrameHandler;
+        _patient setVariable ["kat_Etomidate_Pain", false]
     };
 
     if (((GVAR(Surgery_ConsciousnessRequirement) in [0,1]) && (!(IS_UNCONSCIOUS(_patient)) || _count >= 0.2)) || (GVAR(Surgery_ConsciousnessRequirement) == 3 && _count == 0)) exitWith {
-        [_patient, "Pain", 10, 40, 200, 0, 40] call ACEFUNC(medical_status,addMedicationAdjustment);
+        if !(_patient getVariable ["kat_Etomidate_Pain", false]) then {
+            [_patient, "Pain", 2, 10, 120, 0.6, 40] call ACEFUNC(medical_status,addMedicationAdjustment);
+            _patient setVariable ["kat_Etomidate_Pain", true]};
         [_patient, true] call ACEFUNC(medical,setUnconscious);
     };
 
     if (GVAR(Surgery_ConsciousnessRequirement) == 2 && _count >= 0.2) then {
-        [_patient, 0.4] call ACEFUNC(medical_status,adjustPainLevel);
-        [_patient, "Pain", 10, 40, 30, 0, 40] call ACEFUNC(medical_status,addMedicationAdjustment);
+        if !(_patient getVariable ["kat_Etomidate_Pain", false]) then {
+            [_patient, "Pain", 2, 10, 120, 0.6, 40] call ACEFUNC(medical_status,addMedicationAdjustment);
+            _patient setVariable ["kat_Etomidate_Pain", true]
+        };
     };
-
 }, 5, [_patient, _part]] call CBA_fnc_addPerFrameHandler;

--- a/addons/surgery/functions/fnc_incisionLocal.sqf
+++ b/addons/surgery/functions/fnc_incisionLocal.sqf
@@ -49,20 +49,21 @@ _patient setVariable [QGVAR(fractures), _fractureArray, true];
 
     if ((!_alive) || (_liveFracture == 0)) exitWith {
         [_idPFH] call CBA_fnc_removePerFrameHandler;
-        _patient setVariable ["kat_Etomidate_Pain", false]
+        _patient setVariable [QGVAR(etomidate_Pain), false]
     };
 
     if (((GVAR(Surgery_ConsciousnessRequirement) in [0,1]) && (!(IS_UNCONSCIOUS(_patient)) || _count >= 0.2)) || (GVAR(Surgery_ConsciousnessRequirement) == 3 && _count == 0)) exitWith {
-        if !(_patient getVariable ["kat_Etomidate_Pain", false]) then {
+        if !(_patient getVariable [QGVAR(etomidate_Pain), false]) then {
             [_patient, "Pain", 2, 10, 120, 0.6, 40] call ACEFUNC(medical_status,addMedicationAdjustment);
-            _patient setVariable ["kat_Etomidate_Pain", true]};
+            _patient setVariable [QGVAR(etomidate_Pain), true]};
         [_patient, true] call ACEFUNC(medical,setUnconscious);
     };
 
     if (GVAR(Surgery_ConsciousnessRequirement) == 2 && _count >= 0.2) then {
-        if !(_patient getVariable ["kat_Etomidate_Pain", false]) then {
+        if !(_patient getVariable [QGVAR(etomidate_Pain), false]) then {
             [_patient, "Pain", 2, 10, 120, 0.6, 40] call ACEFUNC(medical_status,addMedicationAdjustment);
-            _patient setVariable ["kat_Etomidate_Pain", true]
+            _patient setVariable [QGVAR(etomidate_Pain), true]
         };
     };
 }, 5, [_patient, _part]] call CBA_fnc_addPerFrameHandler;
+

--- a/addons/surgery/functions/fnc_incisionLocal.sqf
+++ b/addons/surgery/functions/fnc_incisionLocal.sqf
@@ -43,7 +43,7 @@ _patient setVariable [QGVAR(fractures), _fractureArray, true];
 
     private _fractureArray = _patient getVariable [QGVAR(fractures), [0,0,0,0,0,0]];
     private _liveFracture = _fractureArray select _part;
-    private _count = [_patient, "Etomidate"] call ACEFUNC(medical_status,getMedicationCount);
+    private _count = [_patient, "Etomidate", true] call ACEFUNC(medical_status,getMedicationCount);
 
     private _alive = alive _patient;
 
@@ -51,14 +51,14 @@ _patient setVariable [QGVAR(fractures), _fractureArray, true];
         [_idPFH] call CBA_fnc_removePerFrameHandler;
     };
 
-    if (((GVAR(Surgery_ConsciousnessRequirement) in [0,1]) && (!(IS_UNCONSCIOUS(_patient)) || _count == 0)) || (GVAR(Surgery_ConsciousnessRequirement) == 3 && _count == 0)) exitWith {
+    if (((GVAR(Surgery_ConsciousnessRequirement) in [0,1]) && (!(IS_UNCONSCIOUS(_patient)) || _count >= 0.2)) || (GVAR(Surgery_ConsciousnessRequirement) == 3 && _count == 0)) exitWith {
         [_patient, "Pain", 10, 40, 200, 0, 40] call ACEFUNC(medical_status,addMedicationAdjustment);
         [_patient, true] call ACEFUNC(medical,setUnconscious);
     };
 
-    if (GVAR(Surgery_ConsciousnessRequirement) == 2 && _count == 0) then {
+    if (GVAR(Surgery_ConsciousnessRequirement) == 2 && _count >= 0.2) then {
         [_patient, 0.4] call ACEFUNC(medical_status,adjustPainLevel);
         [_patient, "Pain", 10, 40, 30, 0, 40] call ACEFUNC(medical_status,addMedicationAdjustment);
     };
 
-}, GVAR(etomidateTime), [_patient, _part]] call CBA_fnc_addPerFrameHandler;
+}, 5, [_patient, _part]] call CBA_fnc_addPerFrameHandler;


### PR DESCRIPTION
**When merged this pull request will:**
- Make the open reduction PFH run every 5 seconds rather then set via setting
- Make the PFH use the effectiveness rather then just a check
- Make etomidate 60 seconds time in system rather then 45, 

### IMPORTANT

- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
