### PR TITLE
Surgery - Add Ultrasound Airway Condition

### DIFF
--- a/addons/surgery/functions/fnc_ultraAssessmentLocal.sqf
+++ b/addons/surgery/functions/fnc_ultraAssessmentLocal.sqf
@@ -25,6 +25,10 @@ private _thorasic = LSTRING(Ultra_Airway_Normal);
 
 _patient setVariable [QGVAR(imaging), true, true];
 
+if ((_unit getVariable [QEGVAR(airway,occluded), false]) || (_unit getVariable [QEGVAR(airway,obstruction), false])) then {
+    _airway = LSTRING(Ultra_Airway_Compromise);
+}
+
 //Reads Thorasic Condition
 if ((_patient getVariable [QEGVAR(breathing,pneumothorax), 0]) != 0) then {
     _thorasic = LSTRING(Ultra_Thorasic_PTX);

--- a/addons/surgery/functions/fnc_ultraAssessmentLocal.sqf
+++ b/addons/surgery/functions/fnc_ultraAssessmentLocal.sqf
@@ -27,7 +27,7 @@ _patient setVariable [QGVAR(imaging), true, true];
 
 if ((_unit getVariable [QEGVAR(airway,occluded), false]) || (_unit getVariable [QEGVAR(airway,obstruction), false])) then {
     _airway = LSTRING(Ultra_Airway_Compromise);
-}
+};
 
 //Reads Thorasic Condition
 if ((_patient getVariable [QEGVAR(breathing,pneumothorax), 0]) != 0) then {

--- a/addons/surgery/stringtable.xml
+++ b/addons/surgery/stringtable.xml
@@ -725,6 +725,9 @@
             <German>Normal</German>
             <Chinesesimp>正常</Chinesesimp>
         </Key>
+        <Key ID="STR_KAT_Surgery_Ultra_Airway_Compromise">
+            <English>Compromised</English>
+        </Key>
         <Key ID="STR_KAT_Surgery_Ultra_Airway_NoActivity">
             <English>No Activity</English>
             <Japanese>活動なし</Japanese>


### PR DESCRIPTION
**When merged this pull request will:**
- Marks airway as compromised when either an occlusion or obstruction are present
- Reads as compromised regardless of hyperextension or recovery position

### IMPORTANT

- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
