### PR TITLE
Airway - Increase Max Occlusion cooldown

### DIFF
--- a/addons/airway/initSettings.inc.sqf
+++ b/addons/airway/initSettings.inc.sqf
@@ -55,7 +55,7 @@
     "SLIDER",
     [LLSTRING(SETTING_occlusion_cooldownPeriod), LLSTRING(SETTING_occlusion_cooldownPeriod_DESC)],
     [CBA_SETTINGS_CAT, ELSTRING(GUI,SubCategory_Basic)],
-    [0, 60, 6, 1],
+    [0, 1200, 6, 1],
     true
 ] call CBA_fnc_addSetting;
 


### PR DESCRIPTION
**When merged this pull request will:**
Increase the max CBA setting value for occlusion cooldowns from 60 seconds to 20 minutes. We'd like the flexibility to have this cooldown be a bit longer, as occasionally folks will vomit 3-4 times during a casualty event.

### IMPORTANT

- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
