### PR TITLE
Circulation - Fix PEA occurring when chance is 0

### DIFF
--- a/addons/circulation/functions/fnc_handleCardiacArrest.sqf
+++ b/addons/circulation/functions/fnc_handleCardiacArrest.sqf
@@ -40,7 +40,7 @@ if (_initial) then {
     if !(_active) exitWith {};
 
     if (GET_BLOOD_VOLUME_LITERS(_unit) < GVAR(AdvRhythm_asystoleBloodlossThreshold)) then {
-        if (floor (random 100) < GVAR(AdvRhythm_PEAChance)) then {
+        if ((floor (random 100) < GVAR(AdvRhythm_PEAChance)) && GVAR(AdvRhythm_PEAEnabled)) then {
             _cardiacArrestType = 2;
         } else {
             _cardiacArrestType = 1;
@@ -96,7 +96,7 @@ if (GVAR(AdvRhythm_canDeteriorate)) then {
                 params ["_unit"];
 
                 private _targetType = 1;
-                if (floor (random 100) < GVAR(AdvRhythm_PEAChance)) then {
+                if ((floor (random 100) < GVAR(AdvRhythm_PEAChance)) && GVAR(AdvRhythm_PEAEnabled)) then {
                     _targetType = 2;
                 } else {
                     _targetType = 1;
@@ -135,7 +135,7 @@ if (GVAR(AdvRhythm_canDeteriorate)) then {
                 params ["_unit"];
 
                 private _targetType = 1;
-                if (floor (random 100) < GVAR(AdvRhythm_PEAChance)) then {
+                if ((floor (random 100) < GVAR(AdvRhythm_PEAChance)) && GVAR(AdvRhythm_PEAEnabled)) then {
                     _targetType = 2;
                 } else {
                     _targetType = 1;

--- a/addons/circulation/functions/fnc_handleCardiacArrest.sqf
+++ b/addons/circulation/functions/fnc_handleCardiacArrest.sqf
@@ -54,13 +54,21 @@ if (_initial) then {
     };
 
     if ((count(_unit getVariable [QGVAR(ht), []])) != 0) then {
-        _cardiacArrestType = 2;
+        if (GVAR(AdvRhythm_PEAEnabled)) then {
+            _cardiacArrestType = 2;
+        } else {
+            _cardiacArrestType = 1;
+        };
     };
 
     private _nitroCount = ([_unit, "Nitroglycerin", false] call ACEFUNC(medical_status,getMedicationCount)) select 1;
 
     if ((_nitroCount < 0.5) && ((random 3) < 1)) then {
-        _cardiacArrestType = 2;
+        if (GVAR(AdvRhythm_PEAEnabled)) then {
+            _cardiacArrestType = 2;
+        } else {
+            _cardiacArrestType = 1;
+        };
     };
 
     _unit setVariable [QGVAR(cardiacArrestType), _cardiacArrestType, true];

--- a/addons/circulation/initSettings.inc.sqf
+++ b/addons/circulation/initSettings.inc.sqf
@@ -392,6 +392,15 @@
 
 // Sets chance for Pulseless Electrical Activity / Asystole
 [
+    QGVAR(AdvRhythm_PEAEnabled),
+    "CHECKBOX",
+    LLSTRING(SETTING_AdvRhythm_PEAEnabled),
+    [CBA_SETTINGS_CAT, LSTRING(SubCategory_AdvRhythms)],
+    [false],
+    true
+] call CBA_fnc_addSetting;
+
+[
     QGVAR(AdvRhythm_PEAChance),
     "SLIDER",
     LLSTRING(SETTING_AdvRhythm_PEAChance),

--- a/addons/circulation/initSettings.inc.sqf
+++ b/addons/circulation/initSettings.inc.sqf
@@ -390,7 +390,7 @@
     true
 ] call CBA_fnc_addSetting;
 
-// Sets chance for Pulseless Electrical Activity / Asystole
+// Sets if PEA is enabled or disabled
 [
     QGVAR(AdvRhythm_PEAEnabled),
     "CHECKBOX",
@@ -400,6 +400,7 @@
     true
 ] call CBA_fnc_addSetting;
 
+// Sets chance for Pulseless Electrical Activity / Asystole
 [
     QGVAR(AdvRhythm_PEAChance),
     "SLIDER",

--- a/addons/circulation/stringtable.xml
+++ b/addons/circulation/stringtable.xml
@@ -2595,6 +2595,9 @@
             <Finnish>Pulssittoman sähköisen toiminnan mahdollisuus</Finnish>
             <Dutch>PEA kans</Dutch>
         </Key>
+        <Key ID="STR_KAT_Circulation_SETTING_AdvRhythm_PEAEnabled">
+            <English>Enable PEA</English>
+        </Key>
         <Key ID="STR_KAT_Circulation_SETTING_AdvRhythm_VTChance">
             <English>VT Chance</English>
             <Czech>Šance VT</Czech>


### PR DESCRIPTION
**When merged this pull request will:**
- Add a checkbox to enable PEA
- Adds a check if enabled to nitro caused CA and h&ts

### IMPORTANT

- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
