### PR TITLE
Circulation - Cardiac Arrest Hold for H&T Conditions

### DIFF
--- a/addons/circulation/XEH_preInit.sqf
+++ b/addons/circulation/XEH_preInit.sqf
@@ -399,6 +399,16 @@ if (isServer) then {
     true
 ] call CBA_Settings_fnc_init;
 
+// Sets whether or not H&T conditions keep patients in cardiac arrest until resolved
+[
+    QGVAR(AdvRhythm_HTHold),
+    "CHECKBOX",
+    LLSTRING(SETTING_AdvRhythm_HTHold),
+    [CBA_SETTINGS_CAT, LSTRING(SubCategory_AdvRhythms)],
+    [false],
+    true
+] call CBA_Settings_fnc_init;
+
 // Sets chance for Pulseless Electrical Activity / Asystole
 [
     QGVAR(AdvRhythm_PEAChance),

--- a/addons/circulation/functions/fnc_cprLocal.sqf
+++ b/addons/circulation/functions/fnc_cprLocal.sqf
@@ -32,6 +32,11 @@ private _fnc_advRhythm = {
     params ["_patient", ["_CPR",false]];
 
     private _patientState = _patient getVariable [QGVAR(cardiacArrestType), 0];
+    private _ht = if (GVAR(AdvRhythm_HTHold)) then {
+        ((count(_patient getVariable [QGVAR(ht), []])) == 0)
+    } else {
+        true
+    };
 
     if (_CPR) then {
         if (floor (random 100) < GVAR(AdvRhythm_CPR_ROSC_Chance)) then {
@@ -57,7 +62,7 @@ private _fnc_advRhythm = {
         };
     };
 
-    if (_patient getVariable [QGVAR(cardiacArrestType), 0] isEqualTo 0) exitWith {
+    if ((_patient getVariable [QGVAR(cardiacArrestType), 0] isEqualTo 0) && _ht) exitWith {
         [QACEGVAR(medical,CPRSucceeded), _patient] call CBA_fnc_localEvent;
     };
 

--- a/addons/circulation/stringtable.xml
+++ b/addons/circulation/stringtable.xml
@@ -3051,6 +3051,9 @@
             <Italian>Peso del tempo di deterioramento casuale</Italian>
             <Chinesesimp>随机劣化时间权重</Chinesesimp>
         </Key>
+        <Key ID="STR_KAT_Circulation_SETTING_AdvRhythm_HTHold">
+            <English>Enable H-and-T Holding in Arrest</English>
+        </Key>
         <Key ID="STR_KAT_Circulation_SETTING_AdvRhythm_deteriorateAfterTreatment">
             <English>Deteriorate After Treatment</English>
             <Japanese>治療後に調律状態が悪化するようにする</Japanese>


### PR DESCRIPTION
**When merged this pull request will:**
- Adds setting for H&T conditions to make cardiac arrest never succeed when H&T conditions are present

### IMPORTANT

- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
