### PR TITLE
Pharma - Update medication function use for upcoming ACE v3.18.2

### DIFF
--- a/addons/pharma/functions/fnc_applyIV.sqf
+++ b/addons/pharma/functions/fnc_applyIV.sqf
@@ -49,11 +49,11 @@ if (_usedItem isEqualTo "kat_IV_16") then {
     _IVarray set [_partIndex, 1];
     _patient setVariable [QGVAR(IV), _IVarray, true];
 
-    private _lidocaineCount = [_patient, "Lidocaine", false] call ACEFUNC(medical_status,getMedicationCount);
-    private _morphineCount = [_patient, "Morphine", false] call ACEFUNC(medical_status,getMedicationCount);
-    private _nalbuphineCount = [_patient, "Nalbuphine", false] call ACEFUNC(medical_status,getMedicationCount);
-    private _fentanylCount = [_patient, "Fentanyl", false] call ACEFUNC(medical_status,getMedicationCount);
-    private _ketamineCount = [_patient, "Ketamine", false] call ACEFUNC(medical_status,getMedicationCount);
+    private _lidocaineCount = ([_patient, "Lidocaine", false] call ACEFUNC(medical_status,getMedicationCount)) select 1;
+    private _morphineCount = ([_patient, "Morphine", false] call ACEFUNC(medical_status,getMedicationCount)) select 1;
+    private _nalbuphineCount = ([_patient, "Nalbuphine", false] call ACEFUNC(medical_status,getMedicationCount)) select 1;
+    private _fentanylCount = ([_patient, "Fentanyl", false] call ACEFUNC(medical_status,getMedicationCount)) select 1;
+    private _ketamineCount = ([_patient, "Ketamine", false] call ACEFUNC(medical_status,getMedicationCount)) select 1;
     if (_lidocaineCount <=  0.6 && _morphineCount <=  0.6 && _nalbuphineCount <=  0.6 && _fentanylCount <=  0.6 && _ketamineCount <=  0.6) then {[_patient, 0.8] call ACEFUNC(medical_status,adjustPainLevel)};
 
     [_patient, "activity", LSTRING(iv_log), [[_medic] call ACEFUNC(common,getName), "FAST IO"]] call ACEFUNC(medical_treatment,addToLog);

--- a/addons/pharma/functions/fnc_clotWound.sqf
+++ b/addons/pharma/functions/fnc_clotWound.sqf
@@ -113,8 +113,8 @@ private _fnc_clotWound = {
     private _openWounds = _unit getVariable [VAR_OPEN_WOUNDS, createHashMap];
     private _pulse = _unit getVariable [VAR_HEART_RATE, 80];
     private _coagulationFactor = _unit getVariable [QGVAR(coagulationFactor), 30];
-    private _countTXA = [_unit, "TXA"] call ACEFUNC(medical_status,getMedicationCount);
-    private _countEACA = [_unit, "EACA"] call ACEFUNC(medical_status,getMedicationCount);
+    private _countTXA = ([_unit, "TXA"] call ACEFUNC(medical_status,getMedicationCount)) select 1;
+    private _countEACA = ([_unit, "EACA"] call ACEFUNC(medical_status,getMedicationCount)) select 1;
     private _hasWoundToBandageArray = [];
 
     if (_openWounds isEqualTo createHashMap) exitWith {}; // Exit when hashmap not initialized (Will not work when hashmap is set, cause ace only changes value of "woundCount" to 0)

--- a/addons/pharma/functions/fnc_coagRegen.sqf
+++ b/addons/pharma/functions/fnc_coagRegen.sqf
@@ -40,8 +40,8 @@ if !(GVAR(coagulation)) exitWith {};
     private _savedCoagFactors = _unit getVariable [QGVAR(coagulationSavedFactors), (_unit getVariable [QGVAR(coagulationFactor), 30])];
     private _limitRegenCoagFactors = missionNamespace getVariable [QGVAR(coagulation_factor_count), 30];
     private _cooldownON = _unit getVariable [QGVAR(coagulationRegenCooldown), false];
-    private _countTXA = [_unit, "TXA"] call ACEFUNC(medical_status,getMedicationCount);
-    private _countEACA = [_unit, "EACA"] call ACEFUNC(medical_status,getMedicationCount);
+    private _countTXA = ([_unit, "TXA"] call ACEFUNC(medical_status,getMedicationCount)) select 1;
+    private _countEACA = ([_unit, "EACA"] call ACEFUNC(medical_status,getMedicationCount)) select 1;
     private _ammountToAdd = 1;
 
     if (_currentCoagFactors < _savedCoagFactors) exitWith {

--- a/addons/pharma/functions/fnc_medicationLocal.sqf
+++ b/addons/pharma/functions/fnc_medicationLocal.sqf
@@ -82,8 +82,6 @@ private _medicationConfig = _defaultConfig >> _classname;
 private _painReduce             = GET_NUMBER(_medicationConfig >> "painReduce",getNumber (_defaultConfig >> "painReduce"));
 private _timeInSystem           = GET_NUMBER(_medicationConfig >> "timeInSystem",getNumber (_defaultConfig >> "timeInSystem"));
 private _timeTillMaxEffect      = GET_NUMBER(_medicationConfig >> "timeTillMaxEffect",getNumber (_defaultConfig >> "timeTillMaxEffect"));
-private _maxDose                = GET_NUMBER(_medicationConfig >> "maxDose",getNumber (_defaultConfig >> "maxDose"));
-private _maxDoseDeviation       = GET_NUMBER(_medicationConfig >> "maxDoseDeviation",getNumber (_defaultConfig >> "maxDoseDeviation"));
 private _viscosityChange        = GET_NUMBER(_medicationConfig >> "viscosityChange",getNumber (_defaultConfig >> "viscosityChange"));
 private _hrIncreaseLow          = GET_ARRAY(_medicationConfig >> "hrIncreaseLow",getArray (_defaultConfig >> "hrIncreaseLow"));
 private _hrIncreaseNormal       = GET_ARRAY(_medicationConfig >> "hrIncreaseNormal",getArray (_defaultConfig >> "hrIncreaseNormal"));
@@ -112,7 +110,7 @@ TRACE_3("adjustments",_heartRateChange,_painReduce,_viscosityChange);
 [_patient, _className, _timeTillMaxEffect, _timeInSystem, _heartRateChange, _painReduce, _viscosityChange, _alphaFactor, _opioidRelief, _opioidEffect] call EFUNC(vitals,addMedicationAdjustment);
 
 // Check for medication compatiblity
-[_patient, _className, _maxDose, _maxDoseDeviation, _incompatibleMedication] call ACEFUNC(medical_treatment,onMedicationUsage);
+[_patient, _className, _incompatibleMedication] call ACEFUNC(medical_treatment,onMedicationUsage);
 
 if (_className in ["Lorazepam","EACA","TXA","Atropine","Amiodarone","Flumazenil"]) then {
     [format ["kat_pharma_%1Local", toLower _className], [_patient, _bodyPart], _patient] call CBA_fnc_targetEvent;

--- a/addons/pharma/functions/fnc_treatmentAdvanced_EACALocal.sqf
+++ b/addons/pharma/functions/fnc_treatmentAdvanced_EACALocal.sqf
@@ -21,7 +21,7 @@ params ["_patient", "_bodyPart"];
 private _partIndex = ALL_BODY_PARTS find toLower _bodyPart;
 private _IVarray = _patient getVariable [QGVAR(IV), [0,0,0,0,0,0]];
 private _IVactual = _IVarray select _partIndex;
-private _countEACA = [_patient, "EACA"] call ACEFUNC(medical_status,getMedicationCount);
+private _countEACA = ([_patient, "EACA"] call ACEFUNC(medical_status,getMedicationCount)) select 1;
 private _allowStack = missionNamespace getVariable [QGVAR(allowStackScript_EACA), true];
 private _keepRunning = missionNamespace getVariable [QGVAR(keepScriptRunning_EACA), false];
 private _cycleTime = missionNamespace getVariable [QGVAR(bandageCycleTime_EACA), 5];

--- a/addons/pharma/functions/fnc_treatmentAdvanced_TXALocal.sqf
+++ b/addons/pharma/functions/fnc_treatmentAdvanced_TXALocal.sqf
@@ -21,7 +21,7 @@ params ["_patient", "_bodyPart"];
 private _partIndex = ALL_BODY_PARTS find toLower _bodyPart;
 private _IVarray = _patient getVariable [QGVAR(IV), [0,0,0,0,0,0]];
 private _IVactual = _IVarray select _partIndex;
-private _countTXA = [_patient, "TXA"] call ACEFUNC(medical_status,getMedicationCount);
+private _countTXA = ([_patient, "TXA"] call ACEFUNC(medical_status,getMedicationCount)) select 1;
 private _allowStack = missionNamespace getVariable [QGVAR(allowStackScript_TXA), true];
 private _keepRunning = missionNamespace getVariable [QGVAR(keepScriptRunning_TXA), false];
 private _cycleTime = missionNamespace getVariable [QGVAR(bandageCycleTime_TXA), 5];

--- a/addons/surgery/functions/fnc_closedReductionLocal.sqf
+++ b/addons/surgery/functions/fnc_closedReductionLocal.sqf
@@ -22,11 +22,11 @@ params ["_medic", "_patient", "_bodyPart"];
 private _part = ALL_BODY_PARTS find toLower _bodyPart;
 private _activeFracture = GET_FRACTURES(_patient);
 private _fractureArray = _patient getVariable [QGVAR(fractures), [0,0,0,0,0,0]];
-private _lidocaineCount = [_patient, "Lidocaine", false] call ACEFUNC(medical_status,getMedicationCount);
-private _morphineCount = [_patient, "Morphine", false] call ACEFUNC(medical_status,getMedicationCount);
-private _nalbuphineCount = [_patient, "Nalbuphine", false] call ACEFUNC(medical_status,getMedicationCount);
-private _fentanylCount = [_patient, "Fentanyl", false] call ACEFUNC(medical_status,getMedicationCount);
-private _ketamineCount = [_patient, "Ketamine", false] call ACEFUNC(medical_status,getMedicationCount);
+private _lidocaineCount = ([_patient, "Lidocaine", false] call ACEFUNC(medical_status,getMedicationCount)) select 1;
+private _morphineCount = ([_patient, "Morphine", false] call ACEFUNC(medical_status,getMedicationCount)) select 1;
+private _nalbuphineCount = ([_patient, "Nalbuphine", false] call ACEFUNC(medical_status,getMedicationCount)) select 1;
+private _fentanylCount = ([_patient, "Fentanyl", false] call ACEFUNC(medical_status,getMedicationCount)) select 1;
+private _ketamineCount = ([_patient, "Ketamine", false] call ACEFUNC(medical_status,getMedicationCount)) select 1;
 if (_lidocaineCount <=  0.6 && _morphineCount <=  0.8 && _nalbuphineCount <=  0.8 && _fentanylCount <=  0.8 && _ketamineCount <=  0.8) then {
     private _pain = random [0.7, 0.8, 0.9];
     [_patient, _pain] call ACEFUNC(medical_status,adjustPainLevel);

--- a/addons/surgery/functions/fnc_incisionLocal.sqf
+++ b/addons/surgery/functions/fnc_incisionLocal.sqf
@@ -43,7 +43,7 @@ _patient setVariable [QGVAR(fractures), _fractureArray, true];
 
     private _fractureArray = _patient getVariable [QGVAR(fractures), [0,0,0,0,0,0]];
     private _liveFracture = _fractureArray select _part;
-    private _count = [_patient, "Etomidate", true] call ACEFUNC(medical_status,getMedicationCount);
+    private _count = ([_patient, "Etomidate", true] call ACEFUNC(medical_status,getMedicationCount)) select 1;
 
     private _alive = alive _patient;
 


### PR DESCRIPTION
**When merged this pull request will:**
- Update the use of ACE Medical functions that were recently changed by https://github.com/acemod/ACE3/pull/10393/, to prevent broken medication behaviour once [ACE v3.18.2](https://github.com/acemod/ACE3/milestone/63) is released:
  - 2 params were removed from `medical_treatment_fnc_onMedicationUsage`, that data is now fetched internally.
  - `medical_status_fnc_getMedicationCount` now returns an `[num,num]` array instead of a single `num`, so we have to select the desired element from the array.