### PR TITLE
Circulation - Fix excess leading zeroes in AED-X and CPR time formatting

### DIFF
--- a/addons/circulation/functions/fnc_AEDX_ViewMonitor.sqf
+++ b/addons/circulation/functions/fnc_AEDX_ViewMonitor.sqf
@@ -140,8 +140,17 @@ GVAR(PulseRateReady) = true;
 
     // Handle date and time display - [year,month,day,hour,min]
 
-    ctrlSetText [IDC_DISPLAY_DATEANDTIME, format ["%1/%2/%3               %4:%5", (["", "0"] select (date select 2 < 10)) + str (date select 2), (["", "0"] select (date select 1 < 10)) + str (date select 1), date select 0, (["", "0"] select (date select 3 < 10)) + str (date select 3), (["", "0"] select (date select 4 < 10)) + str (date select 4)]];
-    ctrlSetText [IDC_DISPLAY_ELAPSEDTIME, format ["%1:%2:%3", (["", "0"] select (floor time / 3600 < 10)) + str (floor(time/3600)), (["", "0"] select (floor time / 3600 - floor time / 3600 * 60 < 10)) + str (floor(((time/3600) - floor(time/3600)) * 60)), (["", "0"] select (floor time / 60 - floor time / 60 * 60 < 10)) + str (floor(((time/60) - floor(time/60)) * 60))]];
+    date params ["_year", "_month", "_day", "_hours", "_minutes"];
+    ctrlSetText [
+        IDC_DISPLAY_DATEANDTIME,
+        format ["%1/%2/%3               %4:%5", [_day, 2] call CBA_fnc_formatNumber, [_month, 2] call CBA_fnc_formatNumber, _year, [_hours, 2] call CBA_fnc_formatNumber, [_minutes, 2] call CBA_fnc_formatNumber]
+    ];
+
+    private _time = time;
+    private _hours = floor (_time / 3600);
+    private _minutes = floor ((_time / 60) - (_hours * 60));
+    private _seconds = floor (_time % 60);
+    ctrlSetText [IDC_DISPLAY_ELAPSEDTIME, format ["%1:%2:%3", [_hours, 2] call CBA_fnc_formatNumber, [_minutes, 2] call CBA_fnc_formatNumber, [_seconds, 2] call CBA_fnc_formatNumber]];
 
     if (GVAR(AEDX_MonitorTarget) getVariable [QGVAR(AED_X_VitalsMonitor_Connected), false]) then {
         private _partIndex = ((GVAR(AEDX_MonitorTarget) getVariable [QGVAR(AED_X_VitalsMonitor_Provider), [-1, -1, -1]]) select 2);

--- a/addons/circulation/functions/fnc_AEDX_ViewMonitor_CPR.sqf
+++ b/addons/circulation/functions/fnc_AEDX_ViewMonitor_CPR.sqf
@@ -106,8 +106,14 @@ private _dlg = uiNamespace getVariable ["KAT_Circulation_AEDX_Monitor_Display", 
 
     // Handle date and time display - [year,month,day,hour,min]
 
-    (_dlg displayCtrl IDC_DISPLAY_DATEANDTIME_TITLE) ctrlSetText (format ["%1/%2/%3               %4:%5", (["", "0"] select (date select 2 < 10)) + str (date select 2), (["", "0"] select (date select 1 < 10)) + str (date select 1), date select 0, (["", "0"] select (date select 3 < 10)) + str (date select 3), (["", "0"] select (date select 4 < 10)) + str (date select 4)]);
-    (_dlg displayCtrl IDC_DISPLAY_ELAPSEDTIME_TITLE) ctrlSetText (format ["%1:%2:%3", (["", "0"] select (floor time / 3600 < 10)) + str (floor(time/3600)), (["", "0"] select (floor time / 3600 - floor time / 3600 * 60 < 10)) + str (floor(((time/3600) - floor(time/3600)) * 60)), (["", "0"] select (floor time / 60 - floor time / 60 * 60 < 10)) + str (floor(((time/60) - floor(time/60)) * 60))]);
+    date params ["_year", "_month", "_day", "_hours", "_minutes"];
+    (_dlg displayCtrl IDC_DISPLAY_DATEANDTIME_TITLE) ctrlSetText (format ["%1/%2/%3               %4:%5", [_day, 2] call CBA_fnc_formatNumber, [_month, 2] call CBA_fnc_formatNumber, _year, [_hours, 2] call CBA_fnc_formatNumber, [_minutes, 2] call CBA_fnc_formatNumber]);
+
+    private _time = time;
+    private _hours = floor (_time / 3600);
+    private _minutes = floor ((_time / 60) - (_hours * 60));
+    private _seconds = floor (_time % 60);
+    (_dlg displayCtrl IDC_DISPLAY_ELAPSEDTIME_TITLE) ctrlSetText (format ["%1:%2:%3", [_hours, 2] call CBA_fnc_formatNumber, [_minutes, 2] call CBA_fnc_formatNumber, [_seconds, 2] call CBA_fnc_formatNumber]);
 
     if (GVAR(AEDX_MonitorTarget_Title) getVariable [QGVAR(AED_X_VitalsMonitor_Connected), false]) then {
         private _partIndex = ((GVAR(AEDX_MonitorTarget_Title) getVariable [QGVAR(AED_X_VitalsMonitor_Provider), [-1, -1, -1]]) select 2);

--- a/addons/circulation/functions/fnc_CPRStart.sqf
+++ b/addons/circulation/functions/fnc_CPRStart.sqf
@@ -142,7 +142,9 @@ if (_notInVehicle) then {
 
             // Format time to minutes:seconds
             private _CPRTime = CBA_missionTime - _CPRStartTime;
-            private _time = format ["%1:%2",(["", "0"] select (floor _CPRTime / 3600 - floor _CPRTime / 3600 * 60 < 10)) + str (floor(((_CPRTime/3600) - floor(_CPRTime/3600)) * 60)), (["", "0"] select (floor _CPRTime / 60 - floor _CPRTime / 60 * 60 < 10)) + str (floor(((_CPRTime/60) - floor(_CPRTime/60)) * 60))];
+            private _minutes = floor (_CPRTime / 60);
+            private _seconds = floor (_CPRTime % 60);
+            private _time = format ["%1:%2", [_minutes, 2] call CBA_fnc_formatNumber, [_seconds, 2] call CBA_fnc_formatNumber];
 
             [_patient, "activity", LSTRING(Activity_CPR), [[_medic, false, true] call ACEFUNC(common,getName), _time]] call ACEFUNC(medical_treatment,addToLog);
 


### PR DESCRIPTION
**When merged this pull request will:**
- Overhaul the way AED-X and CPR timestamps are formatted, fixing stuff like this:
![malformed-time-01](https://github.com/user-attachments/assets/96d32023-1ef2-4388-83d2-18106f762aae)
![malformed-time-02](https://github.com/user-attachments/assets/ab89d90a-0e11-4693-b294-c4b66f115c24)
