### PR TITLE
Circulation - Add Nitroglycerin Impacts to Cardiac Arrest Chance and Adjust H&T Factor Impact

### DIFF
--- a/addons/circulation/functions/fnc_cprLocal.sqf
+++ b/addons/circulation/functions/fnc_cprLocal.sqf
@@ -26,6 +26,7 @@ private _randomAmi = random 4;
 private _epiBoost = 1;
 private _amiBoost = 0;
 private _lidoBoost = 0;
+private _nitroEffect = 1;
 private _CPRcount = _patient getVariable [QGVAR(cprCount), 0];
 
 private _fnc_advRhythm = {
@@ -62,7 +63,11 @@ private _fnc_advRhythm = {
         };
     };
 
-    if ((_patient getVariable [QGVAR(cardiacArrestType), 0] isEqualTo 0) && _ht) exitWith {
+    if !(_ht) then {
+        _patient setVariable [QGVAR(cardiacArrestType), 1, true];
+    };
+
+    if ((_patient getVariable [QGVAR(cardiacArrestType), 0] isEqualTo 0)) exitWith {
         [QACEGVAR(medical,CPRSucceeded), _patient] call CBA_fnc_localEvent;
     };
 
@@ -91,6 +96,10 @@ private _fnc_advRhythm = {
         case "Lidocaine":
         {
             _lidoBoost = _lidoBoost + 8;
+        };
+        case "Nitroglycerin":
+        {
+            _nitroEffect = _nitroEffect + 1;
         };
     };
 } forEach (_patient getVariable [QACEGVAR(medical,medications), []]);
@@ -122,7 +131,7 @@ switch (_reviveObject) do {
 };
 
 if (_reviveObject in ["AED", "AEDX"]) exitWith {
-    _chance = _chance + (_amiBoost + (1 max _lidoBoost) * _epiBoost);
+    _chance = _chance + (_amiBoost + (1 max _lidoBoost) * _epiBoost) / _nitroEffect;
 
     private _patientState = _patient getVariable [QGVAR(cardiacArrestType), 0];
 
@@ -168,6 +177,8 @@ if !(GVAR(enable_CPR_Chances)) then {
     if (_patient getVariable [QGVAR(cardiacArrestType), 0] in [4,3] && _randomAmi > 2) then {
         _chance = _chance + _amiBoost;
     };
+
+    _chance = _chance / _nitroEffect;
 
     if (_random <= _chance) then {
         if (GVAR(AdvRhythm)) then {

--- a/addons/circulation/functions/fnc_handleCardiacArrest.sqf
+++ b/addons/circulation/functions/fnc_handleCardiacArrest.sqf
@@ -57,6 +57,12 @@ if (_initial) then {
         _cardiacArrestType = 2;
     };
 
+    private _nitroCount = [_patient, "Nitroglycerin", false] call ACEFUNC(medical_status,getMedicationCount);
+
+    if ((_nitroCount < 0.7) && ((random 3) < 1)) then {
+        _cardiacArrestType = 1;
+    };
+
     _unit setVariable [QGVAR(cardiacArrestType), _cardiacArrestType, true];
 } else {
     _cardiacArrestType = _unit getVariable [QGVAR(cardiacArrestType), 0];

--- a/addons/circulation/functions/fnc_handleCardiacArrest.sqf
+++ b/addons/circulation/functions/fnc_handleCardiacArrest.sqf
@@ -59,8 +59,8 @@ if (_initial) then {
 
     private _nitroCount = ([_patient, "Nitroglycerin", false] call ACEFUNC(medical_status,getMedicationCount)) select 1;
 
-    if ((_nitroCount < 0.7) && ((random 3) < 1)) then {
-        _cardiacArrestType = 1;
+    if ((_nitroCount < 0.5) && ((random 3) < 1)) then {
+        _cardiacArrestType = 2;
     };
 
     _unit setVariable [QGVAR(cardiacArrestType), _cardiacArrestType, true];

--- a/addons/circulation/functions/fnc_handleCardiacArrest.sqf
+++ b/addons/circulation/functions/fnc_handleCardiacArrest.sqf
@@ -57,7 +57,7 @@ if (_initial) then {
         _cardiacArrestType = 2;
     };
 
-    private _nitroCount = [_patient, "Nitroglycerin", false] call ACEFUNC(medical_status,getMedicationCount);
+    private _nitroCount = ([_patient, "Nitroglycerin", false] call ACEFUNC(medical_status,getMedicationCount)) select 1;
 
     if ((_nitroCount < 0.7) && ((random 3) < 1)) then {
         _cardiacArrestType = 1;


### PR DESCRIPTION
**When merged this pull request will:**
- Adds negative impact to all cardiac arrest interventions when nitroglycerin is present
- Moves H&T Factors to prevent patient getting stuck in cardiac arrest loop with no cardiac arrest type

### IMPORTANT

- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
