### PR TITLE
Surgery - Change Clotting Values

### DIFF
--- a/addons/surgery/ACE_Medical_Treatment.hpp
+++ b/addons/surgery/ACE_Medical_Treatment.hpp
@@ -51,7 +51,7 @@ class ACE_Medical_Treatment {
         class BloodClotMinor: FieldDressing {
             class Abrasion {
                 effectiveness = 0;
-                reopeningChance = 0.5;
+                reopeningChance = 0.4;
                 reopeningMinDelay = 120;
                 reopeningMaxDelay = 900;
             };
@@ -116,8 +116,8 @@ class ACE_Medical_Treatment {
         class BloodClotMedium: FieldDressing {
              class Abrasion {
                 effectiveness = 0;
-                reopeningChance = 0.6;
-                reopeningMinDelay = 60;
+                reopeningChance = 0.5;
+                reopeningMinDelay = 90;
                 reopeningMaxDelay = 600;
             };
             class AbrasionMinor: Abrasion {};
@@ -179,8 +179,8 @@ class ACE_Medical_Treatment {
         class BloodClotLarge: FieldDressing {
             class Abrasion {
                 effectiveness = 0;
-                reopeningChance = 0.8;
-                reopeningMinDelay = 30;
+                reopeningChance = 0.7;
+                reopeningMinDelay = 60;
                 reopeningMaxDelay = 600;
             };
             class AbrasionMinor: Abrasion {};

--- a/addons/surgery/ACE_Medical_Treatment.hpp
+++ b/addons/surgery/ACE_Medical_Treatment.hpp
@@ -52,7 +52,7 @@ class ACE_Medical_Treatment {
             class Abrasion {
                 effectiveness = 0;
                 reopeningChance = 0.6;
-                reopeningMinDelay = 300;
+                reopeningMinDelay = 120;
                 reopeningMaxDelay = 900;
             };
             class AbrasionMinor: Abrasion {
@@ -117,7 +117,7 @@ class ACE_Medical_Treatment {
              class Abrasion {
                 effectiveness = 0;
                 reopeningChance = 0.5;
-                reopeningMinDelay = 300;
+                reopeningMinDelay = 60;
                 reopeningMaxDelay = 600;
             };
             class AbrasionMinor: Abrasion {};
@@ -180,7 +180,7 @@ class ACE_Medical_Treatment {
             class Abrasion {
                 effectiveness = 0;
                 reopeningChance = 0.8;
-                reopeningMinDelay = 150;
+                reopeningMinDelay = 30;
                 reopeningMaxDelay = 600;
             };
             class AbrasionMinor: Abrasion {};

--- a/addons/surgery/ACE_Medical_Treatment.hpp
+++ b/addons/surgery/ACE_Medical_Treatment.hpp
@@ -51,7 +51,7 @@ class ACE_Medical_Treatment {
         class BloodClotMinor: FieldDressing {
             class Abrasion {
                 effectiveness = 0;
-                reopeningChance = 0.6;
+                reopeningChance = 0.5;
                 reopeningMinDelay = 120;
                 reopeningMaxDelay = 900;
             };
@@ -116,7 +116,7 @@ class ACE_Medical_Treatment {
         class BloodClotMedium: FieldDressing {
              class Abrasion {
                 effectiveness = 0;
-                reopeningChance = 0.5;
+                reopeningChance = 0.6;
                 reopeningMinDelay = 60;
                 reopeningMaxDelay = 600;
             };

--- a/addons/surgery/ACE_Medical_Treatment.hpp
+++ b/addons/surgery/ACE_Medical_Treatment.hpp
@@ -52,7 +52,7 @@ class ACE_Medical_Treatment {
             class Abrasion {
                 effectiveness = 0;
                 reopeningChance = 0.4;
-                reopeningMinDelay = 120;
+                reopeningMinDelay = 150;
                 reopeningMaxDelay = 900;
             };
             class AbrasionMinor: Abrasion {
@@ -117,7 +117,7 @@ class ACE_Medical_Treatment {
              class Abrasion {
                 effectiveness = 0;
                 reopeningChance = 0.5;
-                reopeningMinDelay = 90;
+                reopeningMinDelay = 120;
                 reopeningMaxDelay = 600;
             };
             class AbrasionMinor: Abrasion {};
@@ -180,7 +180,7 @@ class ACE_Medical_Treatment {
             class Abrasion {
                 effectiveness = 0;
                 reopeningChance = 0.7;
-                reopeningMinDelay = 60;
+                reopeningMinDelay = 90;
                 reopeningMaxDelay = 600;
             };
             class AbrasionMinor: Abrasion {};


### PR DESCRIPTION
This PR intends to adjust the clotting duration and reopening chances in order to reduce the overall effectiveness of clotting and encourage the use of TXA/EACA for patients with a large number of wounds while still maintaining a level of effectiveness for patients needing minimal care.

**When merged this pull request will:**
- Lower the minimum duration of natural clots (Minor 300>120, Medium 300>60, Major 150>30)
- Swap the reopening chances of minor and medium natural clots

### IMPORTANT

- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
