### PR TITLE
misc / stretcher  - Change config lookup to `configOf`

### DIFF
--- a/addons/misc/functions/fnc_groupID.sqf
+++ b/addons/misc/functions/fnc_groupID.sqf
@@ -24,5 +24,5 @@ if (_unit getVariable [QGVAR(loadout), nil] isEqualType "") exitWith {
 private _loadout = _unit getVariable QGVAR(loadout);
   format ["%1: %2", _groupID, _loadout];
 };
-private _loadout = getText (configFile >> "CfgVehicles" >> typeOf _unit >> "displayName");
+private _loadout = getText (configOf _unit >> "displayName");
 format ["%1: %2", _groupID, _loadout];

--- a/addons/stretcher/functions/fnc_attachStretcher.sqf
+++ b/addons/stretcher/functions/fnc_attachStretcher.sqf
@@ -33,8 +33,8 @@ private _actions = [];
                 "",
                 {
                     params ["_target", "", "_parameter"];
-                    private _pos = getArray (configFile >> "CfgVehicles" >> typeOf (_parameter select 0) >> "kat_stretcherPos");
-                    private _vector = getArray (configFile >> "CfgVehicles" >> typeOf (_parameter select 0) >> "kat_stretcherVector");
+                    private _pos = getArray (configOf (_parameter select 0) >> "kat_stretcherPos");
+                    private _vector = getArray (configOf (_parameter select 0) >> "kat_stretcherVector");
                     _target attachTo [(_parameter select 0), _pos];
                     _target setVectorDirAndUp _vector;
                 },


### PR DESCRIPTION
**When merged this pull request will:**
- as per hemtt 
```c++
warning[L-S30]: Use configOf instead of typeOf with configFile for variable `_parameter select 0`
   ┌─ addons/stretcher/functions/fnc_attachStretcher.sqf:36:46
   │
36 │                     private _pos = getArray (configFile >> "CfgVehicles" >> typeOf (_parameter select 0) >> "kat_stretcherPos");
   │                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   │
   = try: configOf (_parameter select 0)
```
### IMPORTANT

- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
