### PR TITLE
Pharma - Fix getMedicationCount on coagRegen

### DIFF
--- a/addons/pharma/functions/fnc_coagRegen.sqf
+++ b/addons/pharma/functions/fnc_coagRegen.sqf
@@ -40,8 +40,8 @@ if !(GVAR(coagulation)) exitWith {};
     private _savedCoagFactors = _unit getVariable [QGVAR(coagulationSavedFactors), (_unit getVariable [QGVAR(coagulationFactor), 30])];
     private _limitRegenCoagFactors = missionNamespace getVariable [QGVAR(coagulation_factor_count), 30];
     private _cooldownON = _unit getVariable [QGVAR(coagulationRegenCooldown), false];
-    private _countTXA = [_unit, "TXA"] call ACEFUNC(medical_status,getMedicationCount);
-    private _countEACA = [_unit, "EACA"] call ACEFUNC(medical_status,getMedicationCount);
+    private _countTXA = ([_unit, "TXA"] call ACEFUNC(medical_status,getMedicationCount)) select 1;
+    private _countEACA = ([_unit, "EACA"] call ACEFUNC(medical_status,getMedicationCount)) select 1;
     private _ammountToAdd = 1;
 
     if (_currentCoagFactors < _savedCoagFactors) exitWith {

--- a/addons/pharma/functions/fnc_coagRegen.sqf
+++ b/addons/pharma/functions/fnc_coagRegen.sqf
@@ -10,7 +10,7 @@
  * None
  *
  * Example:
- * [player] call kat_pharma_fnc_clotWound;
+ * [player] call kat_pharma_fnc_coagRegen;
  *
  * Public: No
  */


### PR DESCRIPTION
**When merged this pull request will:**
- Add `Select 1` at ace_medical_status_fnc_getMedicationCount in kat_pharma_fnc_coagRegen
- For latest ace overdose update maybe missed on https://github.com/KAT-Advanced-Medical/KAM/pull/675

### IMPORTANT

- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
