### PR TITLE
Surgery - Remove REBOA model

### DIFF
--- a/addons/surgery/CfgWeapons.hpp
+++ b/addons/surgery/CfgWeapons.hpp
@@ -71,7 +71,6 @@ class CfgWeapons {
         scope = 2;
         displayName = CSTRING(Reboa_DisplayName);
         picture = QPATHTOF(ui\reboa.paa);
-        model = "\A3\Structures_F_Heli\Items\Electronics\HDMICable_01_F.p3d";
         descriptionShort = CSTRING(Reboa_DescShort);
         class ItemInfo: CBA_MiscItem_ItemInfo {
             mass = 1;


### PR DESCRIPTION
**When merged this pull request will:**
 Remove the HDMI cable from the helicopter's dlc for the reboa dropped item, thus removing the watermark for people that don't own said dlc.

### IMPORTANT

- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
