### PR TITLE
KAT Medical - Add Turkish translation

### DIFF
--- a/addons/airway/stringtable.xml
+++ b/addons/airway/stringtable.xml
@@ -53,7 +53,7 @@
             <Japanese>口咽頭エアウェイの許可</Japanese>
             <Chinese>允許 Guedel（口腔通氣管）</Chinese>
             <Chinesesimp>允许使用口咽通气道(Guedel)</Chinesesimp>
-            <Turkish>Guedel Tüp'e izin ver</Turkish>
+            <Turkish>Guedel Tüpe izin ver</Turkish>
             <Norwegian>Tillat Guedeltubus</Norwegian>
             <Finnish>salli Guedel-putken</Finnish>
             <Dutch>Sta Guedel-tube toe</Dutch>
@@ -72,7 +72,7 @@
             <Japanese>口咽頭エアウェイ(ゲデルチューブ)の使用に必要な医療スキルのレベルを設定します。</Japanese>
             <Chinese>使用喉管所需的訓練水平 - Guedel（口腔通氣管）</Chinese>
             <Chinesesimp>使用口咽通气道所需的医疗培训水平</Chinesesimp>
-            <Turkish>Guedel Tüp'ü kullanmak için gerekli eğitim seviyesi</Turkish>
+            <Turkish>Guedel Tüpü kullanmak için gerekli eğitim seviyesi</Turkish>
             <Norwegian>Nivået av opplæring som kreves for å bruke en Guedeltubus</Norwegian>
             <Finnish>Guedel-putken käyttämiseen vaadittava koulutustaso</Finnish>
             <Dutch>Trainingsniveau benodigd om een Guedel-tube in te brengen</Dutch>
@@ -91,7 +91,7 @@
             <Japanese>喉頭エアウェイの許可</Japanese>
             <Chinese>允許 喉管(King LT-D)</Chinese>
             <Chinesesimp>允许使用喉管(King LT-D)</Chinesesimp>
-            <Turkish>Laringeal Tüp'e izin ver</Turkish>
+            <Turkish>Larenks Tüpüne izin ver</Turkish>
             <Norwegian>Tillat larynxtubus</Norwegian>
             <Finnish>salli kurkunpään putki</Finnish>
             <Dutch>Sta King LT toe</Dutch>
@@ -110,7 +110,7 @@
             <Japanese>喉頭エアウェイ(King LT)の使用に必要な医療スキルのレベルを設定します。</Japanese>
             <Chinese>使用喉管所需的培訓水平-KingLT</Chinese>
             <Chinesesimp>使用喉管所需的医疗培训水平</Chinesesimp>
-            <Turkish>Laringeal Tüp'ü kullanmak için gerekli eğitim seviyesi</Turkish>
+            <Turkish>Larenks Tüpü kullanmak için gereken eğitim seviyesi</Turkish>
             <Norwegian>Nivået av opplæring som kreves for å bruke en Larynkstube</Norwegian>
             <Finnish>Kurkunpään putken käyttämiseen vaadittava koulutustaso</Finnish>
             <Dutch>Trainingsniveau benodigd om een King LT in te brengen</Dutch>
@@ -129,6 +129,7 @@
             <Chinesesimp>允许手动抽吸泵</Chinesesimp>
             <Finnish>Salli manuaalinen imupumppu</Finnish>
             <Dutch>Sta handmatige suctiepomp toe</Dutch>
+            <Turkish>Manuel Aspiratöre izin ver</Turkish>
         </Key>
         <Key ID="STR_KAT_Airway_ALLOW_SUCTION_DESC">
             <English>Training level required to use a Manual Suction Pump</English>
@@ -144,6 +145,7 @@
             <Chinesesimp>使用手动抽吸泵所需的培训水平</Chinesesimp>
             <Finnish>Aika tarkistaa hengitystiet</Finnish>
             <Dutch>Trainingsniveau benodigd om een handmatige suctiepomp te gebruiken</Dutch>
+            <Turkish>Manuel Aspiratör kullanmak için gereken eğitim seviyesi</Turkish>
         </Key>
         <Key ID="STR_KAT_Airway_AccuvacTreatment_displayName">
             <English>Airway Suction</English>
@@ -159,6 +161,7 @@
             <Chinesesimp>呼吸道抽吸</Chinesesimp>
             <Finnish>Ilmateiden imu</Finnish>
             <Dutch>Luchtweg suctie</Dutch>
+            <Turkish>Hava yolu Aspirasyonu</Turkish>
         </Key>
         <Key ID="STR_KAT_Airway_Accuvac_Desc_Short">
             <English>ACCUVAC is a medical suction device for airway suction with battery drive for mobile use in emergency medicine.</English>
@@ -174,7 +177,7 @@
             <Japanese>アキュバックは、救急医療で携行使用するためのバッテリー電源を備えた気道吸引の為の医療用吸引装置です。</Japanese>
             <Chinese>ACCUVAC（電動抽吸器）是一款使用電池驅動的，在緊急狀況時是用於維持呼吸道可攜式醫療裝置</Chinese>
             <Chinesesimp>ACCUVAC是紧急情况下使用的电池驱动的便携式医疗抽吸装置</Chinesesimp>
-            <Turkish>ACCUVAC, acil tıpta mobil kullanım için pilli hava yolu emişine yönelik tıbbi bir emme cihazıdır.</Turkish>
+            <Turkish>ACCUVAC, acil tıpta mobil kullanım için bataryalı bir havayolu aspirasyon cihazıdır.</Turkish>
             <Norwegian>ACCUVAC er en medisinsk sugeenhet for suging av luftveier med batteridrift for mobil bruk innen akuttmedisin</Norwegian>
             <Finnish>ACCUVAC on akkukäyttöinen lääketieteellinen imulaite hengitysteiden imemiseen mobiilikäyttöön hätätilanteissa</Finnish>
             <Dutch>ACCUVAC is een mobiel apparaat voor medische suctie bij spoedeisende hulp</Dutch>
@@ -192,6 +195,7 @@
             <Chinese>ACCUVAC（電動抽吸器）</Chinese>
             <Chinesesimp>ACCUVAC</Chinesesimp>
             <Dutch>ACCUVAC</Dutch>
+            <Turkish>ACCUVAC</Turkish>
         </Key>
         <Key ID="STR_KAT_Airway_Accuvac_NA">
             <English>Medical suction not needed</English>
@@ -226,6 +230,7 @@
             <Chinesesimp>医用抽吸完成，封堵物移除</Chinesesimp>
             <Finnish>Lääketieteellinen imu suoritettu, okkluusio poistettu</Finnish>
             <Dutch>Medische suctie voltooid, Verstopping verwijderd</Dutch>
+            <Turkish>Tıbbi aspirasyon tamamlandı, tıkanıklık giderildi</Turkish>
         </Key>
         <Key ID="STR_KAT_Airway_Activity_HeadTurning">
             <English>%1 finished head turning (x%2)</English>
@@ -243,6 +248,7 @@
             <Norwegian>%1 fullførte vending av hode (%2%).</Norwegian>
             <Finnish>%1 lopetti pään kääntämisen (x%2)</Finnish>
             <Dutch>%1 heeft het hoofd gedraaid (x%2)</Dutch>
+            <Turkish>%1 kafa çevirme işlemini tamamladı (x%2)</Turkish>
         </Key>
         <Key ID="STR_KAT_Airway_AirwayStatus_Clear">
             <English>Airway is clear</English>
@@ -258,7 +264,7 @@
             <Japanese>気道は詰まっていません</Japanese>
             <Chinese>呼吸道暢通</Chinese>
             <Chinesesimp>气道通畅</Chinesesimp>
-            <Turkish>Havayolları temiz</Turkish>
+            <Turkish>Hava yolu açık</Turkish>
             <Norwegian>Luftveiene er frie</Norwegian>
             <Finnish>Tuuliputki on selkeä</Finnish>
             <Dutch>Luchtweg is vrij</Dutch>
@@ -277,7 +283,7 @@
             <Japanese>使用できません、 気道が詰まっています</Japanese>
             <Chinese>物品無法使用，呼吸道尚未暢通</Chinese>
             <Chinesesimp>物品无法使用,气道仍不通畅</Chinesesimp>
-            <Turkish>Öğe kullanılamadı, hava yolları açık değil</Turkish>
+            <Turkish>Ekipman kullanılamadı, hava yolu açık değil</Turkish>
             <Norwegian>Gjenstanden kunne ikke brukes, luftveiene er ikke frie</Norwegian>
             <Finnish>Tuotetta ei voitu käyttää, hengitystiet eivät ole selkeät</Finnish>
             <Dutch>Item kon niet gebruikt worden, luchtwegen zijn niet vrij</Dutch>
@@ -297,6 +303,7 @@
             <Norwegian>Luftvei er blokkert, behov for luftveishåndtering</Norwegian>
             <Finnish>Hengitystiet ovat tukossa, hengityshoitoa tarvitaan</Finnish>
             <Dutch>Luchtweg is geblokkeerd, luchtwegmanagement is vereist</Dutch>
+            <Turkish>Hava yolu tıkalı, havayolu yönetimi gerekli</Turkish>
         </Key>
         <Key ID="STR_KAT_Airway_AirwayStatus_Obstruction_short">
             <English>Obstruction</English>
@@ -312,7 +319,7 @@
             <Japanese>閉塞あり</Japanese>
             <Chinese>阻塞</Chinese>
             <Chinesesimp>闭塞</Chinesesimp>
-            <Turkish>Kapanma</Turkish>
+            <Turkish>Tıkalı</Turkish>
             <Norwegian>Obstruksjon</Norwegian>
             <Finnish>Tukkeuma</Finnish>
             <Dutch>Geblokkeerd</Dutch>
@@ -332,6 +339,7 @@
             <Norwegian>Luftveien er okkludert, behov for medisinsk suging</Norwegian>
             <Finnish>Hengitystiet ovat likaiset, tarvitaan lääkärin imu</Finnish>
             <Dutch>Luchtweg is verstopt, medische suctie is vereist</Dutch>
+            <Turkish>Hava yolu kapalı, havayolu yönetimi gerekli</Turkish>
         </Key>
         <Key ID="STR_KAT_Airway_AirwayStatus_Occlusion_short">
             <English>Occluded</English>
@@ -347,7 +355,7 @@
             <Japanese>異物あり</Japanese>
             <Chinese>異物阻塞</Chinese>
             <Chinesesimp>异物阻塞</Chinesesimp>
-            <Turkish>Tıkalı</Turkish>
+            <Turkish>Kapalı</Turkish>
             <Norwegian>Okkludert</Norwegian>
             <Finnish>Tukkeutunut</Finnish>
             <Dutch>Verstopt</Dutch>
@@ -363,6 +371,7 @@
             <Chinese>氣道嚴重膨脹</Chinese>
             <Chinesesimp>气道严重膨胀</Chinesesimp>
             <Dutch>De luchtwegen hebben een sterke blaarvorming</Dutch>
+            <Turkish>Hava yolu ciddi şekilde hasar görmüş</Turkish>
         </Key>
         <Key ID="STR_KAT_Airway_AirwayStatus_mitigatedObstruction">
             <English>Obstruction is temporarily mitigated</English>
@@ -381,6 +390,7 @@
             <Norwegian>Obstruksjon er midlertidig redusert</Norwegian>
             <Finnish>Tukos on väliaikaisesti lievennetty</Finnish>
             <Dutch>Blokkade is tijdelijk verzacht</Dutch>
+            <Turkish>Tıkanıklık geçici olarak azaltıldı</Turkish>
         </Key>
         <Key ID="STR_KAT_Airway_AirwayStatus_mitigatedObstruction_short">
             <English>Mitigated obstruction</English>
@@ -399,6 +409,7 @@
             <Norwegian>Reduserte obstruksjonen</Norwegian>
             <Finnish>Vähentynyt tukos</Finnish>
             <Dutch>Blokkade tijdelijk verzacht</Dutch>
+            <Turkish>Azaltılmış tıkanıklık</Turkish>
         </Key>
         <Key ID="STR_KAT_Airway_AirwayStatus_noObstruction">
             <English>Airway is not obstructed</English>
@@ -415,6 +426,7 @@
             <Norwegian>Luftvei er ikke blokkert</Norwegian>
             <Finnish>Ilmatiet eivät ole tukossa</Finnish>
             <Dutch>Luchtweg is niet geblokkeerd</Dutch>
+            <Turkish>Hava yolu tıkalı değil</Turkish>
         </Key>
         <Key ID="STR_KAT_Airway_AirwayStatus_noObstruction_short">
             <English>Not obstructed</English>
@@ -430,7 +442,7 @@
             <Japanese>閉塞なし</Japanese>
             <Chinese>無 阻塞</Chinese>
             <Chinesesimp>无阻塞</Chinesesimp>
-            <Turkish>Değil Kapanma</Turkish>
+            <Turkish>Tıkalı değil</Turkish>
             <Norwegian>Ikke blokkert</Norwegian>
             <Finnish>Ei estetty</Finnish>
             <Dutch>Niet geblokkeerd</Dutch>
@@ -450,6 +462,7 @@
             <Norwegian>Luftvei er ikke okkludert</Norwegian>
             <Finnish>Ilmatiet eivät ole likaisia</Finnish>
             <Dutch>Luchtweg is niet verstopt</Dutch>
+            <Turkish>Hava yolu tamamen kapalı değil</Turkish>
         </Key>
         <Key ID="STR_KAT_Airway_AirwayStatus_noOcclusion_short">
             <English>Not occluded</English>
@@ -465,7 +478,7 @@
             <Japanese>異物なし</Japanese>
             <Chinese>無異物</Chinese>
             <Chinesesimp>无闭塞</Chinesesimp>
-            <Turkish>Değil Tıkalı</Turkish>
+            <Turkish>Kapalı değil</Turkish>
             <Norwegian>Ikke okkludert</Norwegian>
             <Finnish>Ei tukossa</Finnish>
             <Dutch>Niet verstopt</Dutch>
@@ -486,6 +499,7 @@
             <Norwegian>Auto Triage Luftveier</Norwegian>
             <Finnish>Luokittelee hengitystiet automaattisesti</Finnish>
             <Dutch>Auto triage van de luchtwegen</Dutch>
+            <Turkish>Otomatik Triaj – Hava yolu</Turkish>
         </Key>
         <Key ID="STR_KAT_Airway_AutoTriage_Desc">
             <English>Sets if checking airways can override current triage level</English>
@@ -503,6 +517,7 @@
             <Norwegian>Setter om sjekking av luftveier kan overstyre gjeldende triage-nivå</Norwegian>
             <Finnish>Määrittää, voiko hengitysteiden tarkistaminen muuttaa nykyistä luokitusta</Finnish>
             <Dutch>Zet of het checken van de luchtwegen het huidige triage niveau overschrijft</Dutch>
+            <Turkish>Hava yolu kontrolünün mevcut triaj seviyesini geçersiz kılıp kılamayacağını ayarlar</Turkish>
         </Key>
         <Key ID="STR_KAT_Airway_BLOCK_HEADTURNING">
             <English>Block head turning</English>
@@ -520,6 +535,7 @@
             <Norwegian>Blokker vending av hode</Norwegian>
             <Finnish>Estä pään kääntyminen</Finnish>
             <Dutch>Blokkeer het draaien van het hoofd</Dutch>
+            <Turkish>Kafa çevirmeyi engelle</Turkish>
         </Key>
         <Key ID="STR_KAT_Airway_BLOCK_HEADTURNING_DESC">
             <English>Blocks head turning if patient has Guedel Tube inserted</English>
@@ -537,6 +553,7 @@
             <Norwegian>Blokkerer vending av hode hvis pasienten har en Guedel Tube satt inn</Norwegian>
             <Finnish>Estää pään pyörimisen, jos potilaalla on guedel-putki</Finnish>
             <Dutch>Blokkeert het draaien van het hoofd als de patiënt een Guedel-tube in heeft</Dutch>
+            <Turkish>Hastada Guedel Tüpü takılıysa kafa çevirmeyi engeller</Turkish>
         </Key>
         <Key ID="STR_KAT_Airway_CancelRecoveryPosition_Log">
             <English>%1 cancelled recovery position</English>
@@ -553,6 +570,7 @@
             <Norwegian>%1 kansellerte stabilt sideleie</Norwegian>
             <Finnish>%1 peruutettu lepoasento</Finnish>
             <Dutch>%1 stopte de stabiele zijligging</Dutch>
+            <Turkish>%1 kurtarma pozisyonunu iptal etti</Turkish>
         </Key>
         <Key ID="STR_KAT_Airway_CancelRecoveryPosition_displayName">
             <English>Cancel recovery position</English>
@@ -608,6 +626,7 @@
             <Norwegian>Fjern Guedeltubus</Norwegian>
             <Finnish>Irrota guedel-putki</Finnish>
             <Dutch>Verwijder Guedel-tube</Dutch>
+            <Turkish>Guedel Tüpünü çıkar</Turkish>
         </Key>
         <Key ID="STR_KAT_Airway_Cancel_Larynxtubus">
             <English>Remove King LT</English>
@@ -625,6 +644,7 @@
             <Norwegian>Fjern Larynkstube</Norwegian>
             <Finnish>Irrota kurkunpään putki</Finnish>
             <Dutch>Verwijder King LT</Dutch>
+            <Turkish>King LT’yi çıkar</Turkish>
         </Key>
         <Key ID="STR_KAT_Airway_Guedel_Desc_Short">
             <English>The Guedel Tube is used to maintain the airway</English>
@@ -640,7 +660,7 @@
             <Japanese>ゲデルチューブ(口咽頭エアウェイ)は気道を確保するために使用される</Japanese>
             <Chinese>抽吸管是用於維持呼吸道</Chinese>
             <Chinesesimp>Guedel是一种气道辅助通气装置,同时集成了舌垫可防止气道阻塞.</Chinesesimp>
-            <Turkish>Guedel Tüpü, hava yollarını kurtarmak için kullanılır</Turkish>
+            <Turkish>Guedel Tüpü hava yolunu açık tutmak için kullanılır</Turkish>
             <Norwegian>Guedel Tube brukes for å redde luftveiene</Norwegian>
             <Finnish>Guedel-letkua käytetään hengitysteiden ylläpitämiseen</Finnish>
             <Dutch>De Guedel-tube wordt gebruikt om de luchtweg veilig te stellen</Dutch>
@@ -678,7 +698,7 @@
             <Japanese>頭部後屈が中止された</Japanese>
             <Chinese>取消後仰頭部</Chinese>
             <Chinesesimp>已取消拉伸</Chinesesimp>
-            <Turkish>Hyperextension İptal Edildi</Turkish>
+            <Turkish>Kafayı aşırı germe iptal edildi</Turkish>
             <Norwegian>Hyperforlengelse av hode er avbrutt</Norwegian>
             <Finnish>Hyperojentuva pää peruttu</Finnish>
             <Dutch>Hoofd overstrekking afgebroken</Dutch>
@@ -696,6 +716,7 @@
             <Chinese>%1 讓 %2 頭部後仰</Chinese>
             <Chinesesimp>%1 头部过度伸展 %2</Chinesesimp>
             <Dutch>%1 overstrekte %2s hoofd</Dutch>
+            <Turkish>%1, %2’nin kafasını aşırı gerdi</Turkish>
         </Key>
         <Key ID="STR_KAT_Airway_Hyperextend_Ready">
             <English>Head hyperextended successfully</English>
@@ -712,6 +733,7 @@
             <Norwegian>hyperforlengelse av hodet fullført</Norwegian>
             <Finnish>Pään ylivenyttely onnistui</Finnish>
             <Dutch>Hoofd succesvol overstrekt</Dutch>
+            <Turkish>Kafa başarıyla aşırı gerildi</Turkish>
         </Key>
         <Key ID="STR_KAT_Airway_Hyperextend_Time">
             <English>Time for overstretch the head</English>
@@ -727,7 +749,7 @@
             <Japanese>頭部後屈顎先挙上法の所要時間</Japanese>
             <Chinese>後仰頭部 的使用時間</Chinese>
             <Chinesesimp>拉伸颈部的所需时间</Chinesesimp>
-            <Turkish>Kafayı aşırı germe zamanı</Turkish>
+            <Turkish>Kafayı aşırı germek için gereken süre</Turkish>
             <Norwegian>Tid for å overstrekke hode</Norwegian>
             <Finnish>Kuinka kauan kestää potilaan pään ylivenytys</Finnish>
             <Dutch>Tijd voor het overstrekken van het hoofd</Dutch>
@@ -746,7 +768,7 @@
             <Japanese>頭部後屈を完了するのにどのくらい時間がかかるか設定します</Japanese>
             <Chinese>完成 後仰頭部 需要多長時間</Chinese>
             <Chinesesimp>拉伸颈部的所需时间</Chinesesimp>
-            <Turkish>Kafanın aşırı gerilmesi ne kadar sürecek</Turkish>
+            <Turkish>Kafayı aşırı germenin ne kadar süreceği</Turkish>
             <Norwegian>Hvor lang tid det vil ta å overstrekke hodet</Norwegian>
             <Finnish>Kuinka kauan kestää potilaan pään hypervenytys</Finnish>
             <Dutch>Hoe lang het gaat duren om het hoofd te overstrekken</Dutch>
@@ -766,6 +788,7 @@
             <Norwegian>Pasientens hode er allerede hyperforlenget</Norwegian>
             <Finnish>Potilaan pää on jo yli ojentunut</Finnish>
             <Dutch>Patiënts hoofd is al overstrekt</Dutch>
+            <Turkish>Hastanın kafası zaten aşırı gerilmiş</Turkish>
         </Key>
         <Key ID="STR_KAT_Airway_Hyperextend_displayName">
             <English>Hyperextending Head</English>
@@ -781,7 +804,7 @@
             <Japanese>頭部後屈顎先挙上法を行う</Japanese>
             <Chinese>進行 頭部後斜 和 提高下巴</Chinese>
             <Chinesesimp>物品无法使用,气道仍不通畅</Chinesesimp>
-            <Turkish>Hyperextension Gerçekleştir</Turkish>
+            <Turkish>Kafayı Aşırı Germe</Turkish>
             <Norwegian>Hyperforlengelse av hode</Norwegian>
             <Finnish>Hyperojentuva pää</Finnish>
             <Dutch>Hoofd overstrekken</Dutch>
@@ -800,7 +823,7 @@
             <Japanese>頭部後屈させています</Japanese>
             <Chinese>後仰頭部中</Chinese>
             <Chinesesimp>拉伸中</Chinesesimp>
-            <Turkish>Uzatılmış</Turkish>
+            <Turkish>Kafayı Aşırı Germe</Turkish>
             <Norwegian>Forlenger</Norwegian>
             <Finnish>Hyperojentuva pää</Finnish>
             <Dutch>Hoofd overstrekken</Dutch>
@@ -819,7 +842,7 @@
             <Japanese>頭部後屈を実施中</Japanese>
             <Chinese>後仰頭部</Chinese>
             <Chinesesimp>拉伸颈部</Chinesesimp>
-            <Turkish>Hyperextension Gerçekleşmiş Kafa</Turkish>
+            <Turkish>Aşırı Gerilmiş Kafa</Turkish>
             <Norwegian>Hode er overekstendert</Norwegian>
             <Finnish>Hyperpidennetty pää</Finnish>
             <Dutch>Hoofd is overstrekt</Dutch>
@@ -838,7 +861,7 @@
             <Japanese>King LT(喉頭エアウェイ)は気道を確保するために使用される</Japanese>
             <Chinese>喉管(King LT)是用於維持呼吸道</Chinese>
             <Chinesesimp>King LT-D是一种无菌的一次性声门上气道装置,是气管插管或面罩通气的替代方法.</Chinesesimp>
-            <Turkish>Laringeal Tüpü, hava yollarını kurtarmak için kullanılır</Turkish>
+            <Turkish>King LT havayolunu açık tutmak için kullanılır</Turkish>
             <Norwegian>Larynkstube brukes for å redde luftveiene</Norwegian>
             <Finnish>Kurkunpään letkua käytetään hengitysteiden ylläpitämiseen</Finnish>
             <Dutch>De King LT wordt gebruikt om de luchtweg veilig te stellen</Dutch>
@@ -857,7 +880,7 @@
             <Japanese>King LT (喉頭エアウェイ)</Japanese>
             <Chinese>喉管(King LT-D)</Chinese>
             <Chinesesimp>喉管(King LT-D)</Chinesesimp>
-            <Turkish>Laringeal Tüp</Turkish>
+            <Turkish>King LT</Turkish>
             <Norwegian>Larynkstube</Norwegian>
             <Finnish>Kurkunpään putki</Finnish>
             <Dutch>King LT</Dutch>
@@ -991,6 +1014,7 @@
             <Norwegian>%1 fjernet Guedeltubus</Norwegian>
             <Finnish>%1 guedel-putki poistettu</Finnish>
             <Dutch>%1 verwijdderde Guedel-tube</Dutch>
+            <Turkish>%1 Guedel Tüpünü çıkardı</Turkish>
         </Key>
         <Key ID="STR_KAT_Airway_RemoveLarynxtubus_Log">
             <English>%1 removed KingLT</English>
@@ -1008,6 +1032,7 @@
             <Norwegian>%1 fjernet Larynkstube</Norwegian>
             <Finnish>%1 kurkunpään putki poistettu</Finnish>
             <Dutch>%1 verwijdderde King LT</Dutch>
+            <Turkish>%1 King LT’yi çıkardı</Turkish>
         </Key>
         <Key ID="STR_KAT_Airway_Reusable_AirwayItems">
             <English>Reusable Airway Items</English>
@@ -1025,6 +1050,7 @@
             <Norwegian>Gjennbrukbare lufvei gjennstander</Norwegian>
             <Finnish>Uudelleenkäytettävät henkitorvilaitteet</Finnish>
             <Dutch>Herbruikbare luchtwegmiddelen</Dutch>
+            <Turkish>Yeniden Kullanılabilir Hava Yolu Ekipmanları</Turkish>
         </Key>
         <Key ID="STR_KAT_Airway_Reusable_AirwayItems_DESC">
             <English>Regain the KingLT or Guedel Tube when manually removing them</English>
@@ -1042,6 +1068,7 @@
             <Norwegian>Gjenopprett larynkstube eller Guedeltubus når du fjerner dem manuelt</Norwegian>
             <Finnish>Ota kurkunpää- tai guedelputki takaisin, kun poistat ne manuaalisesti</Finnish>
             <Dutch>Krijg de King LT of de Guedel-tube terug wanneer deze handmatig verwijderd worden</Dutch>
+            <Turkish>Manuel olarak çıkarıldığında King LT veya Guedel Tüpü geri kazanılır</Turkish>
         </Key>
         <Key ID="STR_KAT_Airway_SETTING_CancelRecoveryPosition_Time">
             <English>Time for cancelling recovery position</English>
@@ -1057,7 +1084,7 @@
             <Japanese>回復体位を崩すの所要時間</Japanese>
             <Chinese>取消恢復體態時間</Chinese>
             <Chinesesimp>取消恢复体态时间</Chinesesimp>
-            <Turkish>Kurtarma pozisyonunu iptal etmek için zaman</Turkish>
+            <Turkish>Kurtarma pozisyonunu iptal etme süresi</Turkish>
             <Norwegian>Tid for å avbryte stabilt sideleie</Norwegian>
             <Finnish>Aika peruuttaa lepoasento</Finnish>
             <Dutch>Tijd om een stabiele zijligging te stoppen</Dutch>
@@ -1077,6 +1104,7 @@
             <Norwegian>Hvor lang tid det vil ta å manuelt kansellere stabilt sideleie</Norwegian>
             <Finnish>Kuinka kauan lepoasennon manuaalinen peruuttaminen kestää</Finnish>
             <Dutch>Hoe lang het gaat duren om de stabiele zijligging te stoppen</Dutch>
+            <Turkish>Kurtarma pozisyonunu manuel olarak iptal etmenin ne kadar süreceği</Turkish>
         </Key>
         <Key ID="STR_KAT_Airway_SETTING_ENABLE">
             <English>ACE-Airway injuries activated?</English>
@@ -1092,7 +1120,7 @@
             <Japanese>気道障害モジュールを有効化</Japanese>
             <Chinese>啟用ACE-呼吸道受傷機制?</Chinese>
             <Chinesesimp>启用ACE-气道功能</Chinesesimp>
-            <Turkish>ACE-Havayolu yaralanmaları aktive edildi mi?</Turkish>
+            <Turkish>ACE – Hava Yolu yaralanmaları aktif mi?</Turkish>
             <Norwegian>ACE - Luftveiskade aktivert?</Norwegian>
             <Finnish>Hengitysteiden vammat aktivoituivat?</Finnish>
             <Dutch>Is ACE-Luchtweg verwondingen geactiveerd?</Dutch>
@@ -1113,6 +1141,7 @@
             <Norwegian>Intervall for vending av hode</Norwegian>
             <Finnish>pään käännösväli</Finnish>
             <Dutch>Hoofddraaiing interval</Dutch>
+            <Turkish>Kafa Çevirme Aralığı</Turkish>
         </Key>
         <Key ID="STR_KAT_Airway_SETTING_HeadTurning_Interval_DESC">
             <English>Time between head turning attempts</English>
@@ -1130,6 +1159,7 @@
             <Norwegian>Tiden mellom forsøk på vending av hode</Norwegian>
             <Finnish>pään käännösyritysten välinen aika</Finnish>
             <Dutch>Tijd tussen hoofddraaiing pogingen</Dutch>
+            <Turkish>Kafa çevirme denemeleri arasındaki süre</Turkish>
         </Key>
         <Key ID="STR_KAT_Airway_SETTING_RecoveryPosition_Time">
             <English>Time for recovery position</English>
@@ -1145,7 +1175,7 @@
             <Japanese>回復体位の所要時間</Japanese>
             <Chinese>建立 復甦姿勢 時間</Chinese>
             <Chinesesimp>建立恢复体态时间</Chinesesimp>
-            <Turkish>Kurtarma pozisyonu için zaman</Turkish>
+            <Turkish>Kurtarma pozisyonu için süre</Turkish>
             <Norwegian>Tid for å legge i stabilt sideleie</Norwegian>
             <Finnish>palautumisasennon aika</Finnish>
             <Dutch>Tijd voor de stabiele zijligging</Dutch>
@@ -1165,6 +1195,7 @@
             <Norwegian>Tid i stabilt sideleie for å bli kvitt okklusjonen</Norwegian>
             <Finnish>Palautuminen Asento-aika tyhjennystukoksen poistamiseksi</Finnish>
             <Dutch>Stabiele zijligging: Benodigde tijd om zich te ontdoen van een verstopping</Dutch>
+            <Turkish>Kurtarma pozisyonunda tıkanıklığın boşalması için gereken süre</Turkish>
         </Key>
         <Key ID="STR_KAT_Airway_SETTING_RecoveryPosition_TimeToDrain_DESC">
             <English>Maximum time required for patient in recovery position to be drained of occlusion.</English>
@@ -1181,6 +1212,7 @@
             <Norwegian>Maks nødvendig tid en pasient må være i stabilt sideleie for å bli kvitt okklusjonen.</Norwegian>
             <Finnish>Enimmäisaika, joka tarvitaan potilaan puhdistamiseen toipumisasennossa</Finnish>
             <Dutch>Maximale tijd die nodig is om een patiënt in de stabiele zijligging te ontdoen van een verstopping.</Dutch>
+            <Turkish>Hastanın iyileşme pozisyonunda kapanıklığın tamamen boşalması için gereken maksimum süre</Turkish>
         </Key>
         <Key ID="STR_KAT_Airway_SETTING_RecoveryPosition_Time_DESC">
             <English>How long it will take to establish recovery position</English>
@@ -1196,7 +1228,7 @@
             <Japanese>回復体位を完了するのにどのくらい時間がかかるか設定します</Japanese>
             <Chinese>建立 復甦姿勢 的所需時間</Chinese>
             <Chinesesimp>建立恢复体态的所需时间</Chinesesimp>
-            <Turkish>Kurtarma pozisyonunun oluşturulması ne kadar sürer?</Turkish>
+            <Turkish>Kurtarma pozisyonunu vermenin ne kadar süreceği</Turkish>
             <Norwegian>Hvor lang tid vil det ta å legge i stabilt sideleie</Norwegian>
             <Finnish>Kuinka kauan kestää, että potilas asetetaan toipumisasentoon</Finnish>
             <Dutch>Hoe lang het gaat duren om iemand in de stabiele zijligging te leggen</Dutch>
@@ -1234,7 +1266,7 @@
             <Japanese>気道閉塞の確率</Japanese>
             <Chinese>呼吸道阻塞機率</Chinese>
             <Chinesesimp>气道闭塞几率</Chinesesimp>
-            <Turkish>Tıkanmış bir hava yolu olasılığı</Turkish>
+            <Turkish>Hava yolu tıkanıklığı olasılığı</Turkish>
             <Norwegian>Sannsynligheten for blokkert luftvei</Norwegian>
             <Finnish>Tukkeutuneiden hengitysteiden todennäköisyys</Finnish>
             <Dutch>Kans op geblokkeerde luchtweg</Dutch>
@@ -1255,6 +1287,7 @@
             <Norwegian>Sannsynlighet for en blokkert luftvei i prosent som oppstår hver gang det skjer: \n- Bevisstløshet \n- Fjerning av Larynkstube / Guedel Tube</Norwegian>
             <Finnish>Tukkeutuneen hengitysteiden todennäköisyys prosentteina, joka pyörii joka kerta:\n- Putoaminen tajuttomuuteen poistaminen / Guedel putki</Finnish>
             <Dutch>Kans op geblokkeerde luchtweg in een percentage die gerold wordt elke: \n- Bewusteloos raken \n- KingLT / Guedel verwijderen</Dutch>
+            <Turkish>Bilinç kaybı veya King LT / Guedel Tüpü çıkarıldığında yüzdelik havayolu tıkanıklığı olasılığı</Turkish>
         </Key>
         <Key ID="STR_KAT_Airway_SETTING_occluded">
             <English>Probability for airway occluding</English>
@@ -1270,7 +1303,7 @@
             <Japanese>気道異物の確率</Japanese>
             <Chinese>呼吸道異物阻塞機率</Chinese>
             <Chinesesimp>气道异物几率</Chinesesimp>
-            <Turkish>Hava yolunu tıkama olasılığı</Turkish>
+            <Turkish>Hava yolunun kapanma olasılığı</Turkish>
             <Norwegian>Sannsynlighet for at luftveien blir blokkert</Norwegian>
             <Finnish>Todennäköisyys hengitysteiden tukkeutumiseen</Finnish>
             <Dutch>Kans op een luchtwegverstopping</Dutch>
@@ -1291,6 +1324,7 @@
             <Norwegian>Sannsynligheten for en okklusjon i prosent som blir rullet i innstillingen for [Okklusjons repetisjonsintervall] (standard hver 60 sekunder).</Norwegian>
             <Finnish>Tukosten todennäköisyys prosentteina joka on satunnaisesti laskettu Asetukset: [Okkluusiotoistoajastin] (oletusarvo on kuusikymmentä sekuntia)</Finnish>
             <Dutch>Kans op een luchtwegverstopping in een percentage die gerold wordt elke Instelling:[Verstopping herhaling timer] (standaard elke 60 seconden)</Dutch>
+            <Turkish>Son kapanıklık giderildikten sonra yeni kapanıklığın oluşamayacağı süre (saniye) (Temel değer her 60 saniye)</Turkish>
         </Key>
         <Key ID="STR_KAT_Airway_SETTING_occlusion_cooldownPeriod">
             <English>Occlusion Cooldown Period</English>
@@ -1308,6 +1342,7 @@
             <Norwegian>Avkjølingsperiode for okklusjon</Norwegian>
             <Finnish>Okkluusiojäähdytyssykli</Finnish>
             <Dutch>Verstoppings afkoelingsperiode</Dutch>
+            <Turkish>Kapanıklık Bekleme Süresi</Turkish>
         </Key>
         <Key ID="STR_KAT_Airway_SETTING_occlusion_cooldownPeriod_DESC">
             <English>Period in seconds during which patient cannot get another occlusion after last occlusion was cleared. Set to 0 to disable this feature.</English>
@@ -1315,6 +1350,7 @@
             <Spanish>Período en segundos durante el cual el paciente no puede recibir otra oclusión después de que la última haya sido eliminada. Establecer a 0 para desactivar esta función.</Spanish>
             <German>Zeitraum in Sekunden, in dem ein Patient keine weitere Okklusion bekommen kann, nachdem die letzte Okklusion beseitigt wurde. Auf 0 setzen, um diese Funktion zu deaktivieren.</German>
             <Japanese>患者の気道異物が解消された後、再度気道異物が発生しない期間(秒)。 0に設定で無効化。</Japanese>
+            <Turkish>Son kapanıklık giderildikten sonra yeni tıkanıklığın oluşamayacağı süre. Bu özelliği kapatmak için 0 olarak ayarlayın</Turkish>
         </Key>
         <Key ID="STR_KAT_Airway_SETTING_occlusion_repeatTimer">
             <English>Occlusion repeat timer</English>
@@ -1333,6 +1369,7 @@
             <Norwegian>Repetisjonsintervall for Okklusjon</Norwegian>
             <Finnish>Okkluusiotoistoajastin</Finnish>
             <Dutch>Verstoppings herhaling timer</Dutch>
+            <Turkish>Kapanıklık Bekleme Süresi</Turkish>
         </Key>
         <Key ID="STR_KAT_Airway_SETTING_occlusion_repeatTimer_DESC">
             <English>Time interval in seconds at which the system checks for new occlusion occurrences in unconscious patients.</English>
@@ -1340,6 +1377,7 @@
             <Spanish>Intervalo de tiempo en segundos en el que el sistema verifica la aparición de nuevas oclusiones en pacientes inconscientes.</Spanish>
             <German>Zeitintervall in Sekunden, in dem das System neue Okklusionsereignisse bei bewusstlosen Patienten überprüft.</German>
             <Japanese>意識不明の患者の新たな気道異物の発生をシステムがチェックする間隔(秒)。</Japanese>
+            <Turkish>Sistemin bilinçsiz hastalarda yeni tıkanıklıkları kontrol ettiği süre (saniye)</Turkish>
         </Key>
         <Key ID="STR_KAT_Airway_SETTING_puking_sound">
             <English>Activate the puking sound?</English>
@@ -1366,6 +1404,7 @@
             <Spanish>Activar o desactivar el efecto de sonido cuando un paciente presenta una obstrucción de las vías respiratorias (vomitando).</Spanish>
             <German>Aktiviert oder deaktiviert den Soundeffekt, wenn bei einem Patienten eine Atemwegsobstruktion (Erbrechen) auftritt.</German>
             <Japanese>患者に気道異物(嘔吐)が発生した場合のサウンド効果を有効化または無効化します。</Japanese>
+            <Turkish>Havayolu kapanıklığı geliştiğinde kusma ses efektini aç/kapat</Turkish>
         </Key>
         <Key ID="STR_KAT_Airway_SUCCES_HEADTURNING">
             <English>Success probability for head-turning</English>
@@ -1381,7 +1420,7 @@
             <Japanese>顔を横に向ける (指拭法で異物除去) の成功確率</Japanese>
             <Chinese>轉頭的成功的機率 (清除異物)</Chinese>
             <Chinesesimp>清理气道异物的成功几率</Chinesesimp>
-            <Turkish>Baş döndürme başarı olasılığı</Turkish>
+            <Turkish>Kafa çevirme başarı olasılığı</Turkish>
             <Norwegian>sannsynligheten for sukksess ved vending av hode</Norwegian>
             <Finnish>onnistumisen todennäköisyys pään kääntämisessä</Finnish>
             <Dutch>Succeskans voor hoofddraaiing</Dutch>
@@ -1400,7 +1439,7 @@
             <Japanese>高いほど、成功の可能性が高くなります</Japanese>
             <Chinese>越高，成功的機率越大</Chinese>
             <Chinesesimp>越高，成功的可能性越大</Chinesesimp>
-            <Turkish>Başarı olasılığı ne kadar yüksekse, o kadar iyi</Turkish>
+            <Turkish>Değer yükseldikçe başarı olasılığı artar</Turkish>
             <Norwegian>Jo høyere, desto bedre er sannsynligheten for suksess</Norwegian>
             <Finnish>Mitä korkeampi, sitä suurempi on onnistumisen todennäköisyys</Finnish>
             <Dutch>Groter betekent een hogere kans op succes</Dutch>
@@ -1422,6 +1461,7 @@
             <Norwegian>Instillinger for luftveis gjennstander</Norwegian>
             <Finnish>henkitorven laitteen asetukset</Finnish>
             <Dutch>Instelling voor luchtwegmiddelen</Dutch>
+            <Turkish>Hava Yolu Ekipmanları Ayarları</Turkish>
         </Key>
         <Key ID="STR_KAT_Airway_SubCategory_RecoveryPositionHyperextend">
             <English>Recovery Position + Head Hyperextend Settings</English>
@@ -1438,6 +1478,7 @@
             <Norwegian>Instillinger for stabil sideleie og Hyperforlengelse av hodet</Norwegian>
             <Finnish>Palautusasento + pään ylivenytysasetukset</Finnish>
             <Dutch>Stabiele zijliggings- en hoofd overstrekkings opties</Dutch>
+            <Turkish>Kurtarma Pozisyonu + Kafa Aşırı Germe Ayarları</Turkish>
         </Key>
         <Key ID="STR_KAT_Airway_SubCategory_Suction">
             <English>Suction devices Settings</English>
@@ -1453,6 +1494,7 @@
             <Chinesesimp>抽吸装置设置</Chinesesimp>
             <Finnish>Imulaitteen asetukset</Finnish>
             <Dutch>Suctie apparaten instellingen</Dutch>
+            <Turkish>Aspirasyon Cihazları Ayarları</Turkish>
         </Key>
         <Key ID="STR_KAT_Airway_SuctionTreatment_displayName">
             <English>Airway Suction (Manual)</English>
@@ -1468,6 +1510,7 @@
             <Chinesesimp>气道吸气（手动）</Chinesesimp>
             <Finnish>Ilmateiden imu (manuaalinen)</Finnish>
             <Dutch>Handmatige luchtweg suctie</Dutch>
+            <Turkish>Hava yolu Aspirasyonu (Manuel)</Turkish>
         </Key>
         <Key ID="STR_KAT_Airway_Suction_Desc_Short">
             <English>Manual Suction Pump is a medical suction device for airway suction manually. This is an alternative to electrical devices.</English>
@@ -1483,6 +1526,7 @@
             <Chinesesimp>手动抽吸泵是一种用于手动气道抽吸的医用抽吸装置。这是电气设备的替代品。</Chinesesimp>
             <Finnish>Manuaalinen imupumppu on lääketieteellinen imulaite hengitysteiden manuaaliseen imemiseen. tämä on vaihtoehto sähkölaitteille</Finnish>
             <Dutch>De handmatige suctiepomp is een apparaat om handmatig de luchtwegen af te zuigen. Dit is een alternatief voor electrische apparaten</Dutch>
+            <Turkish>Manuel Aspiratör, havayolu aspirasyonu için kullanılan manuel bir tıbbi cihazdır.</Turkish>
         </Key>
         <Key ID="STR_KAT_Airway_Suction_Display">
             <English>Manual Suction Pump</English>
@@ -1498,6 +1542,7 @@
             <Chinesesimp>手动抽吸泵</Chinesesimp>
             <Finnish>Manuaalinen imupumppu</Finnish>
             <Dutch>Handmatige suctiepomp</Dutch>
+            <Turkish>Manuel Aspiratör</Turkish>
         </Key>
         <Key ID="STR_KAT_Airway_Suction_Log">
             <English>%1 did a medical suction using a %2</English>
@@ -1512,6 +1557,7 @@
             <Chinese>%1 使用 %2 進行了醫療抽吸</Chinese>
             <Chinesesimp>%1 使用 %2 进行了医用抽吸</Chinesesimp>
             <Dutch>%1 voerde een medische suctie uit met een %2</Dutch>
+            <Turkish>%1, %2 kullanarak tıbbi aspirasyon yaptı</Turkish>
         </Key>
         <Key ID="STR_KAT_Airway_Suction_Reuse">
             <English>Reusable Manual Suction Pump</English>
@@ -1527,6 +1573,7 @@
             <Chinesesimp>可重复使用的手动抽吸泵</Chinesesimp>
             <Finnish>Uudelleenkäytettävä manuaalinen imupumppu</Finnish>
             <Dutch>Herbruikbare handmatige suctiepomp</Dutch>
+            <Turkish>Yeniden Kullanılabilir Manuel Aspiratör</Turkish>
         </Key>
         <Key ID="STR_KAT_Airway_Suction_Reuse_DESC">
             <English>Regain the Manual Suction Pump after use</English>
@@ -1542,6 +1589,7 @@
             <Chinesesimp>使用后重新启动手动抽吸泵</Chinesesimp>
             <Finnish>Ota manuaalinen imupumppu takaisin käytön jälkeen</Finnish>
             <Dutch>Krijg de handmatige suctiepomp terug na gebruik</Dutch>
+            <Turkish>Kullanım sonrası Manuel Aspiratör geri kazanılır</Turkish>
         </Key>
         <Key ID="STR_KAT_Airway_TIME_ACCUVAC">
             <English>Time for ACCUVAC</English>
@@ -1557,7 +1605,7 @@
             <Japanese>アキュバックの所要時間</Japanese>
             <Chinese>ACCUVAC時間</Chinese>
             <Chinesesimp>ACCUVAC時間</Chinesesimp>
-            <Turkish>ACCUVAC için Zaman</Turkish>
+            <Turkish>ACCUVAC kullanım süresi</Turkish>
             <Norwegian>Tid for ACCUVAC</Norwegian>
             <Finnish>ACCUVACin aika</Finnish>
             <Dutch>Behandelstijd van een ACCUVAC</Dutch>
@@ -1576,7 +1624,7 @@
             <Japanese>アキュバックを使用するのにどのくらい時間がかかるか設定します</Japanese>
             <Chinese>使用ACCUVAC需要多長時間</Chinese>
             <Chinesesimp>使用紧急医疗抽吸器的所需時間</Chinesesimp>
-            <Turkish>ACCUVAC'ı kullanmak ne kadar sürecek</Turkish>
+            <Turkish>ACCUVAC kullanımının ne kadar süreceği</Turkish>
             <Norwegian>Hvor lang tid vil det ta å bruke ACCUVAC</Norwegian>
             <Finnish>Kuinka kauan ACCUVACin käyttö kestää</Finnish>
             <Dutch>Hoe lang het gaat duren om de ACCUVAC te gebruiken</Dutch>
@@ -1595,7 +1643,7 @@
             <Japanese>気道の確認の所要時間</Japanese>
             <Chinese>檢查呼吸道的時間</Chinese>
             <Chinesesimp>检查气道的所需时间</Chinesesimp>
-            <Turkish>Havayollarını kontrol etme zamanı</Turkish>
+            <Turkish>Hava yolu kontrol süresi</Turkish>
             <Norwegian>Tid for å sjekke luftveiene</Norwegian>
             <Finnish>Kuinka kauan hengitysteiden tarkistaminen kestää</Finnish>
             <Dutch>Tijd voor de controle van de luchtwegen</Dutch>
@@ -1614,7 +1662,7 @@
             <Japanese>気道の確認を完了するのにどのくらい時間がかかるか設定します</Japanese>
             <Chinese>檢查呼吸道需要多長時間</Chinese>
             <Chinesesimp>检查气道的所需时间</Chinesesimp>
-            <Turkish>Havayollarını kontrol etmek ne kadar sürecek</Turkish>
+            <Turkish>Havayolunu kontrol etmenin ne kadar süreceği</Turkish>
             <Norwegian>Hvor lang tid det vil ta å sjekke luftveiene</Norwegian>
             <Finnish>Kuinka kauan hengitysteiden tarkistaminen kestää</Finnish>
             <Dutch>Hoe lang het gaat duren om de luchtwegen te checken</Dutch>
@@ -1633,7 +1681,7 @@
             <Japanese>口咽頭エアウェイの所要時間</Japanese>
             <Chinese>Geudeltubus的時間</Chinese>
             <Chinesesimp>口咽通气道時間</Chinesesimp>
-            <Turkish>Geudel Tüp zamanı</Turkish>
+            <Turkish>Guedel Tüpü kullanım süresi</Turkish>
             <Norwegian>Tid for Guedeltubus</Norwegian>
             <Finnish>Guedel-putken aika</Finnish>
             <Dutch>Intubatietijd voor Guedel-tube</Dutch>
@@ -1652,7 +1700,7 @@
             <Japanese>口咽頭エアウェイ(ゲデルチューブ)を使用するのにどのくらい時間がかかるか設定します</Japanese>
             <Chinese>使用 Guedel（口腔通氣管） 所需時間</Chinese>
             <Chinesesimp>使用口咽通气道的所需时间</Chinesesimp>
-            <Turkish>Guedel Tüp'ü kullanmak ne kadar sürecek</Turkish>
+            <Turkish>Guedel Tüpü kullanmanın ne kadar süreceği</Turkish>
             <Norwegian>Hvor lang tid vil det ta å bruke Guedeltubus</Norwegian>
             <Finnish>Kuinka kauan Guedel-putken asettaminen vie</Finnish>
             <Dutch>Hoe lang het gaat duren om een Guedel-tube in te brengen</Dutch>
@@ -1671,7 +1719,7 @@
             <Japanese>喉頭エアウェイの所要時間</Japanese>
             <Chinese>喉管（King LT-D）- 使用時間</Chinese>
             <Chinesesimp>喉管時間</Chinesesimp>
-            <Turkish>Laringeal Tüp için Zaman</Turkish>
+            <Turkish>Larenks Tüpü kullanım süresi</Turkish>
             <Norwegian>Tid for Larynxtubus</Norwegian>
             <Finnish>Kurkunpään putkiaika</Finnish>
             <Dutch>Tijd voor het gebruik van een King LT</Dutch>
@@ -1690,7 +1738,7 @@
             <Japanese>喉頭エアウェイ(King LT)を使用するのにどのくらい時間がかかるか設定します</Japanese>
             <Chinese>使用 喉管（King LT-D）需要多長時間</Chinese>
             <Chinesesimp>使用喉管的所需時間</Chinesesimp>
-            <Turkish>Laringeal Tüp'ü kullanmak ne kadar sürecek</Turkish>
+            <Turkish>Larenks Tüpü kullanmanın ne kadar süreceği</Turkish>
             <Norwegian>Hvor lang tid vil det ta å bruke Larynxtubus</Norwegian>
             <Finnish>Kuinka kauan kurkunpään putken asettaminen vie</Finnish>
             <Dutch>Hoe lang het gaat duren voor het gebruik van een King LT</Dutch>
@@ -1709,6 +1757,7 @@
             <Chinesesimp>手吸泵所需时间</Chinesesimp>
             <Finnish>aika manuaaliselle imupumpulle</Finnish>
             <Dutch>Behandelstijd van een handmatige suctiepomp</Dutch>
+            <Turkish>Manuel Aspiratör kullanım süresi</Turkish>
         </Key>
         <Key ID="STR_KAT_Airway_TIME_SUCTION_DESC">
             <English>How long it will take to use Manual Suction Pump</English>
@@ -1724,6 +1773,7 @@
             <Chinesesimp>使用手吸泵需要多长时间</Chinesesimp>
             <Finnish>Kuinka kauan manuaalisen imupumpun käyttö kestää</Finnish>
             <Dutch>Hoe lang het gaat duren om een handmatige suctiepomp te gebruiken</Dutch>
+            <Turkish>Manuel Aspiratör kullanmanın ne kadar süreceği</Turkish>
         </Key>
         <Key ID="STR_KAT_Airway_Vomit_Display">
             <English>Vomit (Small)</English>
@@ -1739,7 +1789,7 @@
             <Japanese>吐瀉物 (小)</Japanese>
             <Chinese>嘔吐物 (少量)</Chinese>
             <Chinesesimp>呕吐物 (少量)</Chinesesimp>
-            <Turkish>Kusmuk (Küçük)</Turkish>
+            <Turkish>Kusma (Hafif)</Turkish>
             <Norwegian>Oppkast (Litt)</Norwegian>
             <Finnish>oksentaa (pieni)</Finnish>
             <Dutch>Braaksel (klein)</Dutch>
@@ -1758,7 +1808,7 @@
             <Japanese>気道を確認しています</Japanese>
             <Chinese>檢查呼吸道</Chinese>
             <Chinesesimp>检查气道</Chinesesimp>
-            <Turkish>Havayolunun Kontrol Ediliyor</Turkish>
+            <Turkish>Hava yolu Kontrol Ediliyor</Turkish>
             <Norwegian>Sjekker luftveien</Norwegian>
             <Finnish>Hengitysteiden tarkastus</Finnish>
             <Dutch>Luchtweg controleren</Dutch>
@@ -1798,6 +1848,7 @@
             <Norwegian>Fjerner</Norwegian>
             <Finnish>Poistaminen</Finnish>
             <Dutch>Verwijderen</Dutch>
+            <Turkish>Çıkarılıyor</Turkish>
         </Key>
         <Key ID="STR_KAT_Airway_airway_log">
             <English>%1 inserted a %2</English>
@@ -1813,7 +1864,7 @@
             <Japanese>%1 が%2を挿管した</Japanese>
             <Chinese>%1 被插入一個 %2</Chinese>
             <Chinesesimp>%1 被插入 %2</Chinesesimp>
-            <Turkish>% 1,% 2 eklendi</Turkish>
+            <Turkish>%1, %2 yerleştirdi</Turkish>
             <Norwegian>%1 satte inn en %2.</Norwegian>
             <Finnish>%1 lisäsi a %2</Finnish>
             <Dutch>%1 heeft een %2 ingebracht</Dutch>
@@ -1826,6 +1877,7 @@
             <German>KAT - ADV Medical: Atemwege</German>
             <Japanese>KAM - 気道 (Airway)</Japanese>
             <Dutch>KAT - ADV Medical: Luchtwegen</Dutch>
+            <Turkish>KAT – Gelişmiş Tıp: Havayolu</Turkish>
         </Key>
         <Key ID="STR_KAT_Airway_checkAirway">
             <English>Check Airway</English>
@@ -1841,7 +1893,7 @@
             <Japanese>気道を確認</Japanese>
             <Chinese>檢查呼吸道</Chinese>
             <Chinesesimp>检查气道</Chinesesimp>
-            <Turkish>Hava Yollarını Kontrol Edin</Turkish>
+            <Turkish>KAT – Gelişmiş Tıp: Havayolu</Turkish>
             <Norwegian>Sjekk lufveier</Norwegian>
             <Finnish>Tarkista hengitystiet</Finnish>
             <Dutch>Check luchtwegen</Dutch>
@@ -1875,6 +1927,7 @@
             <Japanese>%1 が気道を確認: ひどい水膨れ</Japanese>
             <Chinesesimp>%1 条检查气道: 严重起泡</Chinesesimp>
             <Dutch>%1 heeft de luchtwegen gecheckt: Ernstige blaarvorming</Dutch>
+            <Turkish>%1 havayolunu kontrol etti: Ciddi Hasarlı</Turkish>
         </Key>
         <Key ID="STR_KAT_Airway_headTurning_begin">
             <English>Begin Head Turning</English>
@@ -1892,6 +1945,7 @@
             <Norwegian>Begynn vending av hode</Norwegian>
             <Finnish>Aloita potilaan pään kääntäminen</Finnish>
             <Dutch>Begin hoofddraaiing</Dutch>
+            <Turkish>Kafa Çevirmeye Başla</Turkish>
         </Key>
         <Key ID="STR_KAT_Airway_headTurning_cancelled">
             <English>Head turning cancelled</English>
@@ -1909,6 +1963,7 @@
             <Norwegian>vewnding av hode ble avbrutt</Norwegian>
             <Finnish>pään kääntäminen peruttu</Finnish>
             <Dutch>Hoofddraaiing gestopt</Dutch>
+            <Turkish>Kafa çevirme iptal edildi</Turkish>
         </Key>
         <Key ID="STR_KAT_Airway_headTurning_info">
             <English>Head turn performed, airways are still not clear</English>
@@ -1924,7 +1979,7 @@
             <Japanese>除去を試みたが、 気道はまだ詰まっている</Japanese>
             <Chinese>已頭部轉向，但呼吸道仍未清理</Chinese>
             <Chinesesimp>尝试清理气道异物失败, 异物仍存在</Chinesesimp>
-            <Turkish>Baş dönüşü yapıldı, hava yolları hala net değil</Turkish>
+            <Turkish>Kafa çevirme yapıldı, havayolu hâlâ açık değil</Turkish>
             <Norwegian>vending av hode er utført, luftveiene er fortsatt ikke frie</Norwegian>
             <Finnish>Pään käännös suoritettu, hengitystiet vielä epäselvät</Finnish>
             <Dutch>Hoofddraaiing uitgevoerd, luchtwegen zij nog niet vrij</Dutch>
@@ -1944,6 +1999,7 @@
             <Norwegian>Startet vending av hode</Norwegian>
             <Finnish>pään kääntyminen alkoi</Finnish>
             <Dutch>Hoofddraaiing gestart</Dutch>
+            <Turkish>Kafa Çevirme Başlatıldı</Turkish>
         </Key>
         <Key ID="STR_KAT_Airway_headTurning_stop">
             <English>Stop head turning</English>
@@ -1961,6 +2017,7 @@
             <Norwegian>Stop vending av hode</Norwegian>
             <Finnish>Lopeta potilaan pään kääntäminen</Finnish>
             <Dutch>Stop de hoofddraaiing</Dutch>
+            <Turkish>Kafa çevirmeyi durdur</Turkish>
         </Key>
         <Key ID="STR_KAT_Airway_headTurning_success">
             <English>Occlusion removed</English>
@@ -1976,7 +2033,7 @@
             <Japanese>異物が除去された</Japanese>
             <Chinese>阻塞物已移除</Chinese>
             <Chinesesimp>气道异物移除</Chinesesimp>
-            <Turkish>Tıkanıklık kaldırıldı</Turkish>
+            <Turkish>Kapanıklık giderildi</Turkish>
             <Norwegian>Okklusjonen er fjernet</Norwegian>
             <Finnish>Likaantuminen poistettu</Finnish>
             <Dutch>Verstopping verwijderd</Dutch>

--- a/addons/breathing/stringtable.xml
+++ b/addons/breathing/stringtable.xml
@@ -556,9 +556,7 @@
             <Japanese>一度の負傷で発生する気胸へのダメージ。値が低いほど気胸が発生する可能性が高くなります。\n値を非常に低く設定するか0に設定すると、予期しない動作や予期しない負傷による気胸を引き起こす可能性があります。</Japanese>
             <Chinese>單次撞擊的損傷程度（範圍為 0 到 1）需要達到多少，才會觸發氣胸的機率。數值越低，代表越容易發生氣胸。將數值設定過低或設為零，可能會導致無法預期的行為，或因意外傷害引發氣胸。</Chinese>
             <Chinesesimp>单次撞击的损伤程度（范围为 0 到 1）需要达到多少，才会触发气胸的几率。数值越低，代表越容易发生气胸。将数值设定过低或设为零，可能会导致无法预期的行为，或因意外伤害引发气胸。</Chinesesimp>
-            <Turkish>0 ile 1 arasında bir ölçekte, tek bir darbe sırasında oluşması gereken hasar miktarını ifade eder; bu eşik aşıldığında pnömotoraks oluşma ihtimali ortaya çıkar.
-Daha düşük değerler, pnömotoraksın oluşma olasılığının daha yüksek olduğu anlamına gelir.
-Değerin çok düşük veya 0 olarak ayarlanması, beklenmeyen davranışlara ya da beklenmedik yaralanmalar sonucunda pnömotoraks gelişmesine neden olabilir.</Turkish>
+            <Turkish>0 ile 1 arasında bir ölçekte, tek bir darbe sırasında oluşması gereken hasar miktarını ifade eder; bu eşik aşıldığında pnömotoraks oluşma ihtimali ortaya çıkar. Daha düşük değerler, pnömotoraksın oluşma olasılığının daha yüksek olduğu anlamına gelir. Değerin çok düşük veya 0 olarak ayarlanması, beklenmeyen davranışlara ya da beklenmedik yaralanmalar sonucunda pnömotoraks gelişmesine neden olabilir.</Turkish>
             <Finnish>Yhden osuman vaurion määrä asteikolla 0-1, jonka täytyy tapahtua ennen kuin ilmarinta on mahdollista. Pienemmät arvot tarkoittavat, että ilmarinta on todennäköisempää. Arvon asettaminen erittäin alhaiseksi tai arvoon 0 voi aiheuttaa odottamatonta käyttäytymistä tai ilmarintaa epätavallisten vammojen vuoksi.</Finnish>
             <Dutch>De hoeveelheid schade van een enkele impact, op een schaal van 0 tot 1, dat benodigd is voordat een pneumothorax gerold wordt. Lagere waarden kan leiden tot meer pneumothoraxen. Als deze instelling laag of zelfs op 0 staat, kan dit leiden tot raar gedrag of pneumothoraxen van onverwachte wonden</Dutch>
         </Key>

--- a/addons/breathing/stringtable.xml
+++ b/addons/breathing/stringtable.xml
@@ -17,6 +17,7 @@
             <Chinesesimp>高级气胸几率</Chinesesimp>
             <Finnish>Mahdollisuus pitkälle edenneelle ilmarintalle</Finnish>
             <Dutch>Kans op een geadvanceerde pneumothorax</Dutch>
+            <Turkish>Gelişmiş Pnömotoraks Olasılığı</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_ADVANCED_PTX_OPTION">
             <English>Enable Advanced Pneumothoraxes</English>
@@ -34,6 +35,7 @@
             <Chinesesimp>启用高级气胸</Chinesesimp>
             <Finnish>Ota käyttöön edistyneet ilmarintakehät</Finnish>
             <Dutch>Sta geadvanceerde pneumothoraxen toe</Dutch>
+            <Turkish>Gelişmiş Pnömotoraksları Etkinleştir</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_ALLOW_CHESTSEAL">
             <English>Allow Chest Seal</English>
@@ -49,7 +51,7 @@
             <Japanese>チェストシールの許可</Japanese>
             <Chinese>允許使用 胸腔密封貼</Chinese>
             <Chinesesimp>允许使用 胸腔密封贴</Chinesesimp>
-            <Turkish>Chest Seal'a izin ver</Turkish>
+            <Turkish>Chest Seal kullanımına izin ver</Turkish>
             <Finnish>Salli rintatiiviste</Finnish>
             <Dutch>Sta chest seal toe</Dutch>
         </Key>
@@ -86,6 +88,7 @@
             <Chinesesimp>%1已使用%2（x%3）</Chinesesimp>
             <Finnish>%1 käytetty %2 (x%3)</Finnish>
             <Dutch>%1 gebruikte %2 (x%3)</Dutch>
+            <Turkish>%1, %2 kullandı (x%3)</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_Activity_BVM_Oxygenated">
             <English>%1 (Oxygenated)</English>
@@ -102,6 +105,7 @@
             <Chinesesimp>%1（含氧）</Chinesesimp>
             <Finnish>%1 (Kyllästetty hapella)</Finnish>
             <Dutch>%1 (zuurstofrijk)</Dutch>
+            <Turkish>%1 (Oksijenlenmiş)</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_AttachOxygenVehicle">
             <English>Connect to Aircraft Oxygen</English>
@@ -114,6 +118,7 @@
             <Chinese>連接到飛機氧氣</Chinese>
             <Chinesesimp>连接到飞机氧气</Chinesesimp>
             <Dutch>Met het zuurstofsysteem van het vliegtuig verbinden</Dutch>
+            <Turkish>Uçak oksijenine bağlan</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_AttachPersonalOxygenTank">
             <English>Connect Personal Oxygen</English>
@@ -126,6 +131,7 @@
             <Chinese>連接個人氧氣</Chinese>
             <Chinesesimp>连接个人氧气</Chinesesimp>
             <Dutch>Met persoonlijke zuurstoftank verbinden</Dutch>
+            <Turkish>Kişisel oksijeni bağla</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_BVM_Desc_Short">
             <English>Bag-Valve-Mask, used to assist with breathing of unconscious patients</English>
@@ -143,6 +149,7 @@
             <Chinesesimp>袋阀面罩，用于帮助昏迷患者呼吸</Chinesesimp>
             <Finnish>Pussi-venttiili-naamari, käytetään auttamaan tajuttomien potilaiden hengittämisessä</Finnish>
             <Dutch>Bag-Valve-Mask of een zakventielmasker wordt gebruikt voor het ondersteunen van de ademhaling van bewusteloze personen</Dutch>
+            <Turkish>Bag-Valve-Mask, bilinçsiz hastalarda solunuma yardımcı olmak için kullanılır</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_BVM_Display">
             <English>BVM</English>
@@ -160,6 +167,7 @@
             <Chinesesimp>BVM</Chinesesimp>
             <Finnish>BVM</Finnish>
             <Dutch>BVM</Dutch>
+            <Turkish>BVM</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_Cancel_NasalCannula">
             <English>Remove Nasal Cannula</English>
@@ -174,6 +182,7 @@
             <Chinese>移除鼻導管</Chinese>
             <Chinesesimp>移除鼻导管</Chinesesimp>
             <Dutch>Verwijder nasale canule</Dutch>
+            <Turkish>Nasal Cannula’yı çıkar</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_CheckBreathing_Log">
             <English>%1 checked breathing: %2</English>
@@ -190,6 +199,7 @@
             <Chinesesimp>%1检查呼吸：%2</Chinesesimp>
             <Finnish>%1 tarkistettu hengitys: %2</Finnish>
             <Dutch>%1 controleerde ademhaling: %2</Dutch>
+            <Turkish>%1 solunumu kontrol etti: %2</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_CheckPersonalOxygenTank">
             <English>Check Personal Oxygen Status</English>
@@ -202,6 +212,7 @@
             <Chinese>檢查個人氧氣狀況</Chinese>
             <Chinesesimp>检查个人氧气状况</Chinesesimp>
             <Dutch>Persoonlijke zuurstoftank controleren</Dutch>
+            <Turkish>Kişisel oksijen durumunu kontrol et</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_Check_Breathing">
             <English>Check Breathing</English>
@@ -218,6 +229,7 @@
             <Chinesesimp>检查呼吸</Chinesesimp>
             <Finnish>Tarkista potilaan hengitys</Finnish>
             <Dutch>Check ademhaling</Dutch>
+            <Turkish>Solunumu kontrol et</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_Check_Breathing_Progress">
             <English>Checking Breathing</English>
@@ -234,6 +246,7 @@
             <Chinesesimp>检查呼吸中</Chinesesimp>
             <Finnish>Potilaan hengityksen tarkistaminen</Finnish>
             <Dutch>Ademhaling controleren</Dutch>
+            <Turkish>Solunum kontrol ediliyor</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_ChestSealApplied">
             <English>Chest Seal Applied</English>
@@ -250,6 +263,7 @@
             <Chinesesimp>胸部密封已应用</Chinesesimp>
             <Finnish>Rintatiiviste on kiinnitetty</Finnish>
             <Dutch>Chest seal aangebracht</Dutch>
+            <Turkish>Chest Seal uygulandı</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_CyanosisStatus_Mild">
             <English>Mild Cyanosis</English>
@@ -319,6 +333,7 @@
             <Chinesesimp>决定完全恶化的气胸是否恶化为晚期（高级）气胸的概率。这是按照气胸恶化的间隔设定的每个时机持续计算的。</Chinesesimp>
             <Finnish>Prosenttiosuus mahdollisuus, joka määrittää, kehittyykö täysin heikentynyt ilmarinta pitkälle edenneeksi ilmarintaksi. Tämä lasketaan jatkuvasti pneumotoraksin etenemisajan mukaan.</Finnish>
             <Dutch>De kans in procenten, dat bepaalt of een pneumothorax zich doorontwikkeld naar een geadvanceerde pneumothorax. Dit wordt doorlopend gerold op basis van de pneumothorax verslechterings interval</Dutch>
+            <Turkish>Tamamen kötüleşmiş bir pnömotoraksın gelişmiş pnömotoraksa dönüşüp dönüşmeyeceğini belirleyen yüzde olasılık; bu değer pnömotoraks kötüleşme aralığına göre sürekli olarak hesaplanır.</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_DESCRIPTION_ADVANCED_PTX_OPTION">
             <English>Enables advanced pneumothoraxes - hemopneumothorax and tensionpneumothorax</English>
@@ -336,6 +351,7 @@
             <Chinesesimp>启用高级气胸 - 血气胸和张力性气胸</Chinesesimp>
             <Finnish>Mahdollistaa pitkälle edenneen pneumotoraksin - hemopneumotoraksin ja jännitysilmarinta</Finnish>
             <Dutch>Staat geadvanceerde pneumothoraxen - hemopneumothorax en spanningspneumothorax - toe</Dutch>
+            <Turkish>Gelişmiş pnömotoraksları etkinleştirir – Hemopnömotoraks ve Gergin pnömotoraks</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_DESCRIPTION_HEMOPNEUMOTHORAX_CHANCE_OPTION">
             <English>Sets the chance for hemopneumothorax. Also sets the chance for tenstion pneumothorax (60% Hemo = 40% Tension)</English>
@@ -353,6 +369,7 @@
             <Chinesesimp>设定血气胸的几率。同时设定张力性气胸的几率（60％血气胸= 40％张力性气胸）。</Chinesesimp>
             <Finnish>Asettaa hemopneumotoraksin mahdollisuuden. Asettaa myös jännittyneen pneumotoraksin mahdollisuuden. (60% hemo = 40% jännitystä)</Finnish>
             <Dutch>Legt de kans op een hemopneumothorax vast. Legt ook de kans voor spanningspneumothorax vast. (60% Hemo = 40% spanning)</Dutch>
+            <Turkish>Hemopnömotoraks olasılığını ayarlar. Aynı zamanda Gergin pnömotoraks olasılığını da belirler (%60 Hemo = %40 Tension)</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_DESCRIPTION_STABLE_SPO2">
             <English>After reaching more than selected value (default 85), only then patient can get conscious</English>
@@ -368,7 +385,7 @@
             <Japanese>設定した値(デフォルトは85)を超えた後、患者は意識を取り戻すことができます</Japanese>
             <Chinese>達到選定值以上（默認值85）後，患者才能恢復意識</Chinese>
             <Chinesesimp>达到设定值以上(默认85)之后,患者才能恢复意识</Chinesesimp>
-            <Turkish>Seçilen değerden (varsayılan 85) daha fazlasına ulaştıktan sonra, ancak o zaman hasta bilincini geri kazanabilir</Turkish>
+            <Turkish>Seçilen değerin (varsayılan 85) üzerine çıkıldığında hasta ancak o zaman bilincini kazanabilir</Turkish>
             <Finnish>Vasta sitten, kun valittu arvo (oletusarvo 85) on saavutettu, potilas voi herätä</Finnish>
             <Dutch>Alleen na het bereiken van meer dan deze waarde (standaard 85) kan een patiënt zijn bewustzijn terug krijgen</Dutch>
         </Key>
@@ -387,6 +404,7 @@
             <Chinesesimp>深穿透伤</Chinesesimp>
             <Finnish>Syvä tunkeutuva vamma</Finnish>
             <Dutch>Diep penetrerende wond</Dutch>
+            <Turkish>Derin Delici Yaralanma</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_HEMOPNEUMOTHORAX_CHANCE_OPTION">
             <English>Hemopneumothorax Chance</English>
@@ -404,6 +422,7 @@
             <Chinesesimp>血气胸几率</Chinesesimp>
             <Finnish>Hemopneumotoraksin mahdollisuus</Finnish>
             <Dutch>Hemopneumothorax kans</Dutch>
+            <Turkish>Hemopnömotoraks Olasılığı</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_HEMOPNEUMOTHORAX_TREATMENT_LEVEL">
             <English>Hemothorax / Tension Pnuemothorax Treament Minimum Level</English>
@@ -419,7 +438,7 @@
             <Japanese>血胸/緊張性気胸治療の許可</Japanese>
             <Chinese>血氣胸／張力性氣胸治療最低等級</Chinese>
             <Chinesesimp>血气胸/张力性气胸治疗最低等级</Chinesesimp>
-            <Turkish>Hemotoraks / Gerilim Pnömotoraks Tedavisi Minimum Seviye</Turkish>
+            <Turkish>Hemotoraks / Gergin Pnömotoraks Tedavisi Minimum Seviye</Turkish>
             <Finnish>Hemopneumotoraksi / jännitysilmarinta hoidon vähimmäistaso</Finnish>
             <Dutch>Hemopneumothorax / spanningspneumothorax minimum behandelingsniveau</Dutch>
         </Key>
@@ -437,7 +456,7 @@
             <Japanese>胸腔穿刺減圧および胸腔ドレナージの実施に必要な医療スキルのレベルを設定します。これらは血胸と緊張性気胸の治療に使われます。</Japanese>
             <Chinese>某人能夠執行針減壓和引流體液治療措施所需的最低醫療水平，用於治療血氣胸或張力性氣胸。</Chinese>
             <Chinesesimp>使用胸腔穿刺减压和引流体液治疗所需的最低医疗水平，用于治疗血气胸或张力性气胸。</Chinesesimp>
-            <Turkish>Hemotoraks veya Tansiyon Pnömotoraksı tedavi etmek için kullanılan İğne Dekompresyonu ve Boşaltma Sıvıları tedavi eylemlerini gerçekleştirebilmek için gerekli minimum tıbbi seviye.</Turkish>
+            <Turkish>Hemotoraks veya Gerin Pnömotoraksı tedavi etmek için kullanılan İğne Dekompresyonu ve Boşaltma Sıvıları tedavi eylemlerini gerçekleştirebilmek için gerekli minimum tıbbi seviye.</Turkish>
             <Finnish>Vähimmäiskoulutustaso, joka vaaditaan, jotta joku pystyy suorittamaan neulan dekompression ja nesteenpoiston, jota käytetään hemothoraksin tai jännitysilmarintain hoitoon</Finnish>
             <Dutch>Het minimaal benodigde trainingsniveau voor het uitvoeren van de naalddecompressie- en vloeistof afvoerende handelingen, benodigd om een hemo- en spanningspneumothorax te behandelen</Dutch>
         </Key>
@@ -456,6 +475,7 @@
             <Chinesesimp>血气胸</Chinesesimp>
             <Finnish>hemopneumotoraksi</Finnish>
             <Dutch>Hemopneumothorax</Dutch>
+            <Turkish>Hemopnömotoraks</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_Hemopneumothorax_short">
             <English>HPTX</English>
@@ -472,6 +492,7 @@
             <Chinesesimp>HPTX</Chinesesimp>
             <Finnish>HPT</Finnish>
             <Dutch>HPTX</Dutch>
+            <Turkish>HPTX</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_NasalCannula_Desc_Short">
             <English>The Nasal Cannula can be inserted into a patient's nostrils and connected to a vitals monitor to record a patient's ETCo2 level and respiratory rate.</English>
@@ -486,6 +507,7 @@
             <Chinese>鼻導管可插入病人鼻孔，並連接到生命體徵監測器，以記錄病人的呼氣末期二氧化碳 (ETCo2) 水平和呼吸率。</Chinese>
             <Chinesesimp>鼻导管可以插入患者的鼻孔并连接到生命体征监测仪，以记录患者的ETCo2水平和呼吸频率。</Chinesesimp>
             <Dutch>De nasale canule kan in de neusgaten van de patiënt aangebracht worden en verbonden aan een vitale waarden monitor om de ETCo2 waarden en het ademhalingstempo van de patiënt te monitoren</Dutch>
+            <Turkish>Nasal Cannula hastanın burun deliklerine yerleştirilebilir ve ETCO₂ seviyesi ile solunum sayısını kaydetmek için bir vital monitöre bağlanabilir.</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_NasalCannula_Display">
             <English>Nasal Cannula</English>
@@ -500,6 +522,7 @@
             <Chinese>鼻導管</Chinese>
             <Chinesesimp>鼻插管</Chinesesimp>
             <Dutch>Nasale canule</Dutch>
+            <Turkish>Nasal Cannula</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_PNEUMOTHORAX_DAMAGE_THRESHOLD">
             <English>Pneumothorax Damage Threshold</English>
@@ -515,7 +538,7 @@
             <Japanese>負傷による気胸発生のしきい値</Japanese>
             <Chinese>導致氣胸的損傷臨界值</Chinese>
             <Chinesesimp>导致气胸的损伤临界值</Chinesesimp>
-            <Turkish>Pnömotoraks Hasar Eşiği</Turkish>
+            <Turkish>Pnömotoraks hasar eşiği</Turkish>
             <Finnish>Vaurioiden taso, joka vaaditaan ilmarintakehän kehittymiseen</Finnish>
             <Dutch>Pneumothorax schade drempelwaarde</Dutch>
         </Key>
@@ -533,7 +556,9 @@
             <Japanese>一度の負傷で発生する気胸へのダメージ。値が低いほど気胸が発生する可能性が高くなります。\n値を非常に低く設定するか0に設定すると、予期しない動作や予期しない負傷による気胸を引き起こす可能性があります。</Japanese>
             <Chinese>單次撞擊的損傷程度（範圍為 0 到 1）需要達到多少，才會觸發氣胸的機率。數值越低，代表越容易發生氣胸。將數值設定過低或設為零，可能會導致無法預期的行為，或因意外傷害引發氣胸。</Chinese>
             <Chinesesimp>单次撞击的损伤程度（范围为 0 到 1）需要达到多少，才会触发气胸的几率。数值越低，代表越容易发生气胸。将数值设定过低或设为零，可能会导致无法预期的行为，或因意外伤害引发气胸。</Chinesesimp>
-            <Turkish>Pnömotoraks olasılığı olmadan önce meydana gelmesi gereken, 0 ila 1 ölçeğinde tek bir darbede hasar miktarı. Daha düşük değerler, pnömotoraksın oluşma olasılığının daha yüksek olduğu anlamına gelir. Değerin çok düşük veya sıfır olarak ayarlanması, beklenmedik yaralanmalardan kaynaklanan beklenmedik davranışlara veya pnömotoraksa neden olabilir.</Turkish>
+            <Turkish>0 ile 1 arasında bir ölçekte, tek bir darbe sırasında oluşması gereken hasar miktarını ifade eder; bu eşik aşıldığında pnömotoraks oluşma ihtimali ortaya çıkar.
+Daha düşük değerler, pnömotoraksın oluşma olasılığının daha yüksek olduğu anlamına gelir.
+Değerin çok düşük veya 0 olarak ayarlanması, beklenmeyen davranışlara ya da beklenmedik yaralanmalar sonucunda pnömotoraks gelişmesine neden olabilir.</Turkish>
             <Finnish>Yhden osuman vaurion määrä asteikolla 0-1, jonka täytyy tapahtua ennen kuin ilmarinta on mahdollista. Pienemmät arvot tarkoittavat, että ilmarinta on todennäköisempää. Arvon asettaminen erittäin alhaiseksi tai arvoon 0 voi aiheuttaa odottamatonta käyttäytymistä tai ilmarintaa epätavallisten vammojen vuoksi.</Finnish>
             <Dutch>De hoeveelheid schade van een enkele impact, op een schaal van 0 tot 1, dat benodigd is voordat een pneumothorax gerold wordt. Lagere waarden kan leiden tot meer pneumothoraxen. Als deze instelling laag of zelfs op 0 staat, kan dit leiden tot raar gedrag of pneumothoraxen van onverwachte wonden</Dutch>
         </Key>
@@ -548,6 +573,7 @@
             <Chinese>氧氣已連接</Chinese>
             <Chinesesimp>氧气已连接</Chinesesimp>
             <Dutch>Zuurstof is al verbonden</Dutch>
+            <Turkish>Oksijen zaten bağlı</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_PersonalOxygen_Desc_Short">
             <English>Personal oxygen tank for high altitude operations</English>
@@ -560,6 +586,7 @@
             <Chinese>用於高空作業的個人氧氣罐</Chinese>
             <Chinesesimp>高空作业用便携式氧气罐</Chinesesimp>
             <Dutch>Persoonlijke zuurstoftank voor operaties op grote hoogten</Dutch>
+            <Turkish>Yüksek irtifa operasyonları için kişisel oksijen tüpü</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_PersonalOxygen_Disconnect">
             <English>Oxygen tank disconnected</English>
@@ -572,6 +599,7 @@
             <Chinese>氧氣罐斷開</Chinese>
             <Chinesesimp>氧气罐断开</Chinesesimp>
             <Dutch>Zuurstoftank is afgesloten</Dutch>
+            <Turkish>Oksijen tüpü bağlantısı kesildi</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_PersonalOxygen_Display">
             <English>Personal Oxygen Tank</English>
@@ -584,6 +612,7 @@
             <Chinese>個人氧氣罐</Chinese>
             <Chinesesimp>便携式氧气罐</Chinesesimp>
             <Dutch>Persoonlijke zuurstoftank</Dutch>
+            <Turkish>Kişisel Oksijen Tüpü</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_PersonalOxygen_Empty">
             <English>Oxygen Tank Empty</English>
@@ -596,6 +625,7 @@
             <Chinese>氧氣罐空</Chinese>
             <Chinesesimp>氧气罐空</Chinesesimp>
             <Dutch>Zuurstoftank is leeg</Dutch>
+            <Turkish>Oksijen tüpü boş</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_PersonalOxygen_Remaining">
             <English>Minutes Remaining</English>
@@ -608,6 +638,7 @@
             <Chinese>剩餘分鐘數</Chinese>
             <Chinesesimp>剩余分钟数</Chinesesimp>
             <Dutch>Overgebleven minuten</Dutch>
+            <Turkish>Kalan dakika</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_Pneumothorax">
             <English>Pneumothorax</English>
@@ -622,6 +653,7 @@
             <Japanese>気胸(PTX)</Japanese>
             <Finnish>Pneumotoraksi</Finnish>
             <Dutch>Pneumothorax</Dutch>
+            <Turkish>Pnömotoraks</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_Pneumothorax_short">
             <English>PTX</English>
@@ -638,6 +670,7 @@
             <Chinesesimp>PTX</Chinesesimp>
             <Finnish>PTK</Finnish>
             <Dutch>PTX</Dutch>
+            <Turkish>PTX</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_PocketBVM_Desc_Short">
             <English>Compact version of the Bag-Valve-Mask</English>
@@ -655,6 +688,7 @@
             <Chinesesimp>紧凑型袋式阀面罩</Chinesesimp>
             <Finnish>Pussi-venttiili-naamari kompakti versio</Finnish>
             <Dutch>Compacte versie van de BVM</Dutch>
+            <Turkish>Bag-Valve-Mask’in kompakt versiyonu</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_PocketBVM_Display">
             <English>Pocket BVM</English>
@@ -672,6 +706,7 @@
             <Chinesesimp>便携式BVM</Chinesesimp>
             <Finnish>Kannettava BVM</Finnish>
             <Dutch>Zak BVM</Dutch>
+            <Turkish>Pocket BVM</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_PortableOxygenTankDisconnected_Empty">
             <English>Oxygen tank disconnected (empty)</English>
@@ -689,6 +724,7 @@
             <Chinesesimp>氧气罐断开（空）</Chinesesimp>
             <Finnish>Happisäiliö irrotettu (se on tyhjä)</Finnish>
             <Dutch>Zuurstoftank losgekoppeld (leeg)</Dutch>
+            <Turkish>Pocket BVM</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_PortableOxygenTank_150_Desc_Short">
             <English>Portable Oxygen Tank, containing 150L of oxygen. Connect to BVM to further assist with breathing of critical patients.</English>
@@ -706,6 +742,7 @@
             <Chinesesimp>便携式氧气罐，含150L氧气。连接BVM以进一步协助危重患者的呼吸。</Chinesesimp>
             <Finnish>Kannettava happisäiliö, joka sisältää 150 litraa happea. Yhdistä BVM:ään auttaaksesi kriittisten potilaiden hengittämisessä.</Finnish>
             <Dutch>Draagbare zuurstoftank, bevat 150L van zuurstof. Helpt met het beademen van kritieke patiënten wanneer verbonden aan een BVM</Dutch>
+            <Turkish>150 L oksijen içeren taşınabilir oksijen tüpü. Kritik hastaların solunumuna ek destek sağlamak için BVM’ye bağlanır.</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_PortableOxygenTank_150_Display">
             <English>Portable Oxygen Tank (150L)</English>
@@ -723,6 +760,7 @@
             <Chinesesimp>便携式氧气罐（150L）</Chinesesimp>
             <Finnish>Kannettava happisäiliö (150L)</Finnish>
             <Dutch>Draagbare zuurstoftank (150L)</Dutch>
+            <Turkish>Taşınabilir Oksijen Tüpü (150L)</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_PortableOxygenTank_150_Empty_Display">
             <English>Empty Portable Oxygen Tank (150L)</English>
@@ -740,6 +778,7 @@
             <Chinesesimp>空便携式氧气罐（150L）</Chinesesimp>
             <Finnish>Tyhjä kannettava happisäiliö (150L)</Finnish>
             <Dutch>Lege draagbare zuurstoftank (150L)</Dutch>
+            <Turkish>Boş Taşınabilir Oksijen Tüpü (150L)</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_PortableOxygenTank_300_Desc_Short">
             <English>Portable Oxygen Tank, containing 300L of oxygen. Connect to BVM to further assist with breathing of critical patients.</English>
@@ -757,6 +796,7 @@
             <Chinesesimp>便携式氧气罐，含300L氧气。连接BVM以进一步协助危重患者的呼吸。</Chinesesimp>
             <Finnish>Kannettava happisäiliö, joka sisältää 300 litraa happea. Yhdistä BVM:ään auttaaksesi kriittisten potilaiden hengittämisessä.</Finnish>
             <Dutch>Draagbare zuurstoftank, bevat 300L van zuurstof. Helpt met het beademen van kritieke patiënten wanneer verbonden aan een BVM</Dutch>
+            <Turkish>300 L oksijen içeren taşınabilir oksijen tüpü. Kritik hastaların solunumuna ek destek sağlamak için BVM’ye bağlanır.</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_PortableOxygenTank_300_Display">
             <English>Portable Oxygen Tank (300L)</English>
@@ -774,6 +814,7 @@
             <Chinesesimp>便携式氧气罐（300L）</Chinesesimp>
             <Finnish>Kannettava happisäiliö (300L)</Finnish>
             <Dutch>Draagbare zuurstoftank (300L)</Dutch>
+            <Turkish>Taşınabilir Oksijen Tüpü (300 L)</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_PortableOxygenTank_300_Empty_Display">
             <English>Empty Portable Oxygen Tank (300L)</English>
@@ -791,6 +832,7 @@
             <Chinesesimp>空便携式氧气罐（300L）</Chinesesimp>
             <Finnish>Tyhjä kannettava happisäiliö (300L)</Finnish>
             <Dutch>Lege draagbare zuurstoftank (300L)</Dutch>
+            <Turkish>Boş Taşınabilir Oksijen Tüpü (300L)</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_PortableOxygenTank_Empty_Desc_Short">
             <English>Empty Portable Oxygen Tank, refill at a medical vehicle or facility</English>
@@ -808,6 +850,7 @@
             <Chinesesimp>清空便携式氧气罐，在医疗车辆或设施处重新充装</Chinesesimp>
             <Finnish>Tyhjennä kannettava happisäiliö, täytä lääketieteellisessä ajoneuvossa tai laitoksessa.</Finnish>
             <Dutch>Lege draagbare zuurstoftank, hervul bij een medisch voertuig of -gebouw</Dutch>
+            <Turkish>300 L oksijen içeren taşınabilir oksijen tüpü. Kritik hastaların solunumuna ek destek sağlamak için BVM’ye bağlanır.</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_PulseOximeter_Action_addSound">
             <English>Enable Pulse Oximeter Alarm</English>
@@ -825,6 +868,7 @@
             <Chinesesimp>启用脉搏血氧仪报警</Chinesesimp>
             <Finnish>Ota pulssioksimetrin hälytys käyttöön</Finnish>
             <Dutch>Zet pulsoximeter alarm aan</Dutch>
+            <Turkish>Nabız Oksimetresi Alarmını Etkinleştir</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_PulseOximeter_Action_removeSound">
             <English>Disable Pulse Oximeter Alarm</English>
@@ -842,6 +886,7 @@
             <Chinesesimp>关闭脉搏血氧仪报警</Chinesesimp>
             <Finnish>Poista pulssioksimetrin hälytys käytöstä</Finnish>
             <Dutch>Zet pulsoximeter alarm uit</Dutch>
+            <Turkish>Nabız Oksimetresi Alarmını Kapat</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_Pulseoximeter">
             <English>Pulse Oximeter</English>
@@ -872,6 +917,7 @@
             <Chinese>用於讀取脈搏率和SpO2</Chinese>
             <Chinesesimp>用于读取脉搏率和SpO2</Chinesesimp>
             <Dutch>Wordt gebruikt om polsslag en SpO2 te meten</Dutch>
+            <Turkish>Nabız Oksimetresi Alarmını Etkinleştir</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_Pulseoximeter_Display">
             <English>Attach Pulse Oximeter</English>
@@ -887,7 +933,7 @@
             <Japanese>パルスオキシメーターを取り付ける</Japanese>
             <Chinese>連接脈搏血氧儀</Chinese>
             <Chinesesimp>连接脉搏血氧仪</Chinesesimp>
-            <Turkish>Nabız Oksimetresini Takın&gt;</Turkish>
+            <Turkish>Nabız Oksimetresi Takın</Turkish>
             <Finnish>Kiinnitä pulssioksimetri</Finnish>
             <Dutch>Plaats pulsoximeter</Dutch>
         </Key>
@@ -905,7 +951,7 @@
             <Japanese>パルスオキシメーターを取り外します</Japanese>
             <Chinese>移除 脈搏血氧儀</Chinese>
             <Chinesesimp>移除 脉搏血氧仪</Chinesesimp>
-            <Turkish>Nabız Oksimetresini Çıkarın</Turkish>
+            <Turkish>Nabız Oksimetresi Çıkarın</Turkish>
             <Finnish>Irrota pulssioksimetri</Finnish>
             <Dutch>Verwijder pulsoximeter</Dutch>
         </Key>
@@ -925,6 +971,7 @@
             <Chinesesimp>补充便携式氧气罐（150L）</Chinesesimp>
             <Finnish>Täytä kannettava happisäiliö (150L)</Finnish>
             <Dutch>Hervul draagbare zuurstoftank (150L)</Dutch>
+            <Turkish>Taşınabilir Oksijen Tüpünü Doldur (150 L)</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_RefillPortableOxygenTank_300">
             <English>Refill Portable Oxygen Tank (300L)</English>
@@ -942,6 +989,7 @@
             <Chinesesimp>补充便携式氧气罐（300L）</Chinesesimp>
             <Finnish>Täytä kannettava happisäiliö (300L)</Finnish>
             <Dutch>Hervul draagbare zuurstoftank (300L)</Dutch>
+            <Turkish>Taşınabilir Oksijen Tüpünü Doldur (300 L)</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_RefillPortableOxygenTank_Cancel">
             <English>Oxygen Tank Refill Cancelled</English>
@@ -959,6 +1007,7 @@
             <Chinesesimp>氧气罐加注已取消</Chinesesimp>
             <Finnish>Happisäiliön täyttö peruttu</Finnish>
             <Dutch>Zuurstoftank bijvulling stopgezet</Dutch>
+            <Turkish>Oksijen Tüpü Dolumu İptal Edildi</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_RefillPortableOxygenTank_Complete">
             <English>Oxygen Tank Refill Complete</English>
@@ -976,6 +1025,7 @@
             <Chinesesimp>氧气罐加注完成</Chinesesimp>
             <Finnish>Happisäiliö on täynnä</Finnish>
             <Dutch>Zuurstoftank bijgevuld</Dutch>
+            <Turkish>Oksijen Tüpü Dolumu Tamamlandı</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_RefillPortableOxygenTank_Progress">
             <English>Refilling Portable Oxygen Tank</English>
@@ -993,6 +1043,7 @@
             <Chinesesimp>重新填充便携式氧气罐</Chinesesimp>
             <Finnish>Kannettavan happisäiliön täyttö</Finnish>
             <Dutch>Bijvullen van draagbare zuurstoftank</Dutch>
+            <Turkish>Taşınabilir Oksijen Tüpü Dolduruluyor</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_RefillPortableOxygenTanks">
             <English>Refill Portable Oxygen Tank</English>
@@ -1010,6 +1061,7 @@
             <Chinesesimp>重新填充便携式氧气罐</Chinesesimp>
             <Finnish>Täytä kannettava happisäiliö</Finnish>
             <Dutch>Hervul draagbare zuurstoftank</Dutch>
+            <Turkish>Taşınabilir Oksijen Tüpünü Doldur</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_RemovePersonalOxygenTank">
             <English>Disconnect Personal Oxygen</English>
@@ -1022,6 +1074,7 @@
             <Chinese>斷開個人氧氣</Chinese>
             <Chinesesimp>断开个人氧气</Chinesesimp>
             <Dutch>Persoonlijke zuurstoftank afsluiten</Dutch>
+            <Turkish>Kişisel Oksijeni Ayır</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_Remove_NasalCannula_Log">
             <English>%1 removed Nasal Cannula</English>
@@ -1036,6 +1089,7 @@
             <Chinese>%1 移除了鼻導管</Chinese>
             <Chinesesimp>%1个已移除的鼻导管</Chinesesimp>
             <Dutch>%1 verwijderde nasale canule</Dutch>
+            <Turkish>%1 Nasal Cannula’yı çıkardı</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_Remove_OxyMask">
             <English>Remove Oxygen Mask</English>
@@ -1048,6 +1102,7 @@
             <Chinese>取下氧氣面罩</Chinese>
             <Chinesesimp>取下氧气面罩</Chinesesimp>
             <Dutch>Verwijder zuurstofmasker</Dutch>
+            <Turkish>Oksijen Maskesini Çıkar</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_SETTING_AVAIL_OXYHELMET">
             <English>Available Oxygen Helmets</English>
@@ -1059,6 +1114,7 @@
             <Japanese>利用可能な酸素供給ヘルメット</Japanese>
             <Chinese>可用氧氣頭盔</Chinese>
             <Dutch>Beschikbare zuurstofhelmen</Dutch>
+            <Turkish>Kullanılabilir Oksijen Kaskları</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_SETTING_AVAIL_OXYHELMET_DISC">
             <English>Sets which helmets can act as oxygen masks</English>
@@ -1070,6 +1126,7 @@
             <Japanese>酸素マスクとして動作させたいヘルメットを指定します</Japanese>
             <Chinese>設定哪些頭盔可以作為氧氣面罩</Chinese>
             <Dutch>Bepaald welke helmen als zuurstofmaskers gebruikt kunnen worden</Dutch>
+            <Turkish>Hangi kaskların oksijen maskesi olarak kullanılabileceğini belirler</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_SETTING_AVAIL_OXYMASK">
             <English>Available Oxygen Masks</English>
@@ -1082,6 +1139,7 @@
             <Chinese>可用氧氣面罩</Chinese>
             <Chinesesimp>可用氧气面罩</Chinesesimp>
             <Dutch>Beschikbare zuurstofmaskers</Dutch>
+            <Turkish>Kullanılabilir Oksijen Maskeleri</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_SETTING_AVAIL_OXYMASK_DISC">
             <English>Sets which goggles can act as oxygen masks</English>
@@ -1094,6 +1152,7 @@
             <Chinese>設定哪些護目鏡可以作為氧氣面罩</Chinese>
             <Chinesesimp>设置哪些护目镜可以作为氧气面罩</Chinesesimp>
             <Dutch>Bepaald welke brillen als zuurstofmasker gebruikt kunnen worden</Dutch>
+            <Turkish>Hangi gözlüklerin oksijen maskesi olarak kullanılabileceğini belirler</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_SETTING_Allow_NasalCannula">
             <English>Allow Nasal Cannula</English>
@@ -1108,6 +1167,7 @@
             <Chinese>允許使用鼻導管</Chinese>
             <Chinesesimp>允许使用鼻导管</Chinesesimp>
             <Dutch>Sta nasale canule toe</Dutch>
+            <Turkish>Nasal Cannula’ya İzin Ver</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_SETTING_Allow_NasalCannula_Desc">
             <English>Training level required to insert a Nasal Cannula</English>
@@ -1122,6 +1182,7 @@
             <Chinese>插入鼻導管所需的訓練等級</Chinese>
             <Chinesesimp>插入鼻导管所需的训练等级</Chinesesimp>
             <Dutch>Trainingsniveau benodigd voor het inbrengen van een nasale canule</Dutch>
+            <Turkish>Nasal Cannula takmak için gereken eğitim seviyesi</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_SETTING_BVMOxygen_Multiplier">
             <English>BVM Oxygen Effectiveness Multiplier</English>
@@ -1138,6 +1199,7 @@
             <Chinesesimp>BVM氧气效率倍增器</Chinesesimp>
             <Finnish>BVM happitehokkuuskerroin</Finnish>
             <Dutch>BVM zuurstof effectiviteits vermenigvuldiger</Dutch>
+            <Turkish>BVM Oksijen Etkinlik Çarpanı</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_SETTING_BVMOxygen_Multiplier_DESC">
             <English>Effectiveness multiplier for BVM when used with oxygen</English>
@@ -1145,6 +1207,7 @@
             <Spanish>Multiplicador de efectividad del BVM cuando se usa con oxígeno</Spanish>
             <German>Effektivitätsmultiplikator für BVM bei Verwendung mit Sauerstoff</German>
             <Japanese>酸素ボンベと併用する場合のBVMの有効性の乗数</Japanese>
+            <Turkish>BVM oksijenle kullanıldığında etkinlik çarpanı</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_SETTING_BVM_MedLvl">
             <English>Allow BVM</English>
@@ -1162,6 +1225,7 @@
             <Chinesesimp>允许BVM</Chinesesimp>
             <Finnish>Salli BVM</Finnish>
             <Dutch>Sta BVM toe</Dutch>
+            <Turkish>BVM’ye İzin Ver</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_SETTING_BVM_MedLvl_DESC">
             <English>Sets required medical level to use BVM</English>
@@ -1179,6 +1243,7 @@
             <Chinesesimp>设置使用BVM所需的医疗级别</Chinesesimp>
             <Finnish>Asettaa BVM:n käyttöön vaadittavan lääketieteellisen koulutustason</Finnish>
             <Dutch>Bepaalt het medische trainingsniveau benodigd voor BVM gebruik</Dutch>
+            <Turkish>BVM kullanmak için gereken tıbbi seviye</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_SETTING_BVM_Oxygen_MedLvl">
             <English>Allow BVM with oxygen</English>
@@ -1196,6 +1261,7 @@
             <Chinesesimp>允许BVM与氧气混合</Chinesesimp>
             <Finnish>Salli BVM hapen kanssa</Finnish>
             <Dutch>Sta BVM met zuurstof toe</Dutch>
+            <Turkish>Oksijenle BVM’ye İzin Ver</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_SETTING_BVM_Oxygen_MedLvl_DESC">
             <English>Sets required medical level to use BVM with oxygen</English>
@@ -1213,6 +1279,7 @@
             <Chinesesimp>设定使用BVM和氧气所需的医疗水平</Chinesesimp>
             <Finnish>Asettaa lääketieteellisen koulutustason, joka vaaditaan BVM:n käyttöön hapen kanssa</Finnish>
             <Dutch>Bepaald het medische trainingsniveau benodigt voor het gebruik van een BVM met zuurstof</Dutch>
+            <Turkish>Oksijenle BVM kullanmak için gereken tıbbi seviye</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_SETTING_ENABLE">
             <English>Activate Breathing Module</English>
@@ -1227,6 +1294,7 @@
             <Chinese>啟動呼吸模組</Chinese>
             <Chinesesimp>启用呼吸模块</Chinesesimp>
             <Dutch>Activeer ademhalingsmodule</Dutch>
+            <Turkish>Solunum Modülünü Etkinleştir</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_SETTING_ENABLE_DESC">
             <English>Sets if SPO2 simulation and according functionality like Pneumothorax and \nAirway: occlusion &amp; obstruction (SPO2 reduction will be deactivated) should be activated</English>
@@ -1241,6 +1309,7 @@
             <Chinese>設定是否啟動SpO2模擬以及相應的功能，例如氣胸和氣道：阻塞和梗阻（SpO2降低功能將被停用）。</Chinese>
             <Chinesesimp>如果SPO2模拟和相应的功能，如气胸和\nAirway：闭塞和阻塞（SPO2减少将被停用）应被激活，则设置</Chinesesimp>
             <Dutch>Activeert SpO2 simulatie omtrend pneumothorax en luchtwegen: verstopping en obstructie (SpO2 reductie wordt gedeactiveerd)</Dutch>
+            <Turkish>SpO2 simülasyonu ve buna bağlı pnömotoraks ile hava yolu tıkanması/kapanması gibi işlevlerin etkinleştirilip etkinleştirilmeyeceğini belirler (SpO2 düşüşü devre dışı bırakılır)</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_SETTING_Enable_Etco2">
             <English>Enable ETCo2 Monitoring</English>
@@ -1255,6 +1324,7 @@
             <Chinese>啟用ETCo2監測</Chinese>
             <Chinesesimp>启用ETCo2监测</Chinesesimp>
             <Dutch>Activeer ETCo2 monitor</Dutch>
+            <Turkish>ETCO2 İzlemeyi Etkinleştir</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_SETTING_Enable_Etco2_Desc">
             <English>Sets if medics can view a patient's ETCo2 and Respiratory Rate in the Vitals Monitor when a device capable of monitoring ETCo2 is connected</English>
@@ -1269,6 +1339,7 @@
             <Chinese>設定當連接能夠監測ETCo2的裝置時，醫務人員是否可以在生命體徵監視器中查看患者的ETCo2和呼吸率</Chinese>
             <Chinesesimp>设定当连接能够监测ETCo2的装置时，医务人员是否可以在生命体征监视器中查看患者的ETCo2和呼吸率</Chinesesimp>
             <Dutch>Activeert het zien van ETCo2 en ademhalingstempo op de vitale waarden monitor wanneer een apparaat die ETCo2 kan monitoren is aangesloten</Dutch>
+            <Turkish>ETCO2 ölçebilen bir cihaz bağlıyken sağlık görevlilerinin hastanın ETCO2 ve solunum hızını Vital Monitörde görüp göremeyeceğini belirler</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_SETTING_HPTX_BleedAmount">
             <English>Hemopneumothorax internal bleeding amount</English>
@@ -1286,6 +1357,7 @@
             <Chinesesimp>血气胸内出血量</Chinesesimp>
             <Finnish>Hemopneumotoraksista tulevan sisäisen verenvuodon määrä</Finnish>
             <Dutch>Hemopneumothorax interne bloedingshoeveelheid</Dutch>
+            <Turkish>Hemopnömotoraksta iç kanama miktarı</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_SETTING_HPTX_BleedAmount_DESC">
             <English>Sets amount of internal bleeding that is applied while suffering from hemopneumothorax</English>
@@ -1303,6 +1375,7 @@
             <Chinesesimp>设定血气胸时应用的内出血量</Chinesesimp>
             <Finnish>Määrittää hemopneumotoraksista johtuvan sisäisen verenvuodon määrän</Finnish>
             <Dutch>Defineert de hoeveelheid bloedverlies dat wordt verloren wanneer een patiënt een hemopneumothorax heeft</Dutch>
+            <Turkish>Hemopnömotoraks sırasında uygulanan iç kanama miktarını ayarlar</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_SETTING_MultiplyNegative">
             <English>SpO2 negative multiplier</English>
@@ -1320,6 +1393,7 @@
             <Chinesesimp>SpO2值负乘数</Chinesesimp>
             <Finnish>SpO2 negatiivinen kerroin</Finnish>
             <Dutch>SpO2 negatieve vermenigvuldiger</Dutch>
+            <Turkish>SpO2 negatif çarpanı</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_SETTING_MultiplyNegative_DESC">
             <English>Multiplier for negative SpO2 changes when not breathing properly</English>
@@ -1327,6 +1401,7 @@
             <Spanish>Multiplicador para los descensos de SpO2 cuando la respiración es inadecuada</Spanish>
             <German>Multiplikator für negative SpO2-Änderungen bei unzureichender Atmung</German>
             <Japanese>呼吸が適切ではない場合に変化するSpO2のマイナス効果の乗数</Japanese>
+            <Turkish>Yetersiz solunumda SpO₂ düşüşü için çarpan</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_SETTING_MultiplyPositive">
             <English>SpO2 positive multiplier</English>
@@ -1344,6 +1419,7 @@
             <Chinesesimp>SpO2值正乘数</Chinesesimp>
             <Finnish>SpO2-positiivinen kerroin</Finnish>
             <Dutch>SpO2 positieve vermenigvuldiger</Dutch>
+            <Turkish>SpO2 pozitif çarpanı</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_SETTING_MultiplyPositive_DESC">
             <English>Multiplier for positive SpO2 changes during breathing</English>
@@ -1351,6 +1427,7 @@
             <Spanish>Multiplicador para los aumentos positivos de SpO2 durante la respiración</Spanish>
             <German>Multiplikator für positive SpO2-Änderungen beim Atmen</German>
             <Japanese>適切な呼吸によって変化するSpO2のプラス効果の乗数</Japanese>
+            <Turkish>Nefes alırken SpO2’nin olumlu değişimleri için çarpan</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_SETTING_PACO2_ENABLE">
             <English>Enable PaCO2</English>
@@ -1363,6 +1440,7 @@
             <Chinese>啟用PaCO2</Chinese>
             <Chinesesimp>启用PaCO2</Chinesesimp>
             <Dutch>PaCO2 aanzetten</Dutch>
+            <Turkish>PaCO2’yi Etkinleştir</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_SETTING_PACO2_ENABLE_DESC">
             <English>Enables PaCO2 movement and effects on ph and breathing rate</English>
@@ -1375,6 +1453,7 @@
             <Chinese>啟用PaCO2的變化及其對pH值和呼吸速率的影響</Chinese>
             <Chinesesimp>启用PaCO2的变化及其对pH值和呼吸速率的影响</Chinesesimp>
             <Dutch>Activeert PaCO2 veranderingen en zijn effecten op pH en ademhalingsfrequentie</Dutch>
+            <Turkish>PaCO2 değişimini ve pH ile solunum hızına etkilerini etkinleştirir</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_SETTING_PerfusionMultiplier">
             <English>Perfusion multiplier</English>
@@ -1392,6 +1471,7 @@
             <Chinesesimp>灌注乘数</Chinesesimp>
             <Finnish>Perfuusiokerroin</Finnish>
             <Dutch>Perfusie vermenigvuldiger</Dutch>
+            <Turkish>Perfüzyon çarpanı</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_SETTING_PerfusionMultiplier_DESC">
             <English>Multiplier for SpO2 changes during cardiac arrest</English>
@@ -1399,6 +1479,7 @@
             <Spanish>Multiplicador para los cambios de SpO2 durante un paro cardíaco</Spanish>
             <German>Multiplikator für SpO2-Änderungen während eines Herzstillstands</German>
             <Japanese>心停止によって変化するSpO2の乗数</Japanese>
+            <Turkish>Kardiyak arrest sırasında SpO2 değişimleri için çarpan</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_SETTING_PneumothoraxAlwaysVisible">
             <English>Pneumothorax always visible</English>
@@ -1415,6 +1496,7 @@
             <Chinesesimp>气胸始终可见</Chinesesimp>
             <Finnish>Pneumothorax on aina näkyvissä</Finnish>
             <Dutch>Pneumothorax altijd zichtbaar</Dutch>
+            <Turkish>Pnömotoraks her zaman görünür</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_SETTING_PneumothoraxAlwaysVisible_DESCRIPTION">
             <English>Sets if pneumothorax should always be visible in the medical menu as an injury instead of requiring diagnosis (1x pneumothorax)</English>
@@ -1431,6 +1513,7 @@
             <Chinesesimp>设置气胸是否应始终作为损伤出现在医疗菜单中，而不需要诊断（1x气胸）</Chinesesimp>
             <Finnish>Määrittää, näkyykö ilmarinta aina lääkärille vammana diagnoosin vaatimisen sijaan (1x ilmarinta)</Finnish>
             <Dutch>Defineert of een pneumothorax altijd zichbaar is in het medische menu als een wond, zonder dat deze een diagnose vereist (1x pneumothorax)</Dutch>
+            <Turkish>Pnömotoraksın tanı gerektirmeden tıbbi menüde bir yaralanma olarak her zaman görünüp görünmeyeceğini belirler (1x pnömotoraks)</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_SETTING_PneumothoraxArrest">
             <English>Enable Pneumothorax Arrest</English>
@@ -1445,6 +1528,7 @@
             <Chinese>啟用氣胸心跳驟停</Chinese>
             <Chinesesimp>启用气胸抑制</Chinesesimp>
             <Dutch>Sta pneumothorax hartstilstand toe</Dutch>
+            <Turkish>Pnömotoraks Sonrası Kardiyak Arresti Etkinleştir</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_SETTING_PneumothoraxArrest_DESCRIPTION">
             <English>Enables a chance for cardiac arrest following pneumothorax</English>
@@ -1459,6 +1543,7 @@
             <Chinese>啟用氣胸後發生心跳停止的機率</Chinese>
             <Chinesesimp>气胸后有可能发生心脏骤停</Chinesesimp>
             <Dutch>Staat de kans op een hartstilstand na een pneumothorax toe</Dutch>
+            <Turkish>Pnömotoraks sonrası kardiyak arrest olasılığını etkinleştirir</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_SETTING_PneumothoraxDamageThreshold_DamageTaken">
             <English>Increase pneumothorax chance based on damage</English>
@@ -1475,6 +1560,7 @@
             <Chinesesimp>根据损伤增加气胸的概率</Chinesesimp>
             <Finnish>Lisää pneumotoraksin mahdollisuutta vaurion perusteella</Finnish>
             <Dutch>Verhoogt pneumothorax kans op basis van schade</Dutch>
+            <Turkish>Hasara bağlı pnömotoraks olasılığını artır</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_SETTING_PneumothoraxDamageThreshold_DamageTaken_DESCRIPTION">
             <English>Increase chance of a pneumothorax and advanced pneumothorax occurring based on damage taken if over the pneumothorax damage threshold</English>
@@ -1491,6 +1577,7 @@
             <Chinesesimp>如果超过气胸损伤阈值，则根据所受损伤增加气胸和晚期气胸发生的概率</Chinesesimp>
             <Finnish>Lisää ilmarintakehän ja pitkälle edenneen ilmarinnan esiintymisen todennäköisyyttä tehdyn vaurion perusteella, jos vaurio on suurempi kuin ilmarintakehän kehittymiseen vaadittava vähimmäisvaurio.</Finnish>
             <Dutch>Verhoogt de kans op een (geadvanceerde) pneumothorax wanneer de schade hoger is dan de drempelwaarde</Dutch>
+            <Turkish>Pnömotoraks hasar eşiği aşılırsa alınan hasara bağlı olarak pnömotoraks ve gelişmiş pnömotoraks oluşma olasılığını artırır</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_SETTING_PocketBVM_MedLvl">
             <English>Allow Pocket BVM</English>
@@ -1508,6 +1595,7 @@
             <Chinesesimp>允许便携式BVM</Chinesesimp>
             <Finnish>Salli kannettava BVM</Finnish>
             <Dutch>Sta zak BVM toe</Dutch>
+            <Turkish>Pocket BVM’ye İzin Ver</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_SETTING_PocketBVM_MedLvl_DESC">
             <English>Sets required medical level to use Pocket BVM</English>
@@ -1525,6 +1613,7 @@
             <Chinesesimp>设置使用Pocket BVM所需的医疗级别</Chinesesimp>
             <Finnish>Asettaa kannettavan BVM:n käyttöön vaaditun lääketieteellisen koulutustason</Finnish>
             <Dutch>Bepaalt het medische trainingsniveau benodigd voor zak BVM gebruik</Dutch>
+            <Turkish>Pocket BVM kullanmak için gereken tıbbi eğitim seviyesini belirler</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_SETTING_PortableOxygenTank_RefillTime">
             <English>Portable Oxygen Tank Base Refill Time</English>
@@ -1542,6 +1631,7 @@
             <Chinesesimp>便携式氧气罐底座加注时间</Chinesesimp>
             <Finnish>Kannettava happisäiliö vähimmäistäyttöaika</Finnish>
             <Dutch>Draagbare zuurstoftank hervullings tijd</Dutch>
+            <Turkish>Taşınabilir Oksijen Tüpü Temel Doldurma Süresi</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_SETTING_PortableOxygenTank_RefillTime_DESC">
             <English>Sets time required to refill Oxygen Tank (150L)</English>
@@ -1559,6 +1649,7 @@
             <Chinesesimp>设置重新填充氧气罐（150L）所需的时间</Chinesesimp>
             <Finnish>Asettaa happisäiliön (150L) täyttämiseen tarvittavan ajan</Finnish>
             <Dutch>Bepaalt de benodigde tijd om een zuurstoftank bij te vullen (150L)</Dutch>
+            <Turkish>Oksijen Tüpünü (150 L) doldurmak için gereken süreyi belirler</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_SETTING_SELF_CHESTSEAL">
             <English>Allow Chest Seal self treatment</English>
@@ -1576,6 +1667,7 @@
             <Chinesesimp>允许自我施用临时气胸密封贴</Chinesesimp>
             <Finnish>Salli rintatiivisteen käyttö itsellesi</Finnish>
             <Dutch>Sta chest seal zelfbehandeling toe</Dutch>
+            <Turkish>Chest Seal ile kendi kendine tedaviye izin ver</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_SETTING_SELF_CHESTSEAL_DESC">
             <English>Allows players to apply chest seals on themselves</English>
@@ -1583,6 +1675,7 @@
             <Spanish>Permite a los jugadores aplicar sellos torácicos sobre sí mismos</Spanish>
             <German>Ermöglicht es Spielern, sich selbst Thoraxpflaster anzulegen</German>
             <Japanese>プレイヤーが自分でチェストシールを貼ることを可能にします。</Japanese>
+            <Turkish>Oyuncuların kendilerine chest seal uygulamasına izin verir</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_SETTING_STABLE_SPO2">
             <English>Stable SpO2 value to gain consciousness</English>
@@ -1598,7 +1691,7 @@
             <Japanese>意識を取り戻すために必要なSpO2値</Japanese>
             <Chinese>穩定的SpO2值以恢復意識</Chinese>
             <Chinesesimp>允许意识清醒的最低SpO2值</Chinesesimp>
-            <Turkish>Bilinç kazanmak için gerekli SpO2 değeri</Turkish>
+            <Turkish>Bilinç kazanmak için temel SpO2 değeri</Turkish>
             <Finnish>SpO2-taso, joka vaaditaan tajunnan palauttamiseksi</Finnish>
             <Dutch>Stabiele SpO2 waarde om bewustzijn te verkrijgen</Dutch>
         </Key>
@@ -1615,6 +1708,7 @@
             <Chinese>ETCo2監測所需的單位</Chinese>
             <Chinesesimp>ETCo2监测所需的单位</Chinesesimp>
             <Dutch>Geprefereerde eenheden voor ETCo2 monitoren</Dutch>
+            <Turkish>ETCO2 İzleme için tercih edilen birimler</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_SETTING_Select_Etco2_Units_DESC">
             <English>Units for displaying EtCO2 values</English>
@@ -1622,6 +1716,7 @@
             <Spanish>Unidades para mostrar los valores de EtCO2</Spanish>
             <German>Einheiten für die Anzeige von EtCO2-Werten</German>
             <Japanese>EtCO2値の表示単位</Japanese>
+            <Turkish>ETCO2 değerlerinin gösterim birimleri</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_SETTING_SpO2_Perfusion">
             <English>Enable cardiac arrest SpO2 reduction</English>
@@ -1639,6 +1734,7 @@
             <Chinesesimp>心脏骤停时减少SpO2的下降</Chinesesimp>
             <Finnish>Ota käyttöön sydämenpysähdyksen SpO2-vähennys</Finnish>
             <Dutch>Activeer SpO2 verlies tijdens hartstilstand</Dutch>
+            <Turkish>Kardiyak arrest sırasında SpO2 düşüşünü etkinleştir</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_SETTING_SpO2_Perfusion_DESC">
             <English>Controls whether SpO2 falls during cardiac arrest</English>
@@ -1646,6 +1742,7 @@
             <Spanish>Controla si la SpO2 disminuye durante un paro cardíaco</Spanish>
             <German>Kontrolliert, ob SpO2 während eines Herzstillstands fällt</German>
             <Japanese>心停止によってSpO2が低下するかどうかを制御します。</Japanese>
+            <Turkish>Kardiyak arrest sırasında SpO2’nin düşüp düşmeyeceğini kontrol eder</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_SETTING_SpO2_cardiacActive">
             <English>Activate cardiac arrest SpO2 value</English>
@@ -1660,6 +1757,7 @@
             <Chinese>激活心跳停止SpO2值</Chinese>
             <Chinesesimp>激活心脏骤停的SpO2值</Chinesesimp>
             <Dutch>Activeer hartstilstand SpO2 waarde</Dutch>
+            <Turkish>Kardiyak arrest SpO2 değerini etkinleştir</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_SETTING_SpO2_cardiacActive_DESC">
             <English>Enables cardiac arrest when SpO2 reaches the cardiac value</English>
@@ -1667,6 +1765,7 @@
             <Spanish>Activa el paro cardíaco cuando la SpO2 alcanza el valor cardíaco</Spanish>
             <German>Aktiviert Herzstillstand, wenn SpO2 den Herzwert erreicht</German>
             <Japanese>SpO2が心停止値に達した場合に心停止に至るようにします。</Japanese>
+            <Turkish>SpO2 kardiyak değere ulaştığında kardiyak arresti etkinleştirir</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_SETTING_SpO2_cardiacValue">
             <English>Cardiac arrest SpO2 value</English>
@@ -1681,6 +1780,7 @@
             <Chinese>心跳停止SpO2值</Chinese>
             <Chinesesimp>心脏骤停SpO2值</Chinesesimp>
             <Dutch>Hartstilstand SpO2 waarde</Dutch>
+            <Turkish>Kardiyak arrest SpO2 değeri</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_SETTING_SpO2_cardiacValue_DESC">
             <English>Sets the SpO2 value that triggers cardiac arrest</English>
@@ -1688,6 +1788,7 @@
             <Spanish>Establece el valor de SpO2 que desencadena un paro cardíaco</Spanish>
             <German>Legt den SpO2-Wert fest, der einen Herzstillstand auslöst</German>
             <Japanese>到達すると心停止を引き起こすSpO2値を設定します。</Japanese>
+            <Turkish>Kardiyak arresti tetikleyen SpO2 değerini belirler</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_SETTING_SpO2_dieActive">
             <English>Activate lethal SpO2 value</English>
@@ -1713,6 +1814,7 @@
             <Spanish>Activa la muerte cuando la SpO2 alcanza el valor letal</Spanish>
             <German>Aktiviert den Tod, wenn SpO2 den tödlichen Wert erreicht</German>
             <Japanese>SpO2が致死値に達した場合に死に至るようにします。</Japanese>
+            <Turkish>SpO2 ölümcül değere ulaştığında ölümü etkinleştirir</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_SETTING_SpO2_dieValue">
             <English>Lethal SpO2 value</English>
@@ -1738,6 +1840,7 @@
             <Spanish>Establece el valor de SpO2 que provoca la muerte al alcanzarse</Spanish>
             <German>Legt den SpO2-Wert fest, der bei Erreichen den Tod verursacht</German>
             <Japanese>到達すると死に至るSpO2値を設定します。</Japanese>
+            <Turkish>Ulaşıldığında ölüme neden olan SpO2 değerini belirler</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_SETTING_SpO2_unconscious">
             <English>Unconscious SpO2 value</English>
@@ -1771,7 +1874,7 @@
             <Japanese>SpO2(血酸素飽和度)が設定した値を下回ると気絶し、無意識状態に陥ります。</Japanese>
             <Chinese>當下降到低於該值時，會引起昏迷的SpO2值</Chinese>
             <Chinesesimp>当下降到低于该值时，会令人昏迷的SpO2值</Chinesesimp>
-            <Turkish>Bu değerin altına düştüğünde bilinç kaybına neden olacak SpO2 değeri</Turkish>
+            <Turkish>Bu değerin altına düştüğünde bilinç kaybına neden olan SpO2 değeri</Turkish>
             <Finnish>SpO2-arvo, joka saavuttaessaan aiheuttaa tajuttomuuden</Finnish>
             <Dutch>De SpO2 waarde waaronder je het bewustzijn verliest</Dutch>
         </Key>
@@ -1791,6 +1894,7 @@
             <Chinesesimp>如果SpO2低于90%（默认值），会让你失去耐力</Chinesesimp>
             <Finnish>Menettää kestävyyden, jos olet alle tietyn SpO2-tason (oletusarvo on 90 %)</Finnish>
             <Dutch>Zorgt ervoor dat je stamina verliest als je onder 90% SpO2 zit (standaard waarde)</Dutch>
+            <Turkish>SpO2 %90’ın altındaysa (varsayılan değer) dayanıklılık kaybına neden olur</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_SETTING_Stamina_Loss_SPO2_display">
             <English>Enable Stamina loss on low SpO2</English>
@@ -1808,6 +1912,7 @@
             <Chinesesimp>在低SpO2时启用耐力损失</Chinesesimp>
             <Finnish>Ota kestävyyden menetys käyttöön alhaisilla SpO2-tasoilla</Finnish>
             <Dutch>Sta stamina verlies op laag SpO2 toe</Dutch>
+            <Turkish>Düşük SpO2'de dayanıklılık kaybını etkinleştir</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_SETTING_TensionHemothoraxAlwaysVisible">
             <English>Tension pneumothorax and hemothorax always visible</English>
@@ -1824,6 +1929,7 @@
             <Chinesesimp>设置张力性气胸和血气胸是否应始终作为损伤出现在医疗菜单中，而不需要诊断（1x张力性气胸/1x血气胸）</Chinesesimp>
             <Finnish>Jännitysilmarinta ja hemothorax ovat aina näkyvissä</Finnish>
             <Dutch>Spannings- en hemopneumothorax altijd zichtbaar</Dutch>
+            <Turkish>Gergin pnömotoraks ve hemotoraks her zaman görünür</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_SETTING_TensionHemothoraxAlwaysVisible_DESCRIPTION">
             <English>Sets if tension pneumothorax and hemopneumothorax should always be visible in the medical menu as an injury instead of requiring diagnosis (1x tensionpneumothorax/1x hemopneumothorax)</English>
@@ -1840,6 +1946,7 @@
             <Chinesesimp>设置张力性气胸和血气胸是否应始终作为损伤出现在医疗菜单中，而不需要诊断</Chinesesimp>
             <Finnish>Määrittää, pitäisikö jännityspneumotoraksin ja hemopneumotoraksin aina näkyä lääkärille vammana diagnoosin vaatimisen sijaan (1x jännitysilmarinta tai hemopneumotoraksi)</Finnish>
             <Dutch>Defineert of spannings- en hemopneumothoraxen altijd zichtbaar zijn in het medische menu als een wond, zonder dat deze een diagnose vereist (1x spanningspneumothorax / 1x hemopneumothorax)</Dutch>
+            <Turkish>Gergin pnömotoraks ve hemopnömotoraksın tanı gerektirmeden tıbbi menüde bir yaralanma olarak her zaman görünüp görünmeyeceğini belirler</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_SETTING_Threshold_SpO2Warning">
             <English>Pulse Oximeter Alarm SpO2 Threshold</English>
@@ -1857,6 +1964,7 @@
             <Chinesesimp>脉搏血氧仪报警SpO2阈值</Chinesesimp>
             <Finnish>SpO2-taso, joka laukaisee pulssioksimetrin hälytyksen</Finnish>
             <Dutch>Pulsoximeter alarm SpO2 drempelwaarde</Dutch>
+            <Turkish>Pulse Oximeter Alarmı SpO2 Eşiği</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_SETTING_Threshold_SpO2Warning_DESC">
             <English>SpO2 level at which the pulse oximeter starts warning</English>
@@ -1864,6 +1972,7 @@
             <Spanish>Nivel de SpO2 en el que el pulsioxímetro comienza a advertir</Spanish>
             <German>SpO2-Wert, bei dem das Pulsoximeter zu warnen beginnt</German>
             <Japanese>パルスオキシメーターが警告を開始するSpO2の値</Japanese>
+            <Turkish>Pulse oximeter’ın uyarı vermeye başladığı SpO2 seviyesi</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_SETTING_Time_NasalCannula">
             <English>Time for Nasal Cannula</English>
@@ -1878,6 +1987,7 @@
             <Chinese>鼻導管所需時間</Chinese>
             <Chinesesimp>鼻导管所需时间</Chinesesimp>
             <Dutch>Tijd voor het inbrengen van een nasale canule</Dutch>
+            <Turkish>Nasal Cannula Süresi</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_SETTING_Time_NasalCannula_Desc">
             <English>How long it will take to insert a Nasal Cannula</English>
@@ -1892,6 +2002,7 @@
             <Chinese>插入鼻導管需要多長時間</Chinese>
             <Chinesesimp>插入鼻导管需要多长时间</Chinesesimp>
             <Dutch>Hoelang het gaat duren om een nasale canule in te brengen</Dutch>
+            <Turkish>Nasal Cannula yerleştirmenin ne kadar süreceği</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_SETTING_arrestPneumothorax_interval">
             <English>Deteriorating pneumothorax arrest interval</English>
@@ -1906,6 +2017,7 @@
             <Chinese>惡化性氣胸驟停間隔</Chinese>
             <Chinesesimp>气胸停止间隔恶化</Chinesesimp>
             <Dutch>Pneumothorax verslechterings hartstilstand interval</Dutch>
+            <Turkish>Kötüleşen pnömotoraks arrest aralığı</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_SETTING_arrestPneumothorax_interval_Desc">
             <English>After each interval a chance will be rolled whether or not a pneumothorax will result in cardiac arrest</English>
@@ -1920,6 +2032,7 @@
             <Chinese>每個間隔後，將計算氣胸是否導致心跳停止的機率</Chinese>
             <Chinesesimp>每间隔一次，就会有概率判断气胸是否会导致心脏骤停</Chinesesimp>
             <Dutch>na elke interval wordt er een kansrol uitgevoerd die bepaald of een pneumothorax leidt tot een hartstilstand</Dutch>
+            <Turkish>Her aralıktan sonra pnömotoraksın kardiyak arrestle sonuçlanıp sonuçlanmayacağı için bir olasılık hesaplanır</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_SETTING_clearChestSealAfterTreatment">
             <English>Clear Chest Seal after treatment</English>
@@ -1936,6 +2049,7 @@
             <Chinesesimp>治疗后移除胸腔密封贴</Chinesesimp>
             <Finnish>Poista rintatiiviste hoidon jälkeen</Finnish>
             <Dutch>Verwijder chest seal na behandeling</Dutch>
+            <Turkish>Tedavi sonrası Chest Seal’i temizle</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_SETTING_clearChestSealAfterTreatment_DESC">
             <English>Removes chest seal from medical menu after pneumothorax treatment</English>
@@ -1943,6 +2057,7 @@
             <Spanish>Elimina el sello torácico del menú médico después del tratamiento de un neumotórax</Spanish>
             <German>Entfernt Thoraxpflaster aus dem Medizinmenü nach Pneumothorax-Behandlung</German>
             <Japanese>気胸の治療後、医療メニューからチェストシールを除去します。</Japanese>
+            <Turkish>Pnömotoraks tedavisinden sonra chest seal’i tıbbi menüden kaldırır</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_SETTING_deepPenetratingInjuryChance">
             <English>Deep Penetrating Injury Chance</English>
@@ -1959,6 +2074,7 @@
             <Chinesesimp>深度穿透伤概率</Chinesesimp>
             <Finnish>Mahdollisuus syvään tunkeutuvaan vammaan</Finnish>
             <Dutch>Kans op diep penetrerende wond.</Dutch>
+            <Turkish>Derin Delici Yaralanma Olasılığı</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_SETTING_deepPenetratingInjuryChance_DESC">
             <English>Chance for deep penetrating injury to appear when pneumothorax damage threshold is passed but no pneumothorax is inflicted</English>
@@ -1975,6 +2091,7 @@
             <Chinesesimp>当超过气胸损伤阈值但未造成气胸时，出现深穿透伤的概率</Chinesesimp>
             <Finnish>Mahdollisuus syvään tunkeutuvaan vammaan syntyy, kun ilmarintakehän vaurioituminen on minimaalista, mutta ilmarintaa ei ole kehittynyt.</Finnish>
             <Dutch>Kans voor het verschijnen van een diep penetrerende wond wanneer de drempelwaarde voor een pneumothorax overschreden wordt maar er geen pneumothorax gerold wordt.</Dutch>
+            <Turkish>Pnömotoraks hasar eşiği geçildiği hâlde pnömotoraks oluşmazsa derin penetran yaralanma ortaya çıkma olasılığı</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_SETTING_deterioratingPneumothorax_chance">
             <English>Pneumothorax deterioration chance</English>
@@ -1992,6 +2109,7 @@
             <Chinesesimp>气胸恶化概率</Chinesesimp>
             <Finnish>Pneumotoraksin huononemisen mahdollisuus</Finnish>
             <Dutch>Pneumothorax verslechteringskans</Dutch>
+            <Turkish>Pnömotoraks kötüleşme olasılığı</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_SETTING_deterioratingPneumothorax_chance_DESC">
             <English>Chance for pneumothorax to deteriorate</English>
@@ -2008,6 +2126,7 @@
             <Chinesesimp>气胸恶化的可能性</Chinesesimp>
             <Finnish>Pneumotoraksin mahdollisuus pahentua</Finnish>
             <Dutch>Kans voor een pneumothorax om te verslechteren</Dutch>
+            <Turkish>Pnömotoraksın kötüleşme ihtimali</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_SETTING_deterioratingPneumothorax_interval">
             <English>Deteriorating pneumothorax interval</English>
@@ -2024,6 +2143,7 @@
             <Chinesesimp>气胸间隔恶化</Chinesesimp>
             <Finnish>Aika pneumotoraksin pahenemismahdollisuuksien välillä</Finnish>
             <Dutch>Pneumothorax verslechteringsinterval</Dutch>
+            <Turkish>Pnömotoraks kötüleşme aralığı</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_SETTING_deterioratingPneumothorax_interval_Desc">
             <English>After each interval a chance will be rolled whether or not the pneumothorax will deteriorate</English>
@@ -2040,6 +2160,7 @@
             <Chinesesimp>每次间隔后，气胸是否会恶化的概率都会被滚动</Chinesesimp>
             <Finnish>Jokaisen ajanjakson jälkeen lasketaan mahdollisuus, paheneeko ilmarinta vai ei</Finnish>
             <Dutch>Na elke interval wordt een nieuwe kansrol uitgevoerd die bepaald of de pneumothorax verslechterd</Dutch>
+            <Turkish>Her aralıktan sonra pnömotoraksın kötüleşip kötüleşmeyeceği için bir olasılık hesaplanır</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_SETTING_enableCheckBreathing">
             <English>Enable Check Breathing</English>
@@ -2052,6 +2173,7 @@
             <Chinese>啟用檢查呼吸</Chinese>
             <Chinesesimp>启用检查呼吸</Chinesesimp>
             <Dutch>Ademhalingscheck aanzetten</Dutch>
+            <Turkish>Solunum Kontrolünü Etkinleştir</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_SETTING_enableCheckBreathing_DESC">
             <English>Whether or not Check Breathing medical action is enabled</English>
@@ -2064,6 +2186,7 @@
             <Chinese>檢查呼吸醫療動作是否啟用</Chinese>
             <Chinesesimp>检查呼吸医疗动作是否启用</Chinesesimp>
             <Dutch>Bepaald of de Ademhalingscheck handeling aangezet is</Dutch>
+            <Turkish>Solunum Kontrolü tıbbi eyleminin etkin olup olmadığını belirler</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_SETTING_inspectChest_enable">
             <English>Enable Inspect Chest</English>
@@ -2080,6 +2203,7 @@
             <Chinesesimp>启用胸部检查</Chinesesimp>
             <Finnish>Ota rinnan tarkastus käyttöön</Finnish>
             <Dutch>Sta Thoraxinspectie toe</Dutch>
+            <Turkish>Göğüs İncelemesini Etkinleştir</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_SETTING_inspectChest_enable_DESC">
             <English>Enables the inspect chest action for diagnosing thoracic injuries</English>
@@ -2087,6 +2211,7 @@
             <Spanish>Activa la acción de inspeccionar el pecho para diagnosticar lesiones torácicas</Spanish>
             <German>Aktiviert die Brustraumuntersuchung zur Diagnose von Thoraxverletzungen</German>
             <Japanese>胸腔損傷の診断に必要な胸部検査を有効化します</Japanese>
+            <Turkish>Göğüs yaralanmalarını teşhis etmek için göğüs inceleme eylemini etkinleştirir</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_SETTING_inspectChest_enable_simple">
             <English>Simple</English>
@@ -2103,6 +2228,7 @@
             <Chinesesimp>简单</Chinesesimp>
             <Finnish>Yksinkertainen</Finnish>
             <Dutch>Simpel</Dutch>
+            <Turkish>Basit</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_SETTING_inspectChest_medLvl">
             <English>Allow Inspecting Chest</English>
@@ -2119,6 +2245,7 @@
             <Chinesesimp>允许检查胸部</Chinesesimp>
             <Finnish>Salli rintatutkimus</Finnish>
             <Dutch>Sta thorax inspectie toe</Dutch>
+            <Turkish>Göğüs İncelemesine İzin Ver</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_SETTING_inspectChest_medLvl_DESC">
             <English>Required medical training level to perform chest inspection</English>
@@ -2126,6 +2253,7 @@
             <Spanish>Nivel de formación médica requerido para realizar la inspección del pecho</Spanish>
             <German>Erforderliche medizinische Ausbildungsstufe für Brustraumuntersuchung</German>
             <Japanese>胸部検査の使用に必要な医療スキルのレベルを設定します。</Japanese>
+            <Turkish>Göğüs incelemesi yapmak için gereken tıbbi eğitim seviyesi</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_SETTING_inspectChest_time">
             <English>Inspect Chest Time</English>
@@ -2142,6 +2270,7 @@
             <Chinesesimp>检查胸部时间</Chinesesimp>
             <Finnish>Kuinka kauan rintakehän tarkastus kestää</Finnish>
             <Dutch>Thorax inspectie tijd</Dutch>
+            <Turkish>Göğüs İnceleme Süresi</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_SETTING_inspectChest_time_DESC">
             <English>Time required to complete chest inspection</English>
@@ -2149,6 +2278,7 @@
             <Spanish>Tiempo necesario para completar la inspección del pecho</Spanish>
             <German>Benötigte Zeit für die Brustraumuntersuchung</German>
             <Japanese>胸部検査の完了にかかる時間</Japanese>
+            <Turkish>Göğüs incelemesini tamamlamak için gereken süre</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_SETTING_locationProvideOxygen">
             <English>Location Provide Oxygen</English>
@@ -2165,6 +2295,7 @@
             <Chinesesimp>位置提供氧气</Chinesesimp>
             <Finnish>Tarjoaako sijainti happea</Finnish>
             <Dutch>Locaties die zuurstof geven</Dutch>
+            <Turkish>Konum Oksijen Sağlar</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_SETTING_locationProvideOxygen_DESC">
             <English>Sets if medical vehicles/facilites can provide oxygen</English>
@@ -2181,6 +2312,7 @@
             <Chinesesimp>设置医疗车辆/设施是否可以提供氧气</Chinesesimp>
             <Finnish>Määrittää, voivatko lääketieteelliset ajoneuvot tai tilat tarjota happea</Finnish>
             <Dutch>Bepaalt of voertuigen/gebouwen zuurstof kunnen geven</Dutch>
+            <Turkish>Sağlık araçları/tesislerinin oksijen sağlayıp sağlayamayacağını belirler</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_SETTING_mildValue">
             <English>Mild cyanosis SpO2 value</English>
@@ -2242,6 +2374,7 @@
             <Spanish>Probabilidad de que ocurra un neumotórax a partir de lesiones torácicas</Spanish>
             <German>Wahrscheinlichkeit für Pneumothorax bei Thoraxverletzungen</German>
             <Japanese>胸部の負傷による気胸の発生確率</Japanese>
+            <Turkish>Toraks yaralanmalarından pnömotoraks oluşma olasılığı</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_SETTING_severeValue">
             <English>Severe cyanosis SpO2 value</English>
@@ -2294,6 +2427,7 @@
             <Chinesesimp>显示发绀</Chinesesimp>
             <Finnish>Näytä syanoosi</Finnish>
             <Dutch>Toon cyanose</Dutch>
+            <Turkish>Siyanozu Göster</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_SETTING_showCyanosis_DESC">
             <English>Shows cyanosis of patient in overview tab</English>
@@ -2310,6 +2444,7 @@
             <Chinesesimp>在概览选项卡中显示患者的紫绀</Chinesesimp>
             <Finnish>Näyttää potilaan syanoosin lääketieteellisen yleiskuvan näytössä</Finnish>
             <Dutch>Toont de cyanose van de patiënt op de overzichtspagina</Dutch>
+            <Turkish>Genel bakış sekmesinde hastanın siyanozunu gösterir</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_SETTING_slightValue">
             <English>Slight cyanosis SpO2 value</English>
@@ -2363,6 +2498,7 @@
             <Chinesesimp>听诊器所需时间</Chinesesimp>
             <Finnish>Stetoskoopin kuunteluaika</Finnish>
             <Dutch>Stethoscoop luister tijd</Dutch>
+            <Turkish>Stetoskop Dinleme Süresi</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_SETTING_stethoscopeListeningTime_DESC">
             <English>Sets how long the stethoscope listening period is</English>
@@ -2380,6 +2516,7 @@
             <Chinesesimp>使用听诊器听诊所需时间</Chinesesimp>
             <Finnish>Asettaa kuinka pitkä stetoskoopin kuuntelujakso on</Finnish>
             <Dutch>Bepaald hoelang de stethoscoop luister periode is</Dutch>
+            <Turkish>Stetoskopla dinleme süresinin ne kadar olacağını belirler</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_SETTING_stethoscopeSoundVolume">
             <English>Stethoscope Sound Volume</English>
@@ -2412,7 +2549,7 @@
             <Japanese>聴診器を使用した際の呼吸音の音の大きさを定義します</Japanese>
             <Chinese>確定使用聽診器時胸部聲音的響度</Chinese>
             <Chinesesimp>确定使用听诊器时胸部声音的响度</Chinesesimp>
-            <Turkish>Stetoskop kullanırken toraks seslerinin ne kadar yüksek olduğunu belirler</Turkish>
+            <Turkish>Stetoskop kullanıldığında solunum seslerinin ne kadar yüksek olacağını belirler</Turkish>
             <Finnish>Stetoskoopin äänenvoimakkuus</Finnish>
             <Dutch>Bepaald hoe luid de longgeluiden zijn tijdens het luisteren met een stethoscoop</Dutch>
         </Key>
@@ -2432,6 +2569,7 @@
             <Chinesesimp>首选便携式氧气罐（150L）</Chinesesimp>
             <Finnish>Aseta kannettava happisäiliö (150L) ensisijaiseksi happisäiliöksi</Finnish>
             <Dutch>Defineert de 150L draagbare zuurstoftank als voorkeurstank</Dutch>
+            <Turkish>Taşınabilir Oksijen Tüpünü (150 L) tercih edilen olarak ayarla</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_SetPreferredOxygenTank_300">
             <English>Set Portable Oxygen Tank (300L) as preferred</English>
@@ -2449,6 +2587,7 @@
             <Chinesesimp>首选便携式氧气罐（300L）</Chinesesimp>
             <Finnish>Aseta kannettava happisäiliö (300L) ensisijaiseksi happisäiliöksi</Finnish>
             <Dutch>Defineert de 300L draagbare zuurstoftank als voorkeurstank</Dutch>
+            <Turkish>Taşınabilir Oksijen Tüpünü (300 L) tercih edilen olarak ayarla</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_Stethoscope_desc">
             <English>Allows you to auscultate lung sounds</English>
@@ -2502,6 +2641,7 @@
             <Chinesesimp>紫绀设置</Chinesesimp>
             <Finnish>Syanoosin asetukset</Finnish>
             <Dutch>Cyanose instellingen</Dutch>
+            <Turkish>Siyanoz Ayarları</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_SubCategory_Items">
             <English>Breathing items Settings</English>
@@ -2519,6 +2659,7 @@
             <Chinesesimp>呼吸项目设置</Chinesesimp>
             <Finnish>Hengityselinten hoitolaitteiden asetukset</Finnish>
             <Dutch>Ademhalingsitem instellingen</Dutch>
+            <Turkish>Solunum Eşyaları Ayarları</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_SubCategory_ThoraxInjuries">
             <English>Thorax injuries Settings</English>
@@ -2536,6 +2677,7 @@
             <Chinesesimp>胸部损伤设置</Chinesesimp>
             <Finnish>Asetukset rintakehän vammoihin</Finnish>
             <Dutch>Thoraxverwonding instellingen</Dutch>
+            <Turkish>Toraks Yaralanmaları Ayarları</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_TRAININGLEVEL_CHESTSEAL">
             <English>Training level required to use a Chest Seal</English>
@@ -2589,6 +2731,7 @@
             <Chinesesimp>使用BVM</Chinesesimp>
             <Finnish>Käytä BVM:ää</Finnish>
             <Dutch>Gebruik BVM</Dutch>
+            <Turkish>BVM Kullan</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_UseBVM_Cancelled">
             <English>Rescue Breaths Cancelled</English>
@@ -2605,6 +2748,7 @@
             <Chinesesimp>救援呼吸被取消</Chinesesimp>
             <Finnish>Pelastushengitykset peruttu</Finnish>
             <Dutch>Beademing is gestopt</Dutch>
+            <Turkish>Kurtarıcı Soluklar İptal Edildi</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_UseBVM_Oxygen">
             <English>Use BVM with Oxygen</English>
@@ -2621,6 +2765,7 @@
             <Chinesesimp>使用含氧气的BVM</Chinesesimp>
             <Finnish>Käytä BVM:ää hapen kanssa</Finnish>
             <Dutch>Gebruik BVM met zuurstof</Dutch>
+            <Turkish>Oksijenle BVM Kullan</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_UseBVM_PortableOxygen">
             <English>Use BVM with Oxygen Tank</English>
@@ -2638,6 +2783,7 @@
             <Chinesesimp>使用带氧气罐的BVM</Chinesesimp>
             <Finnish>Käytä BVM:ää happisäiliön kanssa</Finnish>
             <Dutch>Gebruik BVM met zuurstoftank</Dutch>
+            <Turkish>Oksijen Tüpü ile BVM Kullan</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_UseBVM_PortableOxygen_Vehicle">
             <English>Use BVM with Oxygen Tank (Vehicle)</English>
@@ -2654,6 +2800,7 @@
             <Chinesesimp>使用带氧气罐的BVM（车辆）</Chinesesimp>
             <Finnish>Käytä BVM:ää ajoneuvon happisäiliön kanssa</Finnish>
             <Dutch>Gebruik BVM met zuurstoftank (voertuig)</Dutch>
+            <Turkish>Araçtaki Oksijen Tüpü ile BVM Kullan</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_UseBVM_PutAway">
             <English>Put away BVM</English>
@@ -2670,6 +2817,7 @@
             <Chinesesimp>收起BVM</Chinesesimp>
             <Finnish>Varastoi BVM</Finnish>
             <Dutch>BVM wegleggen</Dutch>
+            <Turkish>BVM’yi Kaldır</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_UseBVM_Start">
             <English>Rescue Breaths Started</English>
@@ -2685,6 +2833,7 @@
             <Chinesesimp>救援呼吸开始</Chinesesimp>
             <Finnish>Pelastushengitykset alkavat</Finnish>
             <Dutch>Beademing gestart</Dutch>
+            <Turkish>Kurtarıcı Soluklar Başladı</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_UsePocketBVM">
             <English>Use Pocket BVM</English>
@@ -2702,6 +2851,7 @@
             <Chinesesimp>使用便携式BVM</Chinesesimp>
             <Finnish>Käytä kannettavaa BVM:ää</Finnish>
             <Dutch>Gebruik zak BVM</Dutch>
+            <Turkish>Pocket BVM Kullan</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_VehicleOxygen_Affirm">
             <English>Attached to Aircraft Oxygen</English>
@@ -2714,6 +2864,7 @@
             <Chinese>附在飛機氧氣上</Chinese>
             <Chinesesimp>附在飞机氧气上</Chinesesimp>
             <Dutch>Met vliegtuig zuurstofsyteem verbonden</Dutch>
+            <Turkish>Uçak Oksijenine Bağlandı</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_aatKit_desc">
             <English>The Advanced Airway Treatment Kit is a single use kit designed to treat advanced airway conditions, like hemopneumothorax</English>
@@ -2729,7 +2880,7 @@
             <Japanese>AAT キット (Advanced Airway Treatment, 高度気道治療)は、血気胸などの重度な呼吸器症状を治療するために設計された使い捨てキットです。</Japanese>
             <Chinese>進階氣道治療套件是一次性使用的套件，用於治療氣道血氣胸等進階氣道疾病</Chinese>
             <Chinesesimp>高级气道治疗套件(AAT Kit),用于处理与气胸相关问题</Chinesesimp>
-            <Turkish>Gelişmiş Hava Yolu Tedavi Kiti, hemopnömotoraks gibi gelişmiş hava yolu koşullarını tedavi etmek için tasarlanmış tek kullanımlık bir kittir.</Turkish>
+            <Turkish>Advanced Airway Treatment Kit, hemopnömotoraks gibi ileri hava yolu durumlarını tedavi etmek için tasarlanmış tek kullanımlık bir kittir</Turkish>
             <Finnish>AAT-laite on kertakäyttöinen työkalu, joka on suunniteltu tappavien hengitystiesairauksien, kuten hemopneumotoraksin, hoitoon</Finnish>
             <Dutch>de AAT kit is een eenmalig gebruik kit ontwikkeld voor het behandelen van geadvanceerde luchtwegcondities</Dutch>
         </Key>
@@ -2765,7 +2916,7 @@
             <Japanese>肺音を聴診</Japanese>
             <Chinese>聽診肺音</Chinese>
             <Chinesesimp>听诊肺音</Chinesesimp>
-            <Turkish>Akciğer Seslerini Dinleyin</Turkish>
+            <Turkish>Akciğer Seslerini Dinle</Turkish>
             <Finnish>Kuuntele keuhkojen ääniä</Finnish>
             <Dutch>Beluister de longen</Dutch>
         </Key>
@@ -2784,6 +2935,7 @@
             <Chinesesimp>，略带果香</Chinesesimp>
             <Finnish>, hieman hedelmäinen</Finnish>
             <Dutch>, lichtelijk fruitig</Dutch>
+            <Turkish>, hafif meyvemsi</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_breath_stink">
             <English>, harsh and metallic</English>
@@ -2800,6 +2952,7 @@
             <Chinesesimp>，粗糙的金属质感</Chinesesimp>
             <Finnish>, kova ja metallinen</Finnish>
             <Dutch>, hard en metaalachtig</Dutch>
+            <Turkish>, sert ve metalik</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_breathing_Veryshallow">
             <English>Very Shallow</English>
@@ -2811,6 +2964,7 @@
             <Japanese>とても浅い</Japanese>
             <Chinese>非常淺</Chinese>
             <Dutch>Erg oppervlakkig</Dutch>
+            <Turkish>Çok Yüzeysel</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_breathing_isNormal">
             <English>Patient is breathing normally</English>
@@ -2827,6 +2981,7 @@
             <Chinesesimp>患者呼吸正常</Chinesesimp>
             <Finnish>Potilas hengittää normaalisti</Finnish>
             <Dutch>Patiënt ademt normaal</Dutch>
+            <Turkish>Hasta normal şekilde nefes alıyor</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_breathing_isShallow">
             <English>Patient's breathing is shallow</English>
@@ -2843,6 +2998,7 @@
             <Chinesesimp>患者呼吸微弱</Chinesesimp>
             <Finnish>Potilaan hengitys on pinnallista</Finnish>
             <Dutch>Patiënts ademhaling is oppervlakkig</Dutch>
+            <Turkish>Hastanın solunumu yüzeysel</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_breathing_isVeryShallow">
             <English>Patient's breathing is very shallow</English>
@@ -2854,6 +3010,7 @@
             <Japanese>患者の呼吸はとても浅い</Japanese>
             <Chinese>病人呼吸非常淺</Chinese>
             <Dutch>Patients ademhaling is zeer oppervlakkig</Dutch>
+            <Turkish>Hastanın solunumu çok yüzeysel</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_breathing_none">
             <English>Patient is not breathing</English>
@@ -2871,6 +3028,7 @@
             <Chinesesimp>患者没有呼吸</Chinesesimp>
             <Finnish>Potilas ei hengitä</Finnish>
             <Dutch>Patiënt ademt niet</Dutch>
+            <Turkish>Hasta nefes almıyor</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_breathing_rrNormal">
             <English>RR: Normal</English>
@@ -2881,6 +3039,7 @@
             <Japanese>呼吸速度: 正常</Japanese>
             <Chinese>呼吸頻率：正常</Chinese>
             <Dutch>AF: Normaal</Dutch>
+            <Turkish>RR: Normal</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_breathing_rrRapid">
             <English>RR: Rapid</English>
@@ -2892,6 +3051,7 @@
             <Japanese>呼吸速度: 速い</Japanese>
             <Chinese>呼吸頻率：快</Chinese>
             <Dutch>AF: Versnelt</Dutch>
+            <Turkish>RR: Hızlı</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_breathing_rrSlow">
             <English>RR: Slow</English>
@@ -2903,6 +3063,7 @@
             <Japanese>呼吸速度: 遅い</Japanese>
             <Chinese>呼吸頻率：慢</Chinese>
             <Dutch>AF: Langzaam</Dutch>
+            <Turkish>RR: Yavaş</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_breathing_shallow">
             <English>Shallow</English>
@@ -2919,6 +3080,7 @@
             <Chinesesimp>浅</Chinesesimp>
             <Finnish>Matala</Finnish>
             <Dutch>Oppervlakkig</Dutch>
+            <Turkish>Yüzeysel</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_cba_name">
             <English>KAT - ADV Medical: Breathing</English>
@@ -2928,6 +3090,7 @@
             <German>KAT - ADV Medical: Atmung</German>
             <Japanese>KAM - 呼吸器系 (Breathing)</Japanese>
             <Dutch>KAT - ADV Medical: Ademhaling</Dutch>
+            <Turkish>KAT – Gelişmiş Tıp: Solunum</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_chestseal_desc">
             <English>Chest Seal is engineered to treat, seal, and reseal open chest wounds under most circumstances.</English>
@@ -2943,7 +3106,7 @@
             <Japanese>チェストシールはほとんどの状況下で、胸部への穿通創の閉塞と開放による治療ができるように設計されています。</Japanese>
             <Chinese>胸腔密封貼 設計用於在大多數情況下治療、密封和重新密封開放性胸部傷口。</Chinese>
             <Chinesesimp>胸腔密封贴 设计用于在大多数情况下治疗、密封和重新密封开放性胸部伤口。</Chinesesimp>
-            <Turkish>Chest Seal, çoğu durumda açık göğüs yaralarını tedavi etmek, kapatmak ve yeniden kapatmak için tasarlanmıştır.</Turkish>
+            <Turkish>Chest Seal, çoğu durumda açık göğüs yaralarını tedavi etmek, kapatmak ve yeniden mühürlemek için tasarlanmıştır.</Turkish>
             <Finnish>Rintatiiviste on suunniteltu käsittelemään, tiivistämään ja uudelleensulkemaan avoimia rintahaavoja useimmissa olosuhteissa</Finnish>
             <Dutch>De chest seal is ontwikkeld om open borstwonden te dichten onder de meeste omstandigheden</Dutch>
         </Key>
@@ -2997,7 +3160,7 @@
             <Japanese>1x 血気胸</Japanese>
             <Chinese>1x 血氣胸</Chinese>
             <Chinesesimp>1x 血气胸</Chinesesimp>
-            <Turkish>1x hemopnömotoraks</Turkish>
+            <Turkish>1x Hemopnömotoraks</Turkish>
             <Finnish>1x hemopneumotoraksi</Finnish>
             <Dutch>1x Hemopneumothorax</Dutch>
         </Key>
@@ -3016,6 +3179,7 @@
             <Chinesesimp>检查胸部</Chinesesimp>
             <Finnish>Tutki rintakehä</Finnish>
             <Dutch>Thoraxinspectie</Dutch>
+            <Turkish>Göğsü İncele</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_inspectChest_internalBleeding">
             <English>Skin is rigid, looks bruised</English>
@@ -3032,6 +3196,7 @@
             <Chinesesimp>皮肤僵硬，看起来有瘀伤</Chinesesimp>
             <Finnish>Iho on jäykkä ja näyttää mustelmalta</Finnish>
             <Dutch>Huid is stijf, ziet er gekneusd uit</Dutch>
+            <Turkish>Cilt sert, morarmış görünüyor</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_inspectChest_log">
             <English>%1 inspected chest: %2</English>
@@ -3048,6 +3213,7 @@
             <Chinesesimp>%1个检查胸部：%2</Chinesesimp>
             <Finnish>%1 tarkastettu rintakehä: %2</Finnish>
             <Dutch>%1 inspecteerde thorax:%2</Dutch>
+            <Turkish>%1 göğsü inceledi: %2</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_inspectChest_none">
             <English>No chest movement observed</English>
@@ -3064,6 +3230,7 @@
             <Chinesesimp>未观察到胸部运动</Chinesesimp>
             <Finnish>Rintakehän liikettä ei havaittu</Finnish>
             <Dutch>Geen thorax beweging wordt geobserveerd</Dutch>
+            <Turkish>Göğüs hareketi gözlemlenmedi</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_inspectChest_none_log">
             <English>No chest movement</English>
@@ -3080,6 +3247,7 @@
             <Chinesesimp>胸部无动作</Chinesesimp>
             <Finnish>Ei liikettä rinnassa</Finnish>
             <Dutch>Geen thorax beweging</Dutch>
+            <Turkish>Göğüs hareketi yok</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_inspectChest_normal">
             <English>Chest rise and fall observed</English>
@@ -3096,6 +3264,7 @@
             <Chinesesimp>观察胸部起伏</Chinesesimp>
             <Finnish>Rintakehän nousu ja lasku havaittu</Finnish>
             <Dutch>Stijging en daling van thorax worden geobserveerd</Dutch>
+            <Turkish>Göğüs yükselip alçalması gözlemlendi</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_inspectChest_progress">
             <English>Inspecting Chest</English>
@@ -3112,6 +3281,7 @@
             <Chinesesimp>检查胸部</Chinesesimp>
             <Finnish>Rintakehän tutkiminen</Finnish>
             <Dutch>Thoraxinspectie</Dutch>
+            <Turkish>Göğüs İnceleniyor</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_inspectChest_simple">
             <English>Symptoms indicate %1</English>
@@ -3128,6 +3298,7 @@
             <Chinesesimp>症状表明%1</Chinesesimp>
             <Finnish>Oireet osoittavat %1</Finnish>
             <Dutch>Symptomen indiceren %1</Dutch>
+            <Turkish>Belirtiler %1’i işaret ediyor</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_inspectChest_uneven">
             <English>Chest sides are uneven</English>
@@ -3144,6 +3315,7 @@
             <Chinesesimp>胸部两侧不平</Chinesesimp>
             <Finnish>Rintakehän sivut ovat epätasaiset</Finnish>
             <Dutch>Thoraxzijden zijn oneven</Dutch>
+            <Turkish>Göğüs tarafları asimetrik</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_inspectChest_unevenMovement">
             <English>Uneven chest rise and fall</English>
@@ -3160,6 +3332,7 @@
             <Chinesesimp>胸部起伏不均</Chinesesimp>
             <Finnish>Epätasainen rintakehän nousu ja lasku</Finnish>
             <Dutch>Ongelijkmatige stijging en daling van thorax</Dutch>
+            <Turkish>Asimetrik göğüs yükselip alçalması</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_inspectChest_uneven_log">
             <English>, chest sides uneven</English>
@@ -3176,6 +3349,7 @@
             <Chinesesimp>胸部两侧不平</Chinesesimp>
             <Finnish>, rintakehän sivut epätasaiset</Finnish>
             <Dutch>, thoraxzijden oneven</Dutch>
+            <Turkish>, göğüs tarafları asimetrik</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_listening_progress">
             <English>Listening</English>
@@ -3191,7 +3365,7 @@
             <Japanese>聴診中</Japanese>
             <Chinese>聽診中</Chinese>
             <Chinesesimp>听诊中</Chinesesimp>
-            <Turkish>Dinleme</Turkish>
+            <Turkish>Dinleniyor</Turkish>
             <Finnish>Kuunteleminen</Finnish>
             <Dutch>Luisteren</Dutch>
         </Key>
@@ -3211,6 +3385,7 @@
             <Chinesesimp>针刺胸腔减压套件是一次性使用的套件，设计用于治疗张力性气胸。</Chinesesimp>
             <Finnish>Neulan rintakehän dekompressiotyökalu on kertakäyttöinen työkalu, joka on suunniteltu hemopneumotoraksin hoitoon</Finnish>
             <Dutch>De naalddecompressie kit is een eenmaligsgebruik kit voor de behandeling van een spanningspneumothorax</Dutch>
+            <Turkish>Needle Chest Decompression Kit, gergin pnömotoraksı tedavi etmek için tasarlanmış tek kullanımlık bir kittir.</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_ncdKit_display">
             <English>NCD Kit</English>
@@ -3228,6 +3403,7 @@
             <Chinesesimp>NCD套件</Chinesesimp>
             <Finnish>NCD-laite</Finnish>
             <Dutch>ND kit</Dutch>
+            <Turkish>NCD Kit</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_placing">
             <English>Placing</English>
@@ -3279,7 +3455,7 @@
             <Japanese>パルスオキシメーター: 脈拍: %1 SpO2: %2</Japanese>
             <Chinese>脈搏血氧儀：脈搏：%1 SpO2：%2</Chinese>
             <Chinesesimp>脉搏血氧仪：脉搏：%1 SpO2：%2</Chinesesimp>
-            <Turkish>Nabız Oksimetresi: PR: %1 SpO2: %2</Turkish>
+            <Turkish>Nabız Oximetresi: PR: %1 SpO₂: %2</Turkish>
             <Finnish>Pulssioksimetri PR:%1 SpO2: %2</Finnish>
             <Dutch>Pulsoximeter: PR: %1 SpO2:%2</Dutch>
         </Key>
@@ -3351,7 +3527,7 @@
             <Japanese>デフォルトは無効です。有効にすると、緊張性気胸または血気胸のあるユニットでも、医療メニューに発生した他の気胸が表示されます。</Japanese>
             <Chinese>默認值處於禁用狀態。如果啟用，張力性氣胸或血氣胸的單位也會在醫療選單中顯示氣胸損傷</Chinese>
             <Chinesesimp>默认值处于禁用状态。如果启用，张力性气胸或血气胸的单位也会在医疗菜单中显示气胸损伤</Chinesesimp>
-            <Turkish>Varsayılan devre dışıdır. Etkinleştirilirse, tansiyon pnömotorakslı veya hemopnömotorakslı ünitelerde medikal menüde pnömotoraks yaralanması da görüntülenir.</Turkish>
+            <Turkish>Varsayılan olarak devre dışıdır. Etkinleştirilirse, gergin pnömotoraks veya hemopnömotoraksı olan birimlerde tıbbi menüde pnömotoraks yaralanması da gösterilir.</Turkish>
             <Finnish>Oletuksena poissa käytöstä. Jos tämä on käytössä, potilaiden, joilla on jännittynyt pneumotoraksi tai hemopneumotoraksi, myös ilmarintavammat näkyvät lääkärinnäytössä.</Finnish>
             <Dutch>Standaard staat deze optie uit. Wanneer dit aanstaat zal een spanningspneumothorax of een hemopneumothorax ook een pneumothorax tonen in het medische menu.</Dutch>
         </Key>
@@ -3371,6 +3547,7 @@
             <Chinesesimp>胸腔穿刺减压（NCD套件）</Chinesesimp>
             <Finnish>Neulan dekompressio (NCD Kit)</Finnish>
             <Dutch>Naalddecompressie kit (ND kit)</Dutch>
+            <Turkish>İğne Dekompresyonu (NCD Kit)</Turkish>
         </Key>
         <Key ID="STR_KAT_Breathing_tensionpneumothorax_display">
             <English>Needle Decompression</English>
@@ -3404,7 +3581,7 @@
             <Japanese>1x 緊張性気胸</Japanese>
             <Chinese>1x 張力性氣胸</Chinese>
             <Chinesesimp>1x 张力性气胸</Chinesesimp>
-            <Turkish>1x Gerilim Pnömotoraks'ı</Turkish>
+            <Turkish>1x Gergin Pnömotoraks</Turkish>
             <Finnish>1x jännitysilmarinta</Finnish>
             <Dutch>1x Spanningspneumothorax</Dutch>
         </Key>

--- a/addons/chemical/stringtable.xml
+++ b/addons/chemical/stringtable.xml
@@ -17,6 +17,7 @@
             <Chinesesimp>82毫米CS燃气轮</Chinesesimp>
             <Finnish>82mm CS-kaasulaastikuori</Finnish>
             <Dutch>82mm CS-Gasgranaat</Dutch>
+            <Turkish>82mm CS Gaz Mermisi</Turkish>
         </Key>
         <Key ID="STR_KAT_Chemical_CSGas_MFDNAME">
             <English>CS-Gas</English>
@@ -34,6 +35,7 @@
             <Chinesesimp>CS毒气</Chinesesimp>
             <Finnish>CS-kaasu</Finnish>
             <Dutch>CS-Gas</Dutch>
+            <Turkish>CS Gazı</Turkish>
         </Key>
         <Key ID="STR_KAT_Chemical_ChangeGasMaskFilter">
             <English>Replace gas mask filter</English>
@@ -51,6 +53,7 @@
             <Chinesesimp>更换防毒面具过滤器</Chinesesimp>
             <Finnish>Vaihda kaasunaamarin suodatin</Finnish>
             <Dutch>Vervang het filter van de gasmasker</Dutch>
+            <Turkish>Gaz maskesi filtresini değiştir</Turkish>
         </Key>
         <Key ID="STR_KAT_Chemical_CheckGasMaskDurability">
             <English>Check gas mask durability</English>
@@ -68,6 +71,7 @@
             <Chinesesimp>检查防毒面具的耐用性</Chinesesimp>
             <Finnish>Tarkista kaasunaamarin kestävyys</Finnish>
             <Dutch>Check levensduur Gasmasker</Dutch>
+            <Turkish>Gaz maskesi dayanıklılığını kontrol et</Turkish>
         </Key>
         <Key ID="STR_KAT_Chemical_ChemicalDetectorDescription">
             <English>Used to detect KAT toxic chemicals</English>
@@ -80,6 +84,7 @@
             <Chinese>用於偵測 KAT 有毒化學物質</Chinese>
             <Chinesesimp>用于检测KAT有毒化学物质</Chinesesimp>
             <Dutch>Wordt gebruikt om giftige KAT chemicaliën te detecteren</Dutch>
+            <Turkish>KAT toksik kimyasallarını tespit etmek için kullanılır</Turkish>
         </Key>
         <Key ID="STR_KAT_Chemical_ChemicalDetectorDisplayName">
             <English>JCAD Chemical Detector</English>
@@ -92,6 +97,7 @@
             <Chinese>JCAD 化學偵測器</Chinese>
             <Chinesesimp>JCAD化学检测仪</Chinesesimp>
             <Dutch>JCAD Chemische detector</Dutch>
+            <Turkish>KAT toksik kimyasallarını tespit etmek için kullanılır</Turkish>
         </Key>
         <Key ID="STR_KAT_Chemical_ChemicalDetector_Menu">
             <English>JCAD</English>
@@ -104,6 +110,7 @@
             <Chinese>JCAD</Chinese>
             <Chinesesimp>JCAD</Chinesesimp>
             <Dutch>JCAD</Dutch>
+            <Turkish>JCAD</Turkish>
         </Key>
         <Key ID="STR_KAT_Chemical_ChemicalDetector_Off">
             <English>OFF</English>
@@ -116,6 +123,7 @@
             <Chinese>關閉</Chinese>
             <Chinesesimp>关闭</Chinesesimp>
             <Dutch>UIT</Dutch>
+            <Turkish>KAPALI</Turkish>
         </Key>
         <Key ID="STR_KAT_Chemical_DisableDetectorSound">
             <English>Disable Warning Tone</English>
@@ -128,6 +136,7 @@
             <Chinese>停用警告音</Chinese>
             <Chinesesimp>禁用警告音</Chinesesimp>
             <Dutch>Waarschuwingstoon uitschakelen</Dutch>
+            <Turkish>Uyarı sesini kapat</Turkish>
         </Key>
         <Key ID="STR_KAT_Chemical_EnableDetector">
             <English>Turn On Detector</English>
@@ -140,6 +149,7 @@
             <Chinese>打開探測器</Chinese>
             <Chinesesimp>打开探测器</Chinesesimp>
             <Dutch>Detector aanzetten</Dutch>
+            <Turkish>Dedektörü aç</Turkish>
         </Key>
         <Key ID="STR_KAT_Chemical_EnableDetectorSound">
             <English>Enable Warning Tone</English>
@@ -152,6 +162,7 @@
             <Chinese>啟用警告音</Chinese>
             <Chinesesimp>启用警告音</Chinesesimp>
             <Dutch>Waarschuwingstoon inschakelen</Dutch>
+            <Turkish>Uyarı sesini aç</Turkish>
         </Key>
         <Key ID="STR_KAT_Chemical_GasBox_Displayname">
             <English>[ACE] 82mm Gas Rounds Box</English>
@@ -169,6 +180,7 @@
             <Chinesesimp>[ACE]82毫米燃气轮箱</Chinesesimp>
             <Finnish>[ACE] 82mm kaasulaastin kuorilaatikko</Finnish>
             <Dutch>[ACE] 82mm Gasgranatenkist</Dutch>
+            <Turkish>[ACE] 82mm Gaz Mermi Kutusu</Turkish>
         </Key>
         <Key ID="STR_KAT_Chemical_GasFilterItem">
             <English>Gas mask filter</English>
@@ -186,6 +198,7 @@
             <Chinesesimp>防毒面具过滤器</Chinesesimp>
             <Finnish>Kaasunaamariin suodatin</Finnish>
             <Dutch>Gasmasker filter</Dutch>
+            <Turkish>Gaz maskesi filtresi</Turkish>
         </Key>
         <Key ID="STR_KAT_Chemical_GasFilterItem_desc">
             <English>Replacement filter for gas mask</English>
@@ -203,6 +216,7 @@
             <Chinesesimp>更换防毒面具过滤器</Chinesesimp>
             <Finnish>Vaihtosuodatin kaasunaamariin</Finnish>
             <Dutch>Vervangend filter voor gasmaskers</Dutch>
+            <Turkish>Gaz maskesi için yedek filtre</Turkish>
         </Key>
         <Key ID="STR_KAT_Chemical_GasModule_Displayname">
             <English>Create contaminated area / object</English>
@@ -220,6 +234,7 @@
             <Chinesesimp>创建污染区域/物体</Chinesesimp>
             <Finnish>Saastuta alue/esine</Finnish>
             <Dutch>Creëer gecontamineerd gebied / object</Dutch>
+            <Turkish>Gaz maskesi için yedek filtre</Turkish>
         </Key>
         <Key ID="STR_KAT_Chemical_GasModule_SealLeak">
             <English>Seal leak</English>
@@ -237,6 +252,7 @@
             <Chinesesimp>密封泄漏</Chinesesimp>
             <Finnish>Tuki vuoto</Finnish>
             <Dutch>Dicht lek</Dutch>
+            <Turkish>Sızıntıyı kapat</Turkish>
         </Key>
         <Key ID="STR_KAT_Chemical_GasModule_createContaminatedObject">
             <English>You are about to create a contaminated Object.</English>
@@ -254,6 +270,7 @@
             <Chinesesimp>您将创建一个受污染的对象。</Chinesesimp>
             <Finnish>Olet saastuttamassa esineen.</Finnish>
             <Dutch>Je staat op het punt een gecontamineerd object te creëeren.</Dutch>
+            <Turkish>Kontamine bir nesne oluşturmak üzeresiniz.</Turkish>
         </Key>
         <Key ID="STR_KAT_Chemical_GasModule_createContaminatedZone">
             <English>You are about to create a contaminated Zone.</English>
@@ -271,6 +288,7 @@
             <Chinesesimp>您将创建一个污染区。</Chinesesimp>
             <Finnish>Olet saastuttamassa alueen.</Finnish>
             <Dutch>Je staat op het punt om een gecontamineerd gebied te creëeren.</Dutch>
+            <Turkish>Kontamine bir bölge oluşturmak üzeresiniz.</Turkish>
         </Key>
         <Key ID="STR_KAT_Chemical_GasModule_description">
             <English>Radius around the module which is filled with gas.</English>
@@ -288,6 +306,7 @@
             <Chinesesimp>充满毒气的模块周围的半径。</Chinesesimp>
             <Finnish>Kaasulla täytetyn alueen ympärillä oleva säde</Finnish>
             <Dutch>Radius om de module dat gevuld is met gas.</Dutch>
+            <Turkish>Modül etrafındaki gazla dolu yarıçap.</Turkish>
         </Key>
         <Key ID="STR_KAT_Chemical_GasModule_max_radius_dcs">
             <English>The Maximum Range is a range around the Minimal Range where the gas is less lethal and you have a longer chance of survival.(distance from module to outer ring)</English>
@@ -305,6 +324,7 @@
             <Chinesesimp>最大射程是最小射程附近的一个范围，在这个范围内，毒气的致命性较低，你有更长的生存机会。（模块到外环的距离）</Chinesesimp>
             <Finnish>Maksimietäisyys on vähimmäisalue, jossa kaasu on vähemmän tappava ja sinulla on pidempi mahdollisuus selviytyä. (etäisyys moduulista ulkorenkaaseen)</Finnish>
             <Dutch>Het maximaal bereik is het bereik om het minimale bereik waar het gas minder dodelijk is, en je een langere overlevings hebt. (afstand van module tot buitenste ring)</Dutch>
+            <Turkish>Maksimum Menzil, minimum menzilin dışındaki, gazın daha az ölümcül olduğu ve hayatta kalma şansının daha yüksek olduğu alandır. (modülden dış halkaya olan mesafe)</Turkish>
         </Key>
         <Key ID="STR_KAT_Chemical_GasModule_placeModuleOnObject">
             <English>To create a contaminated object place the module on a empty object.</English>
@@ -322,6 +342,7 @@
             <Chinesesimp>要创建受污染的对象，请将模块放置在空对象上。</Chinesesimp>
             <Finnish>Luodaksesi saastuneen objektin aseta moduuli tyhjälle objektille.</Finnish>
             <Dutch>Om een gecontamineerd object te creëeren, moet je de module op een leeg object plaatsen.</Dutch>
+            <Turkish>Kontamine bir nesne oluşturmak için modülü boş bir nesnenin üzerine yerleştirin.</Turkish>
         </Key>
         <Key ID="STR_KAT_Chemical_HydraGas_DisplayName">
             <English>Hydra GAS 19x</English>
@@ -339,6 +360,7 @@
             <Chinesesimp>九头蛇毒气 19x</Chinesesimp>
             <Finnish>Hydra KAASU 19x</Finnish>
             <Dutch>Hydra GAS 19x</Dutch>
+            <Turkish>Hydra GAS 19x</Turkish>
         </Key>
         <Key ID="STR_KAT_Chemical_HydraGas_ShortName">
             <English>70mm GAS</English>
@@ -356,6 +378,7 @@
             <Chinesesimp>70mm毒气</Chinesesimp>
             <Finnish>70mm KAASU</Finnish>
             <Dutch>70mm GAS</Dutch>
+            <Turkish>70mm Gaz</Turkish>
         </Key>
         <Key ID="STR_KAT_Chemical_HydraGas_desc">
             <English>Unguided rockets with Toxic-gas warhead.</English>
@@ -373,6 +396,7 @@
             <Chinesesimp>装有有毒气体弹头的非制导火箭。</Chinesesimp>
             <Finnish>Ohjaamattomat raketit, joissa on myrkyllinen kaasukärje</Finnish>
             <Dutch>Ongestuurde rakketen met een gifgas kop.</Dutch>
+            <Turkish>Toksik gaz başlıklı güdümsüz roketler.</Turkish>
         </Key>
         <Key ID="STR_KAT_Chemical_Intoxication">
             <English>Intoxication</English>
@@ -390,6 +414,7 @@
             <Chinesesimp>中毒</Chinesesimp>
             <Finnish>Päihtymys</Finnish>
             <Dutch>Intoxicatie</Dutch>
+            <Turkish>Zehirlenme</Turkish>
         </Key>
         <Key ID="STR_KAT_Chemical_Lvl0_Gas">
             <English>Tear gas (Level 0)</English>
@@ -400,6 +425,7 @@
             <German>Tränengas (Level 0)</German>
             <Japanese>催涙ガス (レベル 0)</Japanese>
             <Dutch>Traangas (level 0)</Dutch>
+            <Turkish>Göz yaşartıcı gaz (Seviye 0)</Turkish>
         </Key>
         <Key ID="STR_KAT_Chemical_Lvl1_Gas">
             <English>Toxic gas (Level 1)</English>
@@ -417,6 +443,7 @@
             <Chinesesimp>有毒气体（1级）</Chinesesimp>
             <Finnish>Myrkyllinen kaasu (taso 1)</Finnish>
             <Dutch>Gifgas (Level 1)</Dutch>
+            <Turkish>Toksik Gaz (Seviye 1)</Turkish>
         </Key>
         <Key ID="STR_KAT_Chemical_M43_DisplayName_1x">
             <English>M43 BZ LGB</English>
@@ -434,6 +461,7 @@
             <Chinesesimp>M43 BZ LGB</Chinesesimp>
             <Finnish>M43 BZ LGB</Finnish>
             <Dutch>M43 BZ LGB</Dutch>
+            <Turkish>M43 BZ LGB</Turkish>
         </Key>
         <Key ID="STR_KAT_Chemical_M43_DisplayName_2x">
             <English>2x M43 BZ LGB</English>
@@ -451,6 +479,7 @@
             <Chinesesimp>2x M43 BZ轻型卡车</Chinesesimp>
             <Finnish>2x M43 BZ LGB</Finnish>
             <Dutch>2x M43 BZ LGB</Dutch>
+            <Turkish>2x M43 BZ LGB</Turkish>
         </Key>
         <Key ID="STR_KAT_Chemical_M43_ShortName_1x">
             <English>M43 BZ LGB</English>
@@ -468,6 +497,7 @@
             <Chinesesimp>M43 BZ LGB</Chinesesimp>
             <Finnish>M43 BZ LGB</Finnish>
             <Dutch>M43 BZ LGB</Dutch>
+            <Turkish>M43 BZ LGB</Turkish>
         </Key>
         <Key ID="STR_KAT_Chemical_M43_ShortName_2x">
             <English>2x M43 BZ LGB</English>
@@ -485,6 +515,7 @@
             <Chinesesimp>2x M43 BZ轻型卡车</Chinesesimp>
             <Finnish>2x M43 BZ LGB</Finnish>
             <Dutch>2x M43 BZ LGB</Dutch>
+            <Turkish>2x M43 BZ LGB</Turkish>
         </Key>
         <Key ID="STR_KAT_Chemical_M43_desc">
             <English>Laser Guided Cluster Bomb with a chemical gas payload.</English>
@@ -502,6 +533,7 @@
             <Chinesesimp>带有化学毒气有效载荷的激光制导集束炸弹。</Chinesesimp>
             <Finnish>Laserohjattu rypälepommi kemiallisen kaasun hyötykuormalla</Finnish>
             <Dutch>Laser gestuurde clusterbom met een chemisch gas als lading.</Dutch>
+            <Turkish>Kimyasal gaz yüklü lazer güdümlü misket bombası.</Turkish>
         </Key>
         <Key ID="STR_KAT_Chemical_M7A3_CSGrenade_DisplayName">
             <English>M7A3 Riot CS gas grenade</English>
@@ -519,6 +551,7 @@
             <Chinesesimp>M7A3防暴CS瓦斯手榴弹</Chinesesimp>
             <Finnish>M7A3 CS kaasukranaatti</Finnish>
             <Dutch>M7A3 CS Traangasgranaat</Dutch>
+            <Turkish>M7A3 CS İsyan Kontrol Gaz Bombası</Turkish>
         </Key>
         <Key ID="STR_KAT_Chemical_M7A3_CSGrenade_ShortName">
             <English>M7A3</English>
@@ -536,6 +569,7 @@
             <Chinesesimp>M7A3</Chinesesimp>
             <Finnish>M7A3</Finnish>
             <Dutch>M7A3</Dutch>
+            <Turkish>M7A3</Turkish>
         </Key>
         <Key ID="STR_KAT_Chemical_M7A3_DcsShort">
             <English>The M7A3 CS gas grenade is a non-lethal tear gas grenade that causes severe burning of the mucous membranes and eyes on contact.</English>
@@ -553,6 +587,7 @@
             <Chinesesimp>M7A3 CS毒气手榴弹是一种非致命性催泪瓦斯手榴弹，接触后会严重灼伤粘膜和眼睛。</Chinesesimp>
             <Finnish>M7A3 CS -kaasukranaatti on ei-tappava kyynelkaasukranaatti, joka koskettaa limakalvoja ja silmiä vakavasti.</Finnish>
             <Dutch>The M7A3 CS gasgranaat is een niet-dodelijke traangasgranaat dat op contact een ernstig brandend gevoel in het slijmvlies en de ogen creëerd.</Dutch>
+            <Turkish>M7A3 CS gaz bombası, temas halinde mukozalarda ve gözlerde şiddetli yanmaya neden olan, öldürücü olmayan bir göz yaşartıcı gaz bombasıdır.</Turkish>
         </Key>
         <Key ID="STR_KAT_Chemical_PutOnGasMask">
             <English>Put on gas mask</English>
@@ -565,6 +600,7 @@
             <Chinese>戴上防毒面具</Chinese>
             <Chinesesimp>戴上防毒面具</Chinesesimp>
             <Dutch>Zet gasmasker op</Dutch>
+            <Turkish>Gaz maskesini tak</Turkish>
         </Key>
         <Key ID="STR_KAT_Chemical_SETTING_AVAIL_GASMASK">
             <English>Accepted gas masks</English>
@@ -582,6 +618,7 @@
             <Chinesesimp>被接受的防毒面具</Chinesesimp>
             <Finnish>Hyväksytyt kaasunaamarit</Finnish>
             <Dutch>Geaccepteerde gasmaskers</Dutch>
+            <Turkish>Kabul edilen gaz maskeleri</Turkish>
         </Key>
         <Key ID="STR_KAT_Chemical_SETTING_AVAIL_GASMASK_DISC">
             <English>Enter here the classname of the masks that should work with the system.</English>
@@ -599,6 +636,7 @@
             <Chinesesimp>在此处输入应与系统配合使用的掩码的类名。</Chinesesimp>
             <Finnish>Anna niiden maskien luokan nimet, joiden pitäisi toimia järjestelmän kanssa</Finnish>
             <Dutch>Voer hier de classnames toe van gasmaskers die zouden moeten werken met het systeem.</Dutch>
+            <Turkish>Sistemle çalışması gereken maskelerin sınıf adlarını buraya girin.</Turkish>
         </Key>
         <Key ID="STR_KAT_Chemical_SETTING_GASMASK_DURABILITY">
             <English>Gas masks durability</English>
@@ -616,6 +654,7 @@
             <Chinesesimp>防毒面具耐用性</Chinesesimp>
             <Finnish>Kaasunaamarien kestävyys</Finnish>
             <Dutch>Levensduur van gasmaskers</Dutch>
+            <Turkish>Gaz maskesi dayanıklılığı</Turkish>
         </Key>
         <Key ID="STR_KAT_Chemical_SETTING_GASMASK_DURABILITY_DISC">
             <English>Determines how long you can stand in the gas with a gas mask without getting infected.</English>
@@ -633,6 +672,7 @@
             <Chinesesimp>确定戴防毒面具在毒气中站立多长时间而不会感染。</Chinesesimp>
             <Finnish>Määrittää, kuinka kauan voit seistä kaasussa kaasunaamarin kanssa vaikuttamatta siihen</Finnish>
             <Dutch>Bepaald hoelang je in gas kan staan zonder dat je geïnfecteerd raakt.</Dutch>
+            <Turkish>Gaz maskesi takılıyken enfekte olmadan gaz içinde ne kadar süre dayanabileceğinizi belirler.</Turkish>
         </Key>
         <Key ID="STR_KAT_Chemical_SETTING_dropWeaponChance">
             <English>Drop Weapon Chance</English>
@@ -645,6 +685,7 @@
             <Chinese>丟下武器機會</Chinese>
             <Chinesesimp>投掷武器机会</Chinesesimp>
             <Dutch>Kans om wapen te laten vallen</Dutch>
+            <Turkish>Silah düşürme ihtimali</Turkish>
         </Key>
         <Key ID="STR_KAT_Chemical_SETTING_dropWeaponChance_DESC">
             <English>Determines chance for dropping weapon while in tear gas</English>
@@ -657,6 +698,7 @@
             <Chinese>確定在催淚瓦斯中丟下武器的機率</Chinese>
             <Chinesesimp>确定在催泪瓦斯中投掷武器的几率</Chinesesimp>
             <Dutch>Bepaald de kans om je wapen te laten vallen terwijl je wordt blootgesteld aan traangas</Dutch>
+            <Turkish>Göz yaşartıcı gaz içindeyken silah düşürme olasılığını belirler</Turkish>
         </Key>
         <Key ID="STR_KAT_Chemical_SETTING_gasMaskSoundVolume">
             <English>Gas Mask Sound Volume</English>
@@ -669,6 +711,7 @@
             <Chinese>防毒面具音量</Chinese>
             <Chinesesimp>防毒面具音量</Chinesesimp>
             <Dutch>Volume van gasmasker</Dutch>
+            <Turkish>Gaz maskesi ses seviyesi</Turkish>
         </Key>
         <Key ID="STR_KAT_Chemical_SETTING_gasMaskSoundVolume_DESC">
             <English>Determines how loud the breathing sounds are when using the gas mask</English>
@@ -681,6 +724,7 @@
             <Chinese>確定使用防毒面具時呼吸聲的音量</Chinese>
             <Chinesesimp>确定使用防毒面具时呼吸声的音量</Chinesesimp>
             <Dutch>Bepaald hoe luid de ademhalingsgeluiden zijn terwijl er een gasmasker gebruikt wordt</Dutch>
+            <Turkish>Gaz maskesi kullanırken nefes seslerinin ne kadar yüksek olacağını belirler</Turkish>
         </Key>
         <Key ID="STR_KAT_Chemical_SETTING_gasMaskStaminaLoss">
             <English>Enable Stamina Loss when using Gas Mask</English>
@@ -692,6 +736,7 @@
             <Japanese>ガスマスク使用時のスタミナ減少を有効化</Japanese>
             <Chinese>啟用使用防毒面具時的體力流失</Chinese>
             <Dutch>Uithoudingsvermogenverlies bij gebruik van een gasmasker inschakelen</Dutch>
+            <Turkish>Gaz maskesi kullanırken dayanıklılık kaybını etkinleştir</Turkish>
         </Key>
         <Key ID="STR_KAT_Chemical_SETTING_gasMaskStaminaLoss_DESC">
             <English>If you wear a gasmask you will lose stamina more quickly</English>
@@ -699,6 +744,7 @@
             <Spanish>Si llevas máscara antigás perderás resistencia más rápidamente</Spanish>
             <German>Wenn man eine Gasmaske trägt, verliert man mehr Ausdauer</German>
             <Japanese>ガスマスクを着用するとスタミナがより早く失われます</Japanese>
+            <Turkish>Gaz maskesi kullanırken dayanıklılık kaybını etkinleştir</Turkish>
         </Key>
         <Key ID="STR_KAT_Chemical_SETTING_infectionTime">
             <English>Time until infection</English>
@@ -716,6 +762,7 @@
             <Chinesesimp>感染前的时间</Chinesesimp>
             <Finnish>Aikaa tartunnan saamiseen</Finnish>
             <Dutch>Tijd tot infectie</Dutch>
+            <Turkish>Enfeksiyona kadar geçen süre</Turkish>
         </Key>
         <Key ID="STR_KAT_Chemical_SETTING_infectionTime_DESC">
             <English>Time you can stand in the gas before you get infected or need a gas mask.</English>
@@ -733,6 +780,7 @@
             <Chinesesimp>在感染或需要防毒面具之前，你可以站在毒气中。</Chinesesimp>
             <Finnish>Aika, jonka voit seistä kaasussa, ennen kuin sinulla on vaikutusta tai tarvitset kaasunaamaria</Finnish>
             <Dutch>Tijd dat je in gas kan staan voordat je geïnfecteerd raakt of een gasmasker nodig hebt</Dutch>
+            <Turkish>Enfekte olmadan veya gaz maskesine ihtiyaç duymadan önce gaz içinde kalabileceğiniz süre</Turkish>
         </Key>
         <Key ID="STR_KAT_Chemical_SETTING_showPoisoning">
             <English>Show Poisoning</English>
@@ -745,6 +793,7 @@
             <Chinese>顯示中毒</Chinese>
             <Chinesesimp>显示中毒</Chinesesimp>
             <Dutch>Intoxicaties tonen</Dutch>
+            <Turkish>Zehirlenmeyi göster</Turkish>
         </Key>
         <Key ID="STR_KAT_Chemical_SETTING_showPoisoning_DESC">
             <English>Determines if poisoning and intoxication is shown in the medical menu</English>
@@ -757,6 +806,7 @@
             <Chinese>確定醫療選單中是否顯示中毒</Chinese>
             <Chinesesimp>确定医疗菜单中是否显示中毒</Chinesesimp>
             <Dutch>Bepaald of intoxicaties zichtbaar zijn in het medische menu</Dutch>
+            <Turkish>Zehirlenme durumunun medikal menüde gösterilip gösterilmeyeceğini belirler</Turkish>
         </Key>
         <Key ID="STR_KAT_Chemical_TakeOffGasMask">
             <English>Take off gas mask</English>
@@ -769,6 +819,7 @@
             <Chinese>摘下防毒面具</Chinese>
             <Chinesesimp>摘下防毒面具</Chinesesimp>
             <Dutch>Gasmasker afzetten</Dutch>
+            <Turkish>Gaz maskesini çıkar</Turkish>
         </Key>
         <Key ID="STR_KAT_Chemical_ToxicGas_DisplayName">
             <English>82mm Toxic Gas Round</English>
@@ -786,6 +837,7 @@
             <Chinesesimp>82mm圆形有毒气体</Chinesesimp>
             <Finnish>82 mm myrkyllinen kaasulaastikuori</Finnish>
             <Dutch>82mm Gifgasgranaat</Dutch>
+            <Turkish>82mm Toksik Gaz Mermisi</Turkish>
         </Key>
         <Key ID="STR_KAT_Chemical_ToxicGas_MFDNAME">
             <English>Toxic gas</English>
@@ -803,6 +855,7 @@
             <Chinesesimp>有毒气体</Chinesesimp>
             <Finnish>Myrkyllinen kaasu</Finnish>
             <Dutch>Gifgas</Dutch>
+            <Turkish>Toksik gaz</Turkish>
         </Key>
         <Key ID="STR_KAT_Chemical_TriWire_Gas_Desc">
             <English>Type: Tripwire gas - Sprays a poisonous gas when triggered.&lt;br /&gt;Rounds: 1&lt;br /&gt;Used on: Ground</English>
@@ -820,6 +873,7 @@
             <Chinesesimp>类型：三线制气体-触发时喷出有毒气体&lt;br/&gt;轮次：1&lt;br/&gt;用于：地面</Chinesesimp>
             <Finnish>Tyyppi: kaasu-käsikranaatin laukaisulanka - suihkuttaa myrkyllistä kaasua laukaisussa &lt;br/&gt;Laukut: 1 &lt;br/&gt;Käytetty: maassa</Finnish>
             <Dutch>Type: Gas struikeldraad - Sproeit een giftig gas wanneer geactiveerd.&lt;br/&gt;Ladingen: 1&lt;br/&gt;Gebruik op: De grond</Dutch>
+            <Turkish>Tür: Tetik telli gaz – Tetiklendiğinde zehirli gaz yayar.&lt;br /&gt;Mermi: 1&lt;br /&gt;Kullanım: Zemin</Turkish>
         </Key>
         <Key ID="STR_KAT_Chemical_TriWire_Gas_Name">
             <English>Tripwire Gas</English>
@@ -837,6 +891,7 @@
             <Chinesesimp>Tripwire毒气</Chinesesimp>
             <Finnish>Kaasun ja kranaatin laukaisulanka</Finnish>
             <Dutch>Gas struikeldraad</Dutch>
+            <Turkish>Tetik Telli Gaz</Turkish>
         </Key>
         <Key ID="STR_KAT_Chemical_UI_gasType">
             <English>Gas Type:</English>
@@ -854,6 +909,7 @@
             <Chinesesimp>毒气类型：</Chinesesimp>
             <Finnish>Kaasutyyppi</Finnish>
             <Dutch>Gas type:</Dutch>
+            <Turkish>Gaz Türü:</Turkish>
         </Key>
         <Key ID="STR_KAT_Chemical_UI_max_range">
             <English>Maximum Range.</English>
@@ -871,6 +927,7 @@
             <Chinesesimp>最大范围。</Chinesesimp>
             <Finnish>Suurin kantama</Finnish>
             <Dutch>Maximaal bereik.</Dutch>
+            <Turkish>Maksimum Menzil.</Turkish>
         </Key>
         <Key ID="STR_KAT_Chemical_UI_sealable">
             <English>Is sealable?</English>
@@ -888,6 +945,7 @@
             <Chinesesimp>可密封吗？</Chinesesimp>
             <Finnish>Onko se suljettavissa?</Finnish>
             <Dutch>Is dichtbaar?</Dutch>
+            <Turkish>Sızdırmaz mı?</Turkish>
         </Key>
         <Key ID="STR_KAT_Chemical_UI_sealable_tooltip">
             <English>ONLY WORKS IF LOGIC IS SYNCED WITH AN OBJECT!</English>
@@ -905,6 +963,7 @@
             <Chinesesimp>只有当逻辑与对象同步时才有效！</Chinesesimp>
             <Finnish>TOIMII VAIN JOS LOGIIKKA SYNKRONOIDAAN OBJEKTIN KANSSA!</Finnish>
             <Dutch>WERKT ALLEEN ALS LOGICA GESYNCHRONISEERD IS MET EEN OBJECT!</Dutch>
+            <Turkish>Sızdırmaz mı?</Turkish>
         </Key>
         <Key ID="STR_KAT_Chemical_UI_selectGas">
             <English>Select Gas:</English>
@@ -922,6 +981,7 @@
             <Chinesesimp>选择毒气：</Chinesesimp>
             <Finnish>Valitse Kaasu</Finnish>
             <Dutch>Selecteer gas:</Dutch>
+            <Turkish>Gaz seç:</Turkish>
         </Key>
         <Key ID="STR_KAT_Chemical_cba_name">
             <English>KAT - ADV Medical: Chemical</English>
@@ -931,6 +991,7 @@
             <German>KAT - ADV Medical: Chemie</German>
             <Japanese>KAM - 化学戦 (Chemical)</Japanese>
             <Dutch>KAT - ADV Medical: Chemisch</Dutch>
+            <Turkish>KAT – Gelişmiş Tıp: Kimyasal</Turkish>
         </Key>
         <Key ID="STR_KAT_Chemical_giveGasMask_action">
             <English>Put on gas mask</English>
@@ -948,6 +1009,7 @@
             <Chinesesimp>戴上防毒面具</Chinesesimp>
             <Finnish>Laita kaasunaamari päälle</Finnish>
             <Dutch>Doe gasmasker op</Dutch>
+            <Turkish>Gaz maskesini tak</Turkish>
         </Key>
         <Key ID="STR_KAT_Chemical_giveGasMask_progress">
             <English>Put on gas mask...</English>
@@ -965,6 +1027,7 @@
             <Chinesesimp>戴上防毒面具…</Chinesesimp>
             <Finnish>Kaasunaamari on laitettu päähän</Finnish>
             <Dutch>Gasmasker wordt opgezet...</Dutch>
+            <Turkish>Gaz maskesi takılıyor...</Turkish>
         </Key>
         <Key ID="STR_KAT_Chemical_sealLeak">
             <English>Seal leak</English>
@@ -982,6 +1045,7 @@
             <Chinesesimp>密封泄漏</Chinesesimp>
             <Finnish>Tiivisteen vuoto</Finnish>
             <Dutch>Dicht lek</Dutch>
+            <Turkish>Gaz maskesini tak</Turkish>
         </Key>
         <Key ID="STR_KAT_Chemical_sealantItem">
             <English>Sealant tube</English>
@@ -999,6 +1063,7 @@
             <Chinesesimp>密封胶管</Chinesesimp>
             <Finnish>Tiivisteputki</Finnish>
             <Dutch>Afdichtmiddel buis</Dutch>
+            <Turkish>Sızdırmazlık tüpü</Turkish>
         </Key>
         <Key ID="STR_KAT_Chemical_sealantItem_desc">
             <English>Sealant which is used to seal objects when e.g. a toxic substance leaks out</English>
@@ -1016,6 +1081,7 @@
             <Chinesesimp>密封剂，用于在有毒物质泄漏时密封物体</Chinesesimp>
             <Finnish>Tiiviste, jota käytetään esineiden tiivistämiseen, kun myrkyllistä ainetta vuotaa ulos</Finnish>
             <Dutch>Afdichtmiddel dat gebruikt wordt om een object te dichten wanneer er bijvoorbeeld een giftige stof lekt</Dutch>
+            <Turkish>Örneğin toksik bir madde sızdığında nesneleri kapatmak için kullanılan sızdırmazlık maddesi</Turkish>
         </Key>
     </Package>
 </Project>

--- a/addons/circulation/stringtable.xml
+++ b/addons/circulation/stringtable.xml
@@ -15,6 +15,7 @@
             <Chinesesimp>AED</Chinesesimp>
             <Finnish>AUD</Finnish>
             <Dutch>AED</Dutch>
+            <Turkish>AED</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_AEDStation_Action_PlacePads">
             <English>Station: Place AED Pads</English>
@@ -31,6 +32,7 @@
             <Chinesesimp>固定式 AED：放置 AED 电极片</Chinesesimp>
             <Finnish>Asema: aseta AUD-tyynyt</Finnish>
             <Dutch>Station: Plaats AED pads</Dutch>
+            <Turkish>İstasyon: AED Pedlerini Yerleştir</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_AEDVehicle_Action_PlacePads">
             <English>Vehicle: Place AED Pads</English>
@@ -47,6 +49,7 @@
             <Chinesesimp>车辆：放置AED垫</Chinesesimp>
             <Finnish>Ajoneuvo: aseta AUD-tyynyt</Finnish>
             <Dutch>Voertuig: Plaats AED pads</Dutch>
+            <Turkish>Araç: AED Pedlerini Yerleştir</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_AEDXStation_Action_ConnectMonitor">
             <English>Station: Connect Vitals Monitor</English>
@@ -63,6 +66,7 @@
             <Chinesesimp>设置AED：连接生命监护仪</Chinesesimp>
             <Finnish>Asema: Liitä kuntomonitori</Finnish>
             <Dutch>Station: Verbind de vitale waarden monitor</Dutch>
+            <Turkish>İstasyon: Vitals Monitor’ü Bağla</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_AEDXStation_Action_PlacePads">
             <English>Station: Place AED-X Pads</English>
@@ -79,6 +83,7 @@
             <Chinesesimp>固定式 AED-X：放置 AED-X 电极片</Chinesesimp>
             <Finnish>Asema: aseta AUD-X-tyynyt</Finnish>
             <Dutch>Station: Plaats AED-X pads</Dutch>
+            <Turkish>İstasyon: AED-X Pedlerini Yerleştir</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_AEDXVehicle_Action_ConnectMonitor">
             <English>Vehicle: Connect Vitals Monitor</English>
@@ -94,7 +99,7 @@
             <Japanese>車載AED: バイタルモニターの接続</Japanese>
             <Chinese>車載：連接生命監測器</Chinese>
             <Chinesesimp>载具: 生命监护仪</Chinesesimp>
-            <Turkish>Araç: AED-X'i takın</Turkish>
+            <Turkish>Araç: Vitals Monitor’ü Bağla</Turkish>
             <Finnish>Ajoneuvo: Liitä kuntomonitori</Finnish>
             <Dutch>Voertuig: Verbind de vitale waarden monitor</Dutch>
         </Key>
@@ -113,6 +118,7 @@
             <Chinesesimp>车辆：放置AED-X垫</Chinesesimp>
             <Finnish>Ajonuevo: aseta AUD-X-tyynyt</Finnish>
             <Dutch>Voertuig: Plaats AED-X pads</Dutch>
+            <Turkish>Araç: AED-X Pedlerini Yerleştir</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_AEDX_Action_ConnectMonitor">
             <English>Connect Vitals Monitor</English>
@@ -129,6 +135,7 @@
             <Chinesesimp>连接监控</Chinesesimp>
             <Finnish>Liitä terveysmonitori</Finnish>
             <Dutch>Verbind de vitale waarden monitor</Dutch>
+            <Turkish>Vitals Monitor’ü Bağla</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_AEDX_Action_Connecting_Progress">
             <English>Connecting</English>
@@ -163,6 +170,7 @@
             <Chinesesimp>生命监护仪音频 关闭</Chinesesimp>
             <Finnish>Tärkeän näytön ääni pois päältä</Finnish>
             <Dutch>Vitale waarden monitor UIT</Dutch>
+            <Turkish>Vitals Monitor Sesi KAPALI</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_AEDX_Action_DisconnectMonitor">
             <English>Disconnect Vitals Monitor</English>
@@ -178,7 +186,7 @@
             <Japanese>バイタルモニターの切断</Japanese>
             <Chinese>移除監控</Chinese>
             <Chinesesimp>移除监控</Chinesesimp>
-            <Turkish>İzlemeyi kaldır</Turkish>
+            <Turkish>Vitals Monitor Bağlantısını Kes</Turkish>
             <Finnish>irrota terveysmonitori</Finnish>
             <Dutch>Maak vitale waarden monitor los</Dutch>
         </Key>
@@ -215,6 +223,7 @@
             <Chinesesimp>生命监护仪音频 开启</Chinesesimp>
             <Finnish>Terveysmonitorin ääni päällä</Finnish>
             <Dutch>Vitale waarden monitor audio AAN</Dutch>
+            <Turkish>Vitals Monitor Sesi AÇIK</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_AEDX_Action_PlacePads">
             <English>Place AED-X Pads</English>
@@ -231,6 +240,7 @@
             <Chinesesimp>放置AED-X电极</Chinesesimp>
             <Finnish>Aseta AUD-X-tyynyt</Finnish>
             <Dutch>Plaats AED-X pads</Dutch>
+            <Turkish>AED-X Pedlerini Yerleştir</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_AEDX_Monitor_AED_DISARMED">
             <English>AED DISARMED</English>
@@ -247,6 +257,7 @@
             <Chinesesimp>AED解除</Chinesesimp>
             <Finnish>AED POIS KÄYTÖSTÄ</Finnish>
             <Dutch>AED GEDEACTIVEERD</Dutch>
+            <Turkish>AED DEVRE DIŞI</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_AEDX_Monitor_ANALYZINGEKG">
             <English>ANALYZING ECG</English>
@@ -263,6 +274,7 @@
             <Chinesesimp>正在分析心电图</Chinesesimp>
             <Finnish>EKG:N ANALYSOINTI</Finnish>
             <Dutch>ECG-ANALYSE</Dutch>
+            <Turkish>EKG ANALİZ EDİLİYOR</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_AEDX_Monitor_CHARGED">
             <English>CHARGED</English>
@@ -279,6 +291,7 @@
             <Chinesesimp>已充电</Chinesesimp>
             <Finnish>LAADUT</Finnish>
             <Dutch>OPGELADEN</Dutch>
+            <Turkish>ŞARJ OLDU</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_AEDX_Monitor_CHARGING">
             <English>CHARGING</English>
@@ -295,6 +308,7 @@
             <Chinesesimp>正在充电</Chinesesimp>
             <Finnish>LATAUS</Finnish>
             <Dutch>WORDT GELADEN</Dutch>
+            <Turkish>ŞARJ EDİLİYOR</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_AEDX_Monitor_CheckPads">
             <English>Check Pads</English>
@@ -311,6 +325,7 @@
             <Chinesesimp>检查垫片</Chinesesimp>
             <Finnish>Tarkista tyynyt</Finnish>
             <Dutch>Controleer pads</Dutch>
+            <Turkish>Pedleri Kontrol Et</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_AEDX_Monitor_DISARMED">
             <English>DISARMED</English>
@@ -327,6 +342,7 @@
             <Chinesesimp>解除</Chinesesimp>
             <Finnish>POIS KÄYTÖSTÄ</Finnish>
             <Dutch>GEDEACTIVEERD</Dutch>
+            <Turkish>DEVRE DIŞI</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_AEDX_Monitor_Defibrillator">
             <English>Defibrillator</English>
@@ -342,6 +358,7 @@
             <Chinesesimp>除颤器</Chinesesimp>
             <Finnish>Defibrillaattori</Finnish>
             <Dutch>Defibrillator</Dutch>
+            <Turkish>Defibrilatör</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_AEDX_Monitor_DeliveredEnergy">
             <English>Delivered Energy</English>
@@ -358,6 +375,7 @@
             <Chinesesimp>输送能量</Chinesesimp>
             <Finnish>Toimitettu shokki</Finnish>
             <Dutch>Geleverde energie</Dutch>
+            <Turkish>Verilen Enerji</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_AEDX_Monitor_ENERGYDELIVERED">
             <English>ENERGY DELIVERED</English>
@@ -374,6 +392,7 @@
             <Chinesesimp>输送的能量</Chinesesimp>
             <Finnish>ISKU TOIMITETTU</Finnish>
             <Dutch>GELEVERDE ENERGIE</Dutch>
+            <Turkish>ENERJİ VERİLDİ</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_AEDX_Monitor_HR">
             <English>HR</English>
@@ -390,6 +409,7 @@
             <Chinesesimp>心率(HR)</Chinesesimp>
             <Finnish>HR</Finnish>
             <Dutch>HR</Dutch>
+            <Turkish>HR</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_AEDX_Monitor_MeasureBloodPressure">
             <English>Measure Blood Pressure</English>
@@ -406,6 +426,7 @@
             <Chinesesimp>测量血压</Chinesesimp>
             <Finnish>Mittaa verenpaine</Finnish>
             <Dutch>Meet bloeddruk</Dutch>
+            <Turkish>Kan Basıncını Ölç</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_AEDX_Monitor_NOSHOCKADVISED">
             <English>NO SHOCK ADVISED</English>
@@ -422,6 +443,7 @@
             <Chinesesimp>不建议电击</Chinesesimp>
             <Finnish>EI SUOSITTELUA SHOCKIA</Finnish>
             <Dutch>SCHOK NIET GEADVISEERD</Dutch>
+            <Turkish>ŞOK ÖNERİLMİYOR</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_AEDX_Monitor_PR">
             <English>PR</English>
@@ -438,6 +460,7 @@
             <Chinesesimp>PR</Chinesesimp>
             <Finnish>PR</Finnish>
             <Dutch>PR</Dutch>
+            <Turkish>PR</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_AEDX_Monitor_PUSHSHOCK">
             <English>PUSH SHOCK</English>
@@ -454,6 +477,7 @@
             <Chinesesimp>按下电击按钮</Chinesesimp>
             <Finnish>PAINA SHOKKI</Finnish>
             <Dutch>DRUK SCHOK</Dutch>
+            <Turkish>ŞOKU UYGULA</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_AEDX_Monitor_PerformCPR">
             <English>Perform CPR</English>
@@ -470,6 +494,7 @@
             <Chinesesimp>执行心肺复苏急救</Chinesesimp>
             <Finnish>Suorita elvytys</Finnish>
             <Dutch>Voer CPR uit</Dutch>
+            <Turkish>CPR Uygula</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_AEDX_Monitor_PushAnalyze">
             <English>Push Analyze</English>
@@ -486,6 +511,7 @@
             <Chinesesimp>按下分析按钮</Chinesesimp>
             <Finnish>Paina analysoida</Finnish>
             <Dutch>Druk analyse</Dutch>
+            <Turkish>Analizi Başlat</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_AEDX_Monitor_SHOCKADVISED">
             <English>SHOCK ADVISED</English>
@@ -502,6 +528,7 @@
             <Chinesesimp>建议电击</Chinesesimp>
             <Finnish>SOKI SUOSITELLAAN</Finnish>
             <Dutch>SCHOK GEADVISEERD</Dutch>
+            <Turkish>ŞOK ÖNERİLİYOR</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_AEDX_Monitor_SelectedEnergy">
             <English>Selected Energy</English>
@@ -517,6 +544,7 @@
             <Chinesesimp>选定能源</Chinesesimp>
             <Finnish>Valittu energia</Finnish>
             <Dutch>Geselecteerde energie</Dutch>
+            <Turkish>Seçilen Enerji</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_AEDX_Monitor_StandClear">
             <English>Stand Clear</English>
@@ -533,6 +561,7 @@
             <Chinesesimp>严禁倚靠</Chinesesimp>
             <Finnish>Väistyä</Finnish>
             <Dutch>Afstand houden</Dutch>
+            <Turkish>Uzak Durun</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_AEDX_Monitor_ToggleVolume">
             <English>Toggle Volume</English>
@@ -549,6 +578,7 @@
             <Chinesesimp>切换音量</Chinesesimp>
             <Finnish>Vaihda äänenvoimakkuutta</Finnish>
             <Dutch>Geluid omwisselen</Dutch>
+            <Turkish>Sesi Aç/Kapat</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_AED_Action_PlacePads">
             <English>Place AED Pads</English>
@@ -565,6 +595,7 @@
             <Chinesesimp>放置DEA电极</Chinesesimp>
             <Finnish>Aseta AUD-tyynyt</Finnish>
             <Dutch>Plaats AED pads</Dutch>
+            <Turkish>AED Pedlerini Yerleştir</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_AED_DESCRIPTION">
             <English>Used to resuscitate patients</English>
@@ -580,7 +611,7 @@
             <Japanese>人を蘇生させるために使用される</Japanese>
             <Chinese>用於復甦患者</Chinese>
             <Chinesesimp>使用电击来唤醒患者</Chinesesimp>
-            <Turkish>Oyuncuyu canlandırmak için kullanın</Turkish>
+            <Turkish>Hastaları resüsitasyon yapmak için kullanılır</Turkish>
             <Finnish>Käytetään potilaiden elvyttämiseen.</Finnish>
             <Dutch>Wordt gebruikt om patiënten te reanimeren</Dutch>
         </Key>
@@ -598,7 +629,7 @@
             <Japanese>AED (自動体外式除細動器)</Japanese>
             <Chinese>AED 除顫器</Chinese>
             <Chinesesimp>AED除颤器</Chinesesimp>
-            <Turkish>Otomatik eksternal defibrilatör</Turkish>
+            <Turkish>Otomatik Eksternal Defibrilatör</Turkish>
             <Finnish>Automaattinen ulkoinen defibrillaattori</Finnish>
             <Dutch>Automatische Externe Defibrillator</Dutch>
         </Key>
@@ -618,6 +649,7 @@
             <Chinesesimp>AED的最大成功概率</Chinesesimp>
             <Finnish>Suurin mahdollisuus menestyä AUD:lle</Finnish>
             <Dutch>Maximale succeskans voor AED</Dutch>
+            <Turkish>AED için Maks. Başarı Şansı</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_AED_MaxChance_DESC">
             <English>Maximum success chance for standard AED defibrillation</English>
@@ -625,6 +657,7 @@
             <Spanish>Probabilidad máxima de éxito de la desfibrilación con DEA estándar</Spanish>
             <German>Maximale Erfolgswahrscheinlichkeit für Standard-AED Defibrillation</German>
             <Japanese>標準AED除細動の最高成功率</Japanese>
+            <Turkish>Standart AED defibrilasyonu için maksimum başarı şansı</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_AED_MinChance">
             <English>Min Success chance for AED</English>
@@ -642,6 +675,7 @@
             <Chinesesimp>AED的最小成功概率</Chinesesimp>
             <Finnish>AUD:n onnistumisen minimimahdollisuus</Finnish>
             <Dutch>Minimale succeskans voor AED</Dutch>
+            <Turkish>AED için Min. Başarı Şansı</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_AED_MinChance_DESC">
             <English>Minimum success chance for standard AED defibrillation</English>
@@ -649,6 +683,7 @@
             <Spanish>Probabilidad mínima de éxito de la desfibrilación con DEA estándar</Spanish>
             <German>Minimale Erfolgswahrscheinlichkeit für Standard-AED Defibrillation</German>
             <Japanese>標準AED除細動の最低成功率</Japanese>
+            <Turkish>Standart AED defibrilasyonu için minimum başarı şansı</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_AED_X">
             <English>AED-X</English>
@@ -664,6 +699,7 @@
             <Chinesesimp>AED-X</Chinesesimp>
             <Finnish>AUD-X</Finnish>
             <Dutch>AED-X</Dutch>
+            <Turkish>AED-X</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_AED_X_MaxChance">
             <English>Max Success chance for AED-X</English>
@@ -681,6 +717,7 @@
             <Chinesesimp>AED-X的最大成功概率</Chinesesimp>
             <Finnish>Suurin mahdollisuus menestyä AUD-X:lle</Finnish>
             <Dutch>Maximale succeskans voor AED-X</Dutch>
+            <Turkish>AED-X için Maks. Başarı Şansı</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_AED_X_MaxChance_DESC">
             <English>Maximum success chance for AED-X defibrillation</English>
@@ -688,6 +725,7 @@
             <Spanish>Probabilidad máxima de éxito de la desfibrilación con AED-X</Spanish>
             <German>Maximale Erfolgswahrscheinlichkeit für AED-X Defibrillation</German>
             <Japanese>AED-X除細動の最高成功率</Japanese>
+            <Turkish>AED-X defibrilasyonu için maksimum başarı şansı</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_AED_X_MinChance">
             <English>Min Success chance for AED-X</English>
@@ -705,6 +743,7 @@
             <Chinesesimp>AED-X的最小成功概率</Chinesesimp>
             <Finnish>Minimi mahdollisuus onnistua AUD-X:lle</Finnish>
             <Dutch>Minimale succeskans voor AED-X</Dutch>
+            <Turkish>AED-X için Min. Başarı Şansı</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_AED_X_MinChance_DESC">
             <English>Minimum success chance for AED-X defibrillation</English>
@@ -712,6 +751,7 @@
             <Spanish>Probabilidad mínima de éxito de la desfibrilación con AED-X</Spanish>
             <German>Minimale Erfolgswahrscheinlichkeit für AED-X Defibrillation</German>
             <Japanese>AED-X除細動の最低成功率</Japanese>
+            <Turkish>AED-X defibrilasyonu için minimum başarı şansı</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_ALLOW_AED">
             <English>Allow AED</English>
@@ -1191,6 +1231,7 @@
             <Japanese>血圧カフで血圧を確認</Japanese>
             <Chinese>用血壓計量血壓</Chinese>
             <Dutch>Meet bloeddruk met manchet</Dutch>
+            <Turkish>BP Cuff ile BP Kontrol Et</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_Actions_CheckHRSteth">
             <English>Check HR w/ Stethoscope</English>
@@ -1202,6 +1243,7 @@
             <Japanese>聴診器で脈拍を確認</Japanese>
             <Chinese>用聽診器檢查心率</Chinese>
             <Dutch>Meet hartfrequentie met stethoscoop</Dutch>
+            <Turkish>Stethoscope ile HR Kontrol Et</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_Actions_CheckingBloodPressureCuff">
             <English>Checking BP with BP Cuff</English>
@@ -1213,6 +1255,7 @@
             <Japanese>血圧カフで血圧を確認中</Japanese>
             <Chinese>用血壓計量血壓中</Chinese>
             <Dutch>Bloeddruk wordt gemeten met manchet</Dutch>
+            <Turkish>BP Cuff ile BP kontrol ediliyor</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_Actions_CheckingHRSteth">
             <English>Checking HR with Stethoscope</English>
@@ -1224,6 +1267,7 @@
             <Japanese>聴診器で脈拍を確認中</Japanese>
             <Chinese>用聽診器檢查心率中</Chinese>
             <Dutch>Hartfrequentie wordt gemeten met stethoscoop</Dutch>
+            <Turkish>Stethoscope ile HR kontrol ediliyor</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_Activity_AttachPads">
             <English>%1 attached defibrillator pads (%2)</English>
@@ -1240,6 +1284,7 @@
             <Chinesesimp>%1 附加除颤器垫（%2）</Chinesesimp>
             <Finnish>%1 kiinnitetyt defibrillaattorityynyt (%2)</Finnish>
             <Dutch>%1 heeft defibrillator pad geplaatst (%2)</Dutch>
+            <Turkish>%1 defibrilatör pedlerini taktı (%2)</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_Activity_CPR">
             <English>%1 performed CPR (%2)</English>
@@ -1256,6 +1301,7 @@
             <Chinesesimp>%1 执行心肺复苏（%2）</Chinesesimp>
             <Finnish>%1 suoritettu elyytys (%2)</Finnish>
             <Dutch>%1 heeft CPR uitgevoerd (%2)</Dutch>
+            <Turkish>%1 CPR uyguladı (%2)</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_Activity_ConnectVitalsMonitor">
             <English>%1 connected vitals monitor</English>
@@ -1272,6 +1318,7 @@
             <Chinesesimp>%1 连接的生命体征监测仪</Chinesesimp>
             <Finnish>%1 kytketty terveysmonitori</Finnish>
             <Dutch>%1 heeft een vitale waarden monitor verbonden</Dutch>
+            <Turkish>%1 vitals monitor’ü bağladı</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_Activity_DisconnectVitalsMonitor">
             <English>%1 disconnected vitals monitor</English>
@@ -1288,6 +1335,7 @@
             <Chinesesimp>%1 断开的生命体征监测仪</Chinesesimp>
             <Finnish>%1 irrotettu terveysmonitori</Finnish>
             <Dutch>%1 heeft een vitale waarden monitor losgekoppeld</Dutch>
+            <Turkish>%1 vitals monitor bağlantısını kesti</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_Activity_RemovePads">
             <English>%1 removed defibrillator pads</English>
@@ -1304,6 +1352,7 @@
             <Chinesesimp>%1 拆下的除颤器垫</Chinesesimp>
             <Finnish>%1 poistettu defibrillaattorityynyt</Finnish>
             <Dutch>%1 heeft defibrillator pads verwijderd</Dutch>
+            <Turkish>%1 defibrilatör pedlerini çıkardı</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_Activity_Shock">
             <English>%1 administered shock (%2)</English>
@@ -1320,6 +1369,7 @@
             <Chinesesimp>%1 次电击（%2）</Chinesesimp>
             <Finnish>%1 annettu sokki (%2)</Finnish>
             <Dutch>%1 heeft een schok toegediend (%2)</Dutch>
+            <Turkish>%1 şok uyguladı (%2)</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_AnalyzeRhythm">
             <English>Analyze Rhythm</English>
@@ -1336,6 +1386,7 @@
             <Chinesesimp>心率分析</Chinesesimp>
             <Finnish>Analysoi rytmiä</Finnish>
             <Dutch>Analyseer hartritme</Dutch>
+            <Turkish>Ritmi Analiz Et</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_Apply_Arterial_Test">
             <English>Apply %1 Test</English>
@@ -1348,6 +1399,7 @@
             <Chinese>進行 %1 測試</Chinese>
             <Chinesesimp>应用 %1 测试</Chinesesimp>
             <Dutch>Voer %1 test uit</Dutch>
+            <Turkish>%1 Testini Uygula</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_Arterial_Test">
             <English>ABG Test</English>
@@ -1360,6 +1412,7 @@
             <Chinese>ABG分析</Chinese>
             <Chinesesimp>ABG测试</Chinesesimp>
             <Dutch>ABG test</Dutch>
+            <Turkish>ABG Testi</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_Arterial_Test_Action">
             <English>Run ABG Test</English>
@@ -1372,6 +1425,7 @@
             <Chinese>進行ABG分析</Chinese>
             <Chinesesimp>运行ABG测试</Chinesesimp>
             <Dutch>Voer ABG test uit</Dutch>
+            <Turkish>ABG Testini Çalıştır</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_BPCuff_desc">
             <English>A medical device to accurately determine a patients blood pressure</English>
@@ -1383,6 +1437,7 @@
             <Japanese>患者の血圧を正確に測定する医療機器</Japanese>
             <Chinese>一種準確測量病人血壓的醫療裝置</Chinese>
             <Dutch>Een medisch hulpmiddel om de bloeddruk van een patiënt accuraat te meten</Dutch>
+            <Turkish>Hastanın kan basıncını doğru şekilde belirleyen tıbbi bir cihaz</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_BPCuff_display">
             <English>Blood Pressure Cuff</English>
@@ -1394,6 +1449,7 @@
             <Japanese>血圧カフ</Japanese>
             <Chinese>血壓計</Chinese>
             <Dutch>Bloeddrukmanchet</Dutch>
+            <Turkish>Blood Pressure Cuff</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_BloodIV_A">
             <English>Blood IV (1000ml) BT: A+</English>
@@ -1838,6 +1894,7 @@
             <Chinese>%1 血樣</Chinese>
             <Chinesesimp>%1 血液样本</Chinesesimp>
             <Dutch>%1 bloedstaal</Dutch>
+            <Turkish>%1 Kan Örneği</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_Bloodpressure_Output_Palp">
             <English>%1 over Palp</English>
@@ -1849,6 +1906,7 @@
             <Japanese>触診による拡張期血圧は %1</Japanese>
             <Chinese>比觸診高 %1</Chinese>
             <Dutch>%1 per palpitatie</Dutch>
+            <Turkish>%1 / Palp</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_CPR_MaxChance_Default">
             <English>Max CPR Chance for Default</English>
@@ -1866,6 +1924,7 @@
             <Chinesesimp>默认的最大心肺复苏几率</Chinesesimp>
             <Finnish>Suurin mahdollisuus menestyä oletussotilailla, jotka suorittavat elvytystoimia</Finnish>
             <Dutch>Maximale succeskans van CPR voor standaard</Dutch>
+            <Turkish>Varsayılan Maks. CPR Şansı</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_CPR_MaxChance_Default_DESC">
             <English>Maximum CPR success chance for untrained personnel</English>
@@ -1873,6 +1932,7 @@
             <Spanish>Probabilidad máxima de éxito de la RCP para personal no capacitado</Spanish>
             <German>Maximale CPR-Erfolgschance für unausgebildetes Personal</German>
             <Japanese>訓練を受けていない人員のCPR最大成功率</Japanese>
+            <Turkish>Eğitimsiz personel için maksimum CPR başarı şansı</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_CPR_MaxChance_Doctor">
             <English>Max CPR Chance for Doctors</English>
@@ -1890,6 +1950,7 @@
             <Chinesesimp>医生的最大心肺复苏几率</Chinesesimp>
             <Finnish>Suurin CPR onnistumisen mahdollisuus lääkäreille</Finnish>
             <Dutch>Maximale succeskans van CPR voor doktoren</Dutch>
+            <Turkish>Doktorlar için Maks. CPR Şansı</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_CPR_MaxChance_Doctor_DESC">
             <English>Maximum CPR success chance for doctors</English>
@@ -1897,6 +1958,7 @@
             <Spanish>Probabilidad máxima de éxito de la RCP para médicos</Spanish>
             <German>Maximale CPR-Erfolgschance für Ärzte</German>
             <Japanese>医師のCPR最大成功率</Japanese>
+            <Turkish>Doktorlar için maksimum CPR başarı şansı</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_CPR_MaxChance_RegularMedic">
             <English>Max CPR Chance for Regular medics</English>
@@ -1914,6 +1976,8 @@
             <Chinesesimp>军医的最大心肺复苏几率</Chinesesimp>
             <Finnish>Suurin mahdollisuus menestyä elvytystä suorittaville taistelulääkäreille</Finnish>
             <Dutch>Maximale succeskans van CPR voor reguliere medici</Dutch>
+            <Turkish>Normal medikler için Maks. CPR Şansı
+</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_CPR_MaxChance_RegularMedic_DESC">
             <English>Maximum CPR success chance for regular medics</English>
@@ -1921,6 +1985,7 @@
             <Spanish>Probabilidad máxima de éxito de la RCP para personal médico estándar</Spanish>
             <German>Maximale CPR-Erfolgschance für reguläre Sanitäter</German>
             <Japanese>標準的な衛生兵のCPR最大成功率</Japanese>
+            <Turkish>Normal medikler için maksimum CPR başarı şansı</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_CPR_MinChance_Default">
             <English>Min CPR Chance for Default</English>
@@ -1938,6 +2003,7 @@
             <Chinesesimp>默认的最小心肺复苏几率</Chinesesimp>
             <Finnish>Pienin mahdollisuus menestyä elvytystoiminnassa oletussotilaana</Finnish>
             <Dutch>Minimale succeskans van CPR voor standaard</Dutch>
+            <Turkish>Varsayılan için Min. CPR Şansı</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_CPR_MinChance_Default_DESC">
             <English>Minimum CPR success chance for untrained personnel</English>
@@ -1945,6 +2011,7 @@
             <Spanish>Probabilidad mínima de éxito de la RCP para personal no capacitado</Spanish>
             <German>Minimale CPR-Erfolgschance für unausgebildetes Personal</German>
             <Japanese>訓練を受けていない人員のCPR最小成功率</Japanese>
+            <Turkish>Eğitimsiz personel için minimum CPR başarı şansı</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_CPR_MinChance_Doctor">
             <English>Min CPR Chance for Doctors</English>
@@ -1962,6 +2029,7 @@
             <Chinesesimp>医生的最小心肺复苏几率</Chinesesimp>
             <Finnish>Pienin mahdollisuus menestyä elvytyksen suorittamisessa lääkärinä</Finnish>
             <Dutch>Minimale succeskans van CPR voor doktoren</Dutch>
+            <Turkish>Doktorlar için Min. CPR Şansı</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_CPR_MinChance_Doctor_DESC">
             <English>Minimum CPR success chance for doctors</English>
@@ -1969,6 +2037,7 @@
             <Spanish>Probabilidad mínima de éxito de la RCP para médicos</Spanish>
             <German>Minimale CPR-Erfolgschance für Ärzte</German>
             <Japanese>医師のCPR最小成功率</Japanese>
+            <Turkish>Doktorlar için minimum CPR başarı şansı</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_CPR_MinChance_RegularMedic">
             <English>Min CPR Chance for Regular medics</English>
@@ -1986,6 +2055,8 @@
             <Chinesesimp>军医的最小心肺复苏几率</Chinesesimp>
             <Finnish>Pienin mahdollisuus menestyä elvytystyössä taistelulääkärinä</Finnish>
             <Dutch>Minimale succeskans van CPR voor reguliere medici</Dutch>
+            <Turkish>Normal medikler için Min. CPR Şansı
+</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_CPR_MinChance_RegularMedic_DESC">
             <English>Minimum CPR success chance for regular medics</English>
@@ -1993,6 +2064,7 @@
             <Spanish>Probabilidad mínima de éxito de la RCP para personal médico estándar</Spanish>
             <German>Minimale CPR-Erfolgschance für reguläre Sanitäter</German>
             <Japanese>標準的な衛生兵のCPR最小成功率</Japanese>
+            <Turkish>Normal medikler için minimum CPR başarı şansı</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_CancelCPR">
             <English>CPR Cancelled</English>
@@ -2009,6 +2081,7 @@
             <Chinesesimp>CPR取消</Chinesesimp>
             <Finnish>Elvytys peruttu</Finnish>
             <Dutch>CPR afgebroken</Dutch>
+            <Turkish>CPR İptal Edildi</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_ChangeCPRDevice">
             <English>Change Monitoring Device</English>
@@ -2021,6 +2094,7 @@
             <Chinese>更換監控設備</Chinese>
             <Chinesesimp>更换监控设备</Chinesesimp>
             <Dutch>Verander monitoringsapparaat</Dutch>
+            <Turkish>İzleme Cihazını Değiştir</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_Check_Bloodpressure_Output_Palp">
             <English>You find a blood pressure of %3 over Palp</English>
@@ -2032,6 +2106,7 @@
             <Japanese>触診で計測した拡張期血圧は %3 でした</Japanese>
             <Chinese>你發現血壓比觸診高 %3</Chinese>
             <Dutch>Je vindt een bloeddruk van %3 per palpitatie</Dutch>
+            <Turkish>%3 / Palp kan basıncı tespit ettin</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_Check_Pulse_Output">
             <English>You find a Pulse Rate of %2</English>
@@ -2043,6 +2118,7 @@
             <Japanese>計測した脈拍は %2 でした</Japanese>
             <Chinese>你發現脈搏率為 %2</Chinese>
             <Dutch>Je vindt een hartfrequentie van %2</Dutch>
+            <Turkish>%2 nabız tespit ettin</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_Defibrillator_Action_CancelCharge">
             <English>Cancel Charge</English>
@@ -2059,6 +2135,7 @@
             <Chinesesimp>取消充能</Chinesesimp>
             <Finnish>Peruuta sähkölataus</Finnish>
             <Dutch>Annuleer lading</Dutch>
+            <Turkish>Şarjı İptal Et</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_Defibrillator_Action_Charge">
             <English>Charge Defibrillator</English>
@@ -2075,6 +2152,7 @@
             <Chinesesimp>除颤器充能</Chinesesimp>
             <Finnish>Lataa defibrillaattori</Finnish>
             <Dutch>Laad defribrillator op</Dutch>
+            <Turkish>Defibrilatörü Şarj Et</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_Defibrillator_Action_PlacePads_Progress">
             <English>Placing Defibrillator Pads</English>
@@ -2091,6 +2169,7 @@
             <Chinesesimp>放置除颤器电极</Chinesesimp>
             <Finnish>Defibrillaattorityynyjen asettaminen</Finnish>
             <Dutch>Defibrillatiepads worden geplaatst</Dutch>
+            <Turkish>Defibrilatör Pedleri Yerleştiriliyor</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_Defibrillator_Action_RemovePads">
             <English>Remove Defibrillator Pads</English>
@@ -2107,6 +2186,7 @@
             <Chinesesimp>取下除颤器电极</Chinesesimp>
             <Finnish>Poista defibrillaattorityynyt</Finnish>
             <Dutch>Verwijder defibrillatiepads</Dutch>
+            <Turkish>Defibrilatör Pedlerini Çıkar</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_Defibrillator_Action_RemovePads_Progress">
             <English>Removing Defibrillator Pads</English>
@@ -2123,6 +2203,7 @@
             <Chinesesimp>正在取下除颤器垫</Chinesesimp>
             <Finnish>Defibrillaattorityynyjen poistaminen</Finnish>
             <Dutch>Defibrillatiepads worden verwijderd</Dutch>
+            <Turkish>Defibrilatör Pedleri Çıkarılıyor</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_Defibrillator_Action_Shock">
             <English>Administer Shock</English>
@@ -2139,6 +2220,7 @@
             <Chinesesimp>实施休克</Chinesesimp>
             <Finnish>Anna sokki potilaalle</Finnish>
             <Dutch>Dien schok toe</Dutch>
+            <Turkish>Şok Uygula</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_Defibrillator_PatientDisconnected">
             <English>Patient Disconnected</English>
@@ -2155,6 +2237,7 @@
             <Chinesesimp>患者已断开连接</Chinesesimp>
             <Finnish>Potilas on katkaistu</Finnish>
             <Dutch>Patiënt losgekoppeld</Dutch>
+            <Turkish>Hasta Bağlantısı Kesildi</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_DogTag">
             <English>Check Dogtags</English>
@@ -2203,6 +2286,7 @@
             <Chinese>抽取動脈血樣本</Chinese>
             <Chinesesimp>抽取动脉血样本</Chinesesimp>
             <Dutch>Neem Arterieel bloedstaal</Dutch>
+            <Turkish>Arteriyel Örnek Al</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_DrawBlood250_Action_Use">
             <English>Draw Blood (250ml)</English>
@@ -2381,6 +2465,7 @@
             <Chinesesimp>捡起 AED-X</Chinesesimp>
             <Finnish>Hae AUD-X</Finnish>
             <Dutch>Pak AED-X op</Dutch>
+            <Turkish>AED-X’i Al</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_Pulse_Output">
             <English>%1 PPM</English>
@@ -2392,6 +2477,7 @@
             <Japanese>%1 PPM</Japanese>
             <Chinese>%1 PPM</Chinese>
             <Dutch>%1 PPM</Dutch>
+            <Turkish>%1 PPM</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_SETTING_AEDStation_AllowInteraction">
             <English>Allow AED/X Station Interaction</English>
@@ -2408,6 +2494,7 @@
             <Chinesesimp>允许AED/X站交互</Chinesesimp>
             <Finnish>Salli AUD-X-vuorovaikutus aseman kanssa</Finnish>
             <Dutch>Sta AED/X stations interactie toe</Dutch>
+            <Turkish>AED/X İstasyon Etkileşimine İzin Ver</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_SETTING_AEDStation_AllowInteraction_DESCRIPTION">
             <English>Medical level required to pick up placed AED/X station</English>
@@ -2422,6 +2509,7 @@
             <Chinese>撿起已放置的 AED/X 工作站需要的醫療等級</Chinese>
             <Chinesesimp>领取放置的AED/X站所需的医疗水平</Chinesesimp>
             <Dutch>Benodigd medisch niveau om geplaatste AED/X stations op te pakken</Dutch>
+            <Turkish>Yerleştirilmiş AED/X istasyonunu almak için gereken tıbbi seviye</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_SETTING_AEDX_VitalsMonitor_AttachTime">
             <English>Attach AED-X Vitals Monitor Time</English>
@@ -2438,6 +2526,7 @@
             <Chinesesimp>附上AED-X生命体征监测仪时间</Chinesesimp>
             <Finnish>Kuinka kauan AUD-X-terveysmonitorin kiinnittäminen kestää</Finnish>
             <Dutch>Benodigde tijd om AED-X vitale waarden monitor aan te sluiten</Dutch>
+            <Turkish>AED-X Vitals Monitor Bağlama Süresi</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_SETTING_AEDX_VitalsMonitor_AttachTime_DESC">
             <English>Time required to attach AED-X vitals monitor to patient</English>
@@ -2445,6 +2534,7 @@
             <Spanish>Tiempo necesario para conectar el monitor de signos vitales AED-X al paciente</Spanish>
             <German>Benötigte Zeit zum Anbringen des AED-X Vitalmonitors am Patienten</German>
             <Japanese>AED-Xバイタルモニターを患者へ取り付けるのにかかる時間</Japanese>
+            <Turkish>AED-X vitals monitor’ü hastaya bağlamak için gereken süre</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_SETTING_AEDX_VitalsMonitor_DetachTime">
             <English>Detach AED-X Vitals Monitor Time</English>
@@ -2461,6 +2551,7 @@
             <Chinesesimp>分离AED-X生命体征监护仪时间</Chinesesimp>
             <Finnish>Kuinka kauan AUD-X-terveysmonitorin irrottaminen kestää</Finnish>
             <Dutch>Benodigde tijd om AED-X vitale waarden monitor los te koppelen</Dutch>
+            <Turkish>AED-X Vitals Monitor Ayırma Süresi</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_SETTING_AEDX_VitalsMonitor_DetachTime_DESC">
             <English>Time required to detach AED-X vitals monitor from patient</English>
@@ -2468,6 +2559,7 @@
             <Spanish>Tiempo necesario para desconectar el monitor de signos vitales AED-X del paciente</Spanish>
             <German>Benötigte Zeit zum Entfernen des AED-X Vitalmonitors vom Patienten</German>
             <Japanese>AED-Xバイタルモニターを患者から取り外すのにかかる時間</Japanese>
+            <Turkish>AED-X vitals monitor’ü hastadan ayırmak için gereken süre</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_SETTING_AED_X_VitalsMonitor_BloodPressureInterval">
             <English>AED-X Vitals Monitor BP Measurement Interval</English>
@@ -2484,6 +2576,7 @@
             <Chinesesimp>AED-X 生命监护仪 血压测量间隔</Chinesesimp>
             <Finnish>AUD-X terveysmonitorin verenpaineen mittausväli</Finnish>
             <Dutch>AED-X vitale waarden monitor BD metingsinterval</Dutch>
+            <Turkish>AED-X Vitals Monitor BP Ölçüm Aralığı</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_SETTING_AED_X_VitalsMonitor_BloodPressureInterval_Automatic">
             <English>Automatic (Interval)</English>
@@ -2500,6 +2593,7 @@
             <Chinesesimp>自动（间隔）</Chinesesimp>
             <Finnish>Automaattinen (väli)</Finnish>
             <Dutch>Automatisch (interval)</Dutch>
+            <Turkish>Otomatik (Aralıklı)</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_SETTING_AED_X_VitalsMonitor_BloodPressureInterval_AutomaticInstant">
             <English>Automatic Instant</English>
@@ -2516,6 +2610,7 @@
             <Chinesesimp>自动即时</Chinesesimp>
             <Finnish>Automaattinen (välitön)</Finnish>
             <Dutch>Automatisch direct</Dutch>
+            <Turkish>Otomatik Anlık</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_SETTING_AED_X_VitalsMonitor_BloodPressureInterval_DESC">
             <English>Controls how blood pressure is measured on AED-X monitor</English>
@@ -2523,6 +2618,7 @@
             <Spanish>Controla cómo se mide la presión arterial en el monitor AED-X</Spanish>
             <German>Kontrolliert, wie der Blutdruck am AED-X Monitor gemessen wird</German>
             <Japanese>AED-Xモニターでの血圧測定方法を制御します</Japanese>
+            <Turkish>AED-X monitöründe kan basıncının nasıl ölçüleceğini kontrol eder</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_SETTING_AED_X_VitalsMonitor_BloodPressureInterval_Manual">
             <English>Manual</English>
@@ -2539,6 +2635,7 @@
             <Chinesesimp>手册</Chinesesimp>
             <Finnish>Manuaalinen</Finnish>
             <Dutch>Handmatig</Dutch>
+            <Turkish>Manuel</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_SETTING_AED_X_VitalsMonitor_BloodPressureInterval_Time">
             <English>AED-X Vitals Monitor BP Measurement Interval Time</English>
@@ -2555,6 +2652,7 @@
             <Chinesesimp>AED-X生命体征监测仪血压测量间隔时间</Chinesesimp>
             <Finnish>AUD-X terveysmittarin verenpaineen mittausvälin aika</Finnish>
             <Dutch>Tijd van de AED-X vitale waarde monitor BD metingsinterval</Dutch>
+            <Turkish>AED-X Vitals Monitor BP Ölçüm Aralığı Süresi</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_SETTING_AED_X_VitalsMonitor_BloodPressureInterval_Time_DESC">
             <English>Time interval for automatic blood pressure measurements</English>
@@ -2562,6 +2660,7 @@
             <Spanish>Intervalo de tiempo para las mediciones automáticas de presión arterial</Spanish>
             <German>Zeitintervall für automatische Blutdruckmessungen</German>
             <Japanese>自動血圧測定の間隔</Japanese>
+            <Turkish>Otomatik kan basıncı ölçümleri için zaman aralığı</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_SETTING_AED_X_VitalsMonitor_SoundsSelect">
             <English>AED-X Vitals Monitor Sounds</English>
@@ -2578,6 +2677,7 @@
             <Chinesesimp>AED-X生命体征监测仪声音</Chinesesimp>
             <Finnish>AUD-X terveysmonitorin ääni</Finnish>
             <Dutch>Geluiden van de AED-X vitale waarde monitor</Dutch>
+            <Turkish>AED-X Vitals Monitor Sesleri</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_SETTING_AED_X_VitalsMonitor_SoundsSelect_DESC">
             <English>Selects which sound set to use for AED-X vitals monitor</English>
@@ -2585,6 +2685,7 @@
             <Spanish>Selecciona qué conjunto de sonidos usar para el monitor de signos vitales AED-X</Spanish>
             <German>Wählt aus, welcher Soundsatz für den AED-X Vitalmonitor verwendet wird</German>
             <Japanese>AED-Xバイタルモニターで使用するサウンドセットを選択します</Japanese>
+            <Turkish>AED-X vitals monitor için kullanılacak ses setini seçer</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_SETTING_AED_X_VitalsMonitor_SoundsSelect_Default">
             <English>Default</English>
@@ -2601,6 +2702,7 @@
             <Chinesesimp>默认</Chinesesimp>
             <Finnish>Oletus</Finnish>
             <Dutch>Standaard</Dutch>
+            <Turkish>Varsayılan</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_SETTING_AED_X_VitalsMonitor_SoundsSelect_Original">
             <English>Original</English>
@@ -2617,6 +2719,7 @@
             <Chinesesimp>原件</Chinesesimp>
             <Finnish>Alkuperäinen</Finnish>
             <Dutch>Origineel</Dutch>
+            <Turkish>Orijinal</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_SETTING_AED_duringCpr">
             <English>Allow AED pad application during CPR</English>
@@ -2631,6 +2734,7 @@
             <Chinese>允許在 CPR 期間應用 AED 電極片</Chinese>
             <Chinesesimp>允许在心肺复苏期间使用AED垫</Chinesesimp>
             <Dutch>Sta het plaatsen van AED pads tijdens CPR toe</Dutch>
+            <Turkish>CPR sırasında AED pedi uygulamasına izin ver</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_SETTING_AED_duringCpr_DESC">
             <English>Allows AED pads to be applied while CPR is being performed</English>
@@ -2638,6 +2742,7 @@
             <Spanish>Permite aplicar los electrodos del DEA mientras se realiza la RCP</Spanish>
             <German>Ermöglicht das Anbringen von AED-Pads während der Wiederbelebung</German>
             <Japanese>CPR中にAEDパッドを装着できるようにします</Japanese>
+            <Turkish>CPR uygulanırken AED pedlerinin takılmasına izin verir</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_SETTING_AdvRhythm_AED_ROSC_Chance">
             <English>ROSC After AED Chance</English>
@@ -2654,6 +2759,7 @@
             <Chinesesimp>除颤后恢复自主循环概率</Chinesesimp>
             <Finnish>ROSC AUD-mahdollisuuden jälkeen</Finnish>
             <Dutch>Kans voor ROSC na CPR (Terugkeer naar spontane circulatie)</Dutch>
+            <Turkish>AED Sonrası ROSC Şansı</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_SETTING_AdvRhythm_CPR_ROSC_Chance">
             <English>ROSC After CPR Chance</English>
@@ -2670,6 +2776,7 @@
             <Chinesesimp>CPR 后恢复自主循环概率</Chinesesimp>
             <Finnish>ROSC elvytysmahdollisuuden jälkeen</Finnish>
             <Dutch>Kans voor ROSC na CPR (Terugkeer naar spontane circulatie)</Dutch>
+            <Turkish>CPR Sonrası ROSC Şansı</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_SETTING_AdvRhythm_Enable">
             <English>Advanced Rhythms activated?</English>
@@ -2685,7 +2792,7 @@
             <Japanese>高度な心調律を有効化</Japanese>
             <Chinese>進階心律功能已啟用？</Chinese>
             <Chinesesimp>高级心率启用?</Chinesesimp>
-            <Turkish>Gelişmiş Ritim etkinleştirildi mi?</Turkish>
+            <Turkish>Gelişmiş Ritimler etkin mi?</Turkish>
             <Finnish>Edistyneet sykerytmit aktivoitu?</Finnish>
             <Dutch>Geadvanceerde hartritmes actief?</Dutch>
         </Key>
@@ -2695,6 +2802,7 @@
             <Spanish>Activa el sistema avanzado de ritmos de paro cardíaco</Spanish>
             <German>Aktiviert das erweiterte Herzrhythmus-System bei Herzstillstand</German>
             <Japanese>高度な心停止と調律のシステムを有効化します</Japanese>
+            <Turkish>Gelişmiş kardiyak arrest ritimleri sistemini etkinleştirir</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_SETTING_AdvRhythm_HTHold">
             <English>Enable H-and-T Holding in Arrest</English>
@@ -2705,6 +2813,7 @@
             <German>H&amp;Ts halten Herzstillstand aufrecht</German>
             <Japanese>心停止回復のH&amp;T症状による阻害を有効化</Japanese>
             <Dutch>H&amp;Ts voorkomen herstel uit hartstilstand</Dutch>
+            <Turkish>Arrest sırasında H&amp;T sabitlemeyi etkinleştir</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_SETTING_AdvRhythm_Hardcore_Enable">
             <English>Hardcore Rhythms</English>
@@ -2721,6 +2830,7 @@
             <Chinesesimp>困难模式心律</Chinesesimp>
             <Finnish>Vaikeat sydämen rytmit</Finnish>
             <Dutch>Hardcore hartritmen</Dutch>
+            <Turkish>Hardcore Ritimler</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_SETTING_AdvRhythm_PEAChance">
             <English>PEA Chance</English>
@@ -2737,6 +2847,7 @@
             <Chinesesimp>PEA 概率</Chinesesimp>
             <Finnish>Pulssittoman sähköisen toiminnan mahdollisuus</Finnish>
             <Dutch>PEA kans</Dutch>
+            <Turkish>PEA Olasılığı</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_SETTING_AdvRhythm_PEAEnabled">
             <English>Enable PEA</English>
@@ -2744,6 +2855,7 @@
             <Spanish>Activar PEA</Spanish>
             <Japanese>無脈性電気活動(PEA)を有効化</Japanese>
             <Dutch>Zet PEA aan</Dutch>
+            <Turkish>PEA’yı Etkinleştir</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_SETTING_AdvRhythm_VTChance">
             <English>VT Chance</English>
@@ -2760,6 +2872,7 @@
             <Chinesesimp>心室频脉（VT）概率</Chinesesimp>
             <Finnish>Kammiotakykardian mahdollisuus</Finnish>
             <Dutch>VT kans</Dutch>
+            <Turkish>VT Olasılığı</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_SETTING_AdvRhythm_asystoleBloodlossThreshold">
             <English>Asystole blood loss threshold</English>
@@ -2776,6 +2889,7 @@
             <Chinesesimp>心脏停搏失血阈临界值</Chinesesimp>
             <Finnish>Asystolan vuoksi menetettävä veren määrä</Finnish>
             <Dutch>Asystole bloedverlies drempelwaarde</Dutch>
+            <Turkish>Asystole kan kaybı eşiği</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_SETTING_AdvRhythm_canDeteriorate">
             <English>Can Deteriorate</English>
@@ -2792,6 +2906,7 @@
             <Chinesesimp>心律是否可能恶化</Chinesesimp>
             <Finnish>voivatko ne pahentua?</Finnish>
             <Dutch>Kan verslechteren</Dutch>
+            <Turkish>Kötüleşebilir</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_SETTING_AdvRhythm_canDeteriorate_DESC">
             <English>Allows cardiac arrest rhythms to deteriorate over time</English>
@@ -2799,6 +2914,7 @@
             <Spanish>Permite que los ritmos de paro cardíaco se deterioren con el tiempo</Spanish>
             <German>Ermöglicht es Herzrhythmen, sich im Laufe der Zeit zu verschlechtern</German>
             <Japanese>心停止状態の調律が時間の経過とともに悪化するのを許可します</Japanese>
+            <Turkish>Kardiyak arrest ritimlerinin zamanla kötüleşmesine izin verir</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_SETTING_AdvRhythm_deteriorateAfterTreatment">
             <English>Deteriorate After Treatment</English>
@@ -2815,6 +2931,7 @@
             <Chinesesimp>治疗后是否恶化</Chinesesimp>
             <Finnish>Voiko se pahentua hoidon jälkeen?</Finnish>
             <Dutch>Verslechterd na behandeling</Dutch>
+            <Turkish>Tedavi Sonrası Kötüleşme</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_SETTING_AdvRhythm_deteriorateTimeMax">
             <English>Random Deteriorate Time Maximum</English>
@@ -2831,6 +2948,7 @@
             <Chinesesimp>随机恶化最长时间</Chinesesimp>
             <Finnish>Satunnainen huononemisajan maksimiarvo</Finnish>
             <Dutch>Maximale willekeurige tijd voor een verslechtering</Dutch>
+            <Turkish>Rastgele Kötüleşme Süresi Maksimum</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_SETTING_AdvRhythm_deteriorateTimeWeight">
             <English>Random Deteriorate Time Weight</English>
@@ -2847,6 +2965,7 @@
             <Chinesesimp>随机恶化时间权重</Chinesesimp>
             <Finnish>Satunnainen huononemisajan paino</Finnish>
             <Dutch>Tijdsgewicht willekeurige verslechtering</Dutch>
+            <Turkish>Rastgele Kötüleşme Süresi Ağırlığı</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_SETTING_AdvRhythm_hardcoreDeteriorationChance">
             <English>Hardcore Deterioration Chance</English>
@@ -2863,6 +2982,7 @@
             <Chinesesimp>困难模式恶化概率</Chinesesimp>
             <Finnish>Vaikean sydämen rytmin heikkenemismahdollisuus</Finnish>
             <Dutch>Hardcore verslechteringskans</Dutch>
+            <Turkish>Hardcore Kötüleşme Olasılığı</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_SETTING_BLOOD_DRAWTIME_250ML">
             <English>Drawing time for 250ml Kit</English>
@@ -2878,7 +2998,7 @@
             <Japanese>250mlキットの採血時間</Japanese>
             <Chinese>250 毫升套件的绘制时间</Chinese>
             <Chinesesimp>250 mL的抽取时间</Chinesesimp>
-            <Turkish>250ml Kit için çizim süresi</Turkish>
+            <Turkish>250 ml Kit için kan alma süresi</Turkish>
             <Finnish>Aika, joka kuluu 250 ml:n verta ottamiseen</Finnish>
             <Dutch>Onttrekkingstijd voor 250ml set</Dutch>
         </Key>
@@ -2896,7 +3016,7 @@
             <Japanese>500mlキットの採血時間</Japanese>
             <Chinese>500 毫升套件的抽血時間</Chinese>
             <Chinesesimp>500 mL的抽取时间</Chinesesimp>
-            <Turkish>500ml Kit için çizim süresi</Turkish>
+            <Turkish>500 ml Kit için kan alma süresi</Turkish>
             <Finnish>Aika, joka kuluu 500 ml:n verta ottamiseen</Finnish>
             <Dutch>Onttrekkingstijd voor 500ml set</Dutch>
         </Key>
@@ -2910,6 +3030,7 @@
             <Japanese>血圧カフの許可</Japanese>
             <Chinese>允許使用血壓計</Chinese>
             <Dutch>Bloeddruksmanchet toestaan</Dutch>
+            <Turkish>BP Cuff’e İzin Ver</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_SETTING_BPCuff_DESC">
             <English>Training Level for use of the BP Cuff</English>
@@ -2921,6 +3042,7 @@
             <Japanese>血圧カフの使用に必要な医療スキルのレベルを設定します。</Japanese>
             <Chinese>使用血壓計的訓練等級</Chinese>
             <Dutch>Trainingsniveau dat benodigd is voor het gebruik van een bloeddruksmanchet</Dutch>
+            <Turkish>BP Cuff kullanımı için eğitim seviyesi</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_SETTING_CPR_CHANCES">
             <English>Enable different CPR chances per medical level</English>
@@ -2946,6 +3068,7 @@
             <Spanish>Activa distintas probabilidades de éxito de la RCP según el nivel de formación médica</Spanish>
             <German>Aktiviert verschiedene CPR-Erfolgschancen basierend auf medizinischer Ausbildung</German>
             <Japanese>医療スキルのレベルに基づいて異なるCPR成功率を有効化します</Japanese>
+            <Turkish>Tıbbi eğitim seviyesine göre farklı CPR başarı şanslarını etkinleştirir</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_SETTING_CPR_ChanceInterval">
             <English>CPR Chance Interval</English>
@@ -2962,6 +3085,7 @@
             <Chinesesimp>心肺复苏概率间隔</Chinesesimp>
             <Finnish>Elvytyksen onnistumislaskelmien välinen aika</Finnish>
             <Dutch>CPR kans interval</Dutch>
+            <Turkish>CPR Şans Aralığı</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_SETTING_CPR_ChanceInterval_DESC">
             <English>Interval at which CPR success chance is rolled</English>
@@ -2969,6 +3093,7 @@
             <Spanish>Intervalo en el que se calcula la probabilidad de éxito de la RCP</Spanish>
             <German>Intervall, in dem die CPR-Erfolgschance gewürfelt wird</German>
             <Japanese>CPR成功率をロールする間隔</Japanese>
+            <Turkish>CPR başarı şansının hesaplandığı aralık</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_SETTING_DRAW_BLOODGROUPS">
             <English>Use Bloodgroups for drawing blood?</English>
@@ -2984,7 +3109,7 @@
             <Japanese>採血に血液型を使用しますか?</Japanese>
             <Chinese>抽血時是否使用血型？</Chinese>
             <Chinesesimp>抽血时是否使用血型？</Chinesesimp>
-            <Turkish>Kan almak için Kan Grupları kullanılsın mı?</Turkish>
+            <Turkish>Kan alırken kan grupları kullanılsın mı?</Turkish>
             <Finnish>Käytätkö verityyppejä veren ottamiseen?</Finnish>
             <Dutch>Gebruik van bloedgroepen bij bloedonttrekking?</Dutch>
         </Key>
@@ -3003,6 +3128,7 @@
             <Chinesesimp>安装除颤器极板时间</Chinesesimp>
             <Finnish>Kuinka kauan defibrillaattorityynyjen kiinnittäminen kestää</Finnish>
             <Dutch>Benodigde tijd op defibrillator pads aan te brengen</Dutch>
+            <Turkish>Defibrilatör Pedlerini Takma Süresi</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_SETTING_DefibrillatorPads_AttachTime_DESC">
             <English>Time required to attach defibrillator pads to patient</English>
@@ -3010,6 +3136,7 @@
             <Spanish>Tiempo necesario para colocar los electrodos del desfibrilador en el paciente</Spanish>
             <German>Benötigte Zeit zum Anbringen der Defibrillator-Pads am Patienten</German>
             <Japanese>除細動パッドを患者へ取り付けるのにかかる時間</Japanese>
+            <Turkish>Defibrilatör pedlerini hastaya takmak için gereken süre</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_SETTING_DefibrillatorPads_DetachTime">
             <English>Detach Defibrillator Pads Time</English>
@@ -3026,6 +3153,7 @@
             <Chinesesimp>拆下除颤器极板时间</Chinesesimp>
             <Finnish>Kuinka kauan defibrillaattorityynyjen irrottaminen kestää</Finnish>
             <Dutch>Benodigde tijd om defibrillator pads te verwijderen</Dutch>
+            <Turkish>Defibrilatör Pedlerini Çıkarma Süresi</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_SETTING_DefibrillatorPads_DetachTime_DESC">
             <English>Time required to detach defibrillator pads from patient</English>
@@ -3033,6 +3161,7 @@
             <Spanish>Tiempo necesario para retirar los electrodos del desfibrilador del paciente</Spanish>
             <German>Benötigte Zeit zum Entfernen der Defibrillator-Pads vom Patienten</German>
             <Japanese>除細動パッドを患者から取り外すのにかかる時間</Japanese>
+            <Turkish>Defibrilatör pedlerini hastadan çıkarmak için gereken süre</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_SETTING_Defibrillator_DistanceLimit">
             <English>Distance limit for defibrillators in meters</English>
@@ -3049,6 +3178,7 @@
             <Chinesesimp>除颤器的距离限制（单位：米）</Chinesesimp>
             <Finnish>Defibrillaattorien etäisyysraja metreinä</Finnish>
             <Dutch>Afstandslimiet voor defibrillators in meters</Dutch>
+            <Turkish>Defibrilatörler için mesafe sınırı (metre)</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_SETTING_Defibrillator_DistanceLimit_DESC">
             <English>Maximum distance between defibrillator and patient for operation</English>
@@ -3056,6 +3186,7 @@
             <Spanish>Distancia máxima entre el desfibrilador y el paciente para su funcionamiento</Spanish>
             <German>Maximale Entfernung zwischen Defibrillator und Patient für den Betrieb</German>
             <Japanese>患者と除細動器の操作が可能な最大距離</Japanese>
+            <Turkish>Çalışma için defibrilatör ile hasta arasındaki maksimum mesafe</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_SETTING_ENABLE">
             <English>ACE-Circulation activated?</English>
@@ -3081,6 +3212,7 @@
             <Spanish>Activa el sistema médico de circulación KAT</Spanish>
             <German>Aktiviert das KAT Kreislauf-Medizinsystem</German>
             <Japanese>KAT 循環器系 医療システムを有効にします</Japanese>
+            <Turkish>KAT Sirkülasyon tıbbi sistemini etkinleştirir</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_SETTING_MINIMUM_SAFE_DRAW">
             <English>Minimum blood volume for donor (liters)</English>
@@ -3114,7 +3246,7 @@
             <Japanese>採血出来る献血者の血液最低量。0に設定で無視します</Japanese>
             <Chinese>允許供體引流的最小血量，設定為 0 可忽略此設定。</Chinese>
             <Chinesesimp>允许供体引流的最小血量，设置为 0 可忽略此设置。</Chinesesimp>
-            <Turkish>0'a ayarlanmış bu ayarı yok saymak için bir donörün drene etmesine izin verilen minimum kan hacmi</Turkish>
+            <Turkish>Bir donörden alınmasına izin verilen minimum kan hacmi; bu ayarı yok saymak için 0 yapın</Turkish>
             <Finnish>Vähimmäismäärä verta, jolle luovuttaja voidaan tyhjentää, aseta 0, jotta tämä asetus jätetään huomioimatta</Finnish>
             <Dutch>Minimaal benodigd bloedvolume om een donateur te zijn. Om dit te negeren, zet dit op 0.</Dutch>
         </Key>
@@ -3132,7 +3264,7 @@
             <Japanese>自己採血を有効化</Japanese>
             <Chinese>啟用自我抽血</Chinese>
             <Chinesesimp>启用自我抽血</Chinesesimp>
-            <Turkish>Kendi kendine kan alımını etkinleştir</Turkish>
+            <Turkish>Kendi kendine kan almayı etkinleştir</Turkish>
             <Finnish>Salli veren ottaminen itsestäsi</Finnish>
             <Dutch>Sta zelf bloedonttrekking toe</Dutch>
         </Key>
@@ -3146,6 +3278,7 @@
             <Japanese>聴診器による脈拍確認の許可</Japanese>
             <Chinese>允許使用聽診器檢查心率</Chinese>
             <Dutch>Sta zelfcontrole met stethoscoop toe</Dutch>
+            <Turkish>Stethoscope ile HR kontrolüne izin ver</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_SETTING_StethHR_DESC">
             <English>Training Level for use of the Stethoscope to measure HR</English>
@@ -3157,6 +3290,7 @@
             <Japanese>聴診器による脈拍の測定に必要な医療スキルのレベルを設定します。</Japanese>
             <Chinese>使用聽診器測量心率的訓練等級</Chinese>
             <Dutch>Benodigd trainingsniveau voor het gebruik van een stethoscoop bij het meten van de hartfrequentie</Dutch>
+            <Turkish>HR ölçmek için Stethoscope kullanım eğitim seviyesi</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_SETTING_Threshold_SpO2Warning">
             <English>AED-X alarm SpO2 threshold</English>
@@ -3173,6 +3307,7 @@
             <Chinesesimp>AED-X报警SpO2阈值</Chinesesimp>
             <Finnish>SpO2-taso, joka laukaisee AUD-X-hälytyksen</Finnish>
             <Dutch>Drempelwaarde voor AED-X alarm van SpO2</Dutch>
+            <Turkish>AED-X alarm SpO2 eşiği</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_SETTING_Threshold_SpO2Warning_DESC">
             <English>SpO2 level at which the monitor starts warning</English>
@@ -3180,6 +3315,7 @@
             <Spanish>Nivel de SpO2 en el que el monitor comienza a advertir.</Spanish>
             <German>SpO2-Wert, bei dem der Monitor zu warnen beginnt</German>
             <Japanese>モニターが警告を開始するSpO2の値</Japanese>
+            <Turkish>Monitörün uyarı vermeye başladığı SpO2 seviyesi</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_SETTING_abg_enable">
             <English>Enable ABG Testing</English>
@@ -3192,6 +3328,7 @@
             <Chinese>啟用 ABG 測試</Chinese>
             <Chinesesimp>启用ABG测试</Chinesesimp>
             <Dutch>Sta ABG tests toe</Dutch>
+            <Turkish>ABG Testini Etkinleştir</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_SETTING_abg_enable_DESC">
             <English>Enables ABG Testing and ACE Menu Visibility</English>
@@ -3204,6 +3341,7 @@
             <Chinese>啟用 ABG 測試和 ACE 選單可見性</Chinese>
             <Chinesesimp>启用ABG测试和ACE菜单可见性</Chinesesimp>
             <Dutch>Staat ABG tests toe en maakt deze zichtbaar in ACE menu's</Dutch>
+            <Turkish>ABG testini ve ACE menüsünde görünürlüğünü etkinleştirir</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_SETTING_bloodtype_assign">
             <English>Blood Type Assignment</English>
@@ -3221,6 +3359,7 @@
             <Chinesesimp>血型分配</Chinesesimp>
             <Finnish>Veriryhmämääritys</Finnish>
             <Dutch>Bloedtype toewijzing</Dutch>
+            <Turkish>Kan Grubu Ataması</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_SETTING_bloodtype_assign_DESC">
             <English>Sets how players' blood type is assigned: \nPlayer chosen: Player chooses their own blood type \nPlayer chosen (forced): Player chooses their own blood type, but it doesn't change upon respawning \nRandom: Blood type is random each respawn \nRandom (on join): Blood type is random, but doesn't change upon respawning \nSteamID: Blood type is decided based on player's steamID \nSteamID (custom list): Blood type is decided based on player's steamID and custom list</English>
@@ -3238,6 +3377,7 @@
             <Chinesesimp>设置如何分配玩家的血型：\n选择的玩家：玩家选择自己的血型\n选择（强制）的玩家：球员选择自己的血液类型，但在重生时不会改变\n随机：每次重生时血液类型都是随机的\n随机（加入时）：血液类型是随机的，但重生时不会变化\n团队ID：根据玩家的steamID决定血液类型\n团队ID:根据玩家的streamID和自定义列表决定血液类型</Chinesesimp>
             <Finnish>Asettaa kuinka pelaajan veriryhmä määritetään: \nPelaaja valittu: Pelaaja valitsee oman veriryhmänsä \nPelaaja valittu (pakotettu): Pelaaja valitsee oman veriryhmänsä, mutta se ei muutu uudelleensyntyessä. \nSatunnainen: Veriryhmä on satunnainen jokaisen uudelleensyntymisen yhteydessä. \nSatunnainen (pelaajan liittyessä peliin): Veriryhmä on satunnainen, mutta ei muutu uudelleensyntyessä. \nSteamID: Veriryhmä päätetään pelaajan SteamID:n perusteella. \nSteamID (mukautettu lista): Veriryhmä päätetään pelaajan SteamID:n ja mukautetun listan perusteella.</Finnish>
             <Dutch>Bepaald hoe spelers bloedgroep wordt toegewezen: \nSpeler gekozen: Spelers kunnen hun eigen bloedgroep selecteren. \nSpeler gekozen(geforceerd): Spelers kiezen hun eigen bloedgroep, maar dit veranderd niet op respawn. \nWillekeurig: Bloedgroep wordt willekeurig geselecteerd bij elke respawn. \nWillekeurig (bij toetreding): Bloedgroep is willekeurig, maar veranderd niet bij respawn. \nSteamID: Bloedgroep wordt geselecteerd op basis van de Spelers SteamID.\n SteamID (eigen lijst): Bloedgroep wordt geselecteerd op basis van SteamID en de zelf gemaakte lijst.</Dutch>
+            <Turkish>Oyuncuların kan grubunun nasıl atanacağını belirler: \nOyuncu seçer: Oyuncu kendi kan grubunu seçer \nOyuncu seçer (zorunlu): Oyuncu kendi kan grubunu seçer, ancak respawn olduğunda değişmez \nRastgele: Her respawn’da kan grubu rastgele olur \nRastgele (girişte): Kan grubu rastgeledir, ancak respawn olduğunda değişmez \nSteamID: Kan grubu oyuncunun steamID’sine göre belirlenir \nSteamID (özel liste): Kan grubu oyuncunun steamID’sine ve özel listeye göre belirlenir</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_SETTING_bloodtype_assign_player">
             <English>Player chosen</English>
@@ -3255,6 +3395,7 @@
             <Chinesesimp>玩家已选择</Chinesesimp>
             <Finnish>Pelaaja valittu</Finnish>
             <Dutch>Speler gekozen</Dutch>
+            <Turkish>Oyuncu seçer</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_SETTING_bloodtype_assign_player_forced">
             <English>Player chosen (forced)</English>
@@ -3272,6 +3413,7 @@
             <Chinesesimp>玩家选择（强制）</Chinesesimp>
             <Finnish>Valittu pelaaja (pakotettu)</Finnish>
             <Dutch>Speler gekozen (geforceerd)</Dutch>
+            <Turkish>Oyuncu seçer (zorunlu)</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_SETTING_bloodtype_assign_random">
             <English>Random</English>
@@ -3289,6 +3431,7 @@
             <Chinesesimp>随机</Chinesesimp>
             <Finnish>Satunnainen</Finnish>
             <Dutch>Willekeurig</Dutch>
+            <Turkish>Rastgele</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_SETTING_bloodtype_assign_random_onJoin">
             <English>Random (on join)</English>
@@ -3306,6 +3449,7 @@
             <Chinesesimp>随机（加入时）</Chinesesimp>
             <Finnish>Satunnainen (liittyessä)</Finnish>
             <Dutch>Willekeurig (bij toetreding)</Dutch>
+            <Turkish>Rastgele (girişte)</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_SETTING_bloodtype_assign_steamid">
             <English>SteamID</English>
@@ -3322,6 +3466,7 @@
             <Chinesesimp>SteamID</Chinesesimp>
             <Finnish>SteamID</Finnish>
             <Dutch>SteamID</Dutch>
+            <Turkish>SteamID</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_SETTING_bloodtype_assign_steamid_custom">
             <English>SteamID (custom list)</English>
@@ -3339,6 +3484,7 @@
             <Chinesesimp>SteamID（自定义列表）</Chinesesimp>
             <Finnish>SteamID (muokattu luettelo)</Finnish>
             <Dutch>SteamID (Eigen lijst)</Dutch>
+            <Turkish>SteamID (özel liste)</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_SETTING_bloodtype_custom_list">
             <English>Blood Type Custom List</English>
@@ -3356,6 +3502,7 @@
             <Chinesesimp>血型自定义列表</Chinesesimp>
             <Finnish>Mukautettu luettelo verityypeistä</Finnish>
             <Dutch>Bloedgroepen eigen lijst</Dutch>
+            <Turkish>Kan Grubu Özel Listesi</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_SETTING_bloodtype_custom_list_DESC">
             <English>Sets blood types that will be assigned to players based on their SteamID \nBlood types are separated by a comma (","), list should contain a total of 10 blood types</English>
@@ -3373,6 +3520,7 @@
             <Chinesesimp>设置将根据玩家的SteamID分配给他们的血型\n血型以逗号（“，”）分隔，列表应包含总共10种血型</Chinesesimp>
             <Finnish>Asettaa veriryhmät, jotka määritetään pelaajille heidän SteamID:n perusteella. \nVerityypit erotetaan toisistaan merkillä (","). Listalla tulee olla yhteensä 10 veriryhmää.</Finnish>
             <Dutch>Bepaald de bloedgroepen die aan spelers worden gegeven op basis van hun SteamID. \nBloedgroepen zijn gescheiden met een comma(","). De lijst moet 10 verschillende bloedgroepen bevatten</Dutch>
+            <Turkish>SteamID’ye göre oyunculara atanacak kan gruplarını belirler \nKan grupları virgülle (",") ayrılır; listede toplam 10 kan grubu olmalıdır</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_SETTING_bloodtype_player">
             <English>Blood group</English>
@@ -3398,6 +3546,7 @@
             <Spanish>Establece tu tipo de sangre preferido para multijugador</Spanish>
             <German>Legt Ihre bevorzugte Blutgruppe für Multiplayer fest</German>
             <Japanese>マルチプレイヤーで使用する血液型を設定します</Japanese>
+            <Turkish>Multiplayer için tercih ettiğiniz kan grubunu belirler</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_SETTING_bloodtype_random_weighted">
             <English>Weighted Randomizer</English>
@@ -3415,6 +3564,7 @@
             <Chinesesimp>加权随机化器</Chinesesimp>
             <Finnish>Painotettu satunnaistin</Finnish>
             <Dutch>Gewogen randomizer</Dutch>
+            <Turkish>Ağırlıklı Rastgeleleştirici</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_SETTING_bloodtype_random_weighted_DESC">
             <English>Sets if random blood type given will be weighted according to blood type commonness</English>
@@ -3432,6 +3582,7 @@
             <Chinesesimp>设置是否根据血型共性对随机血型进行加权</Chinesesimp>
             <Finnish>Asettaa, painotetaanko satunnaiset veriryhmät palvelimen yleisen veriryhmän mukaan.</Finnish>
             <Dutch>Bepaald of willekeurige bloedgroepen worden gewogen op basis van de algemeenheid van de bloedgroepen</Dutch>
+            <Turkish>Rastgele verilen kan grubunun, kan grubu yaygınlığına göre ağırlıklandırılıp ağırlıklandırılmayacağını belirler</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_SETTING_cardiacArrestBleedRate">
             <English>Cardiac Arrest Bleed Rate</English>
@@ -3448,6 +3599,7 @@
             <Chinesesimp>心脏骤停出血率</Chinesesimp>
             <Finnish>Verenvuoto sydämenpysähdyksen aikana</Finnish>
             <Dutch>Bloedingsnelheid bij hartstilstand</Dutch>
+            <Turkish>Kardiyak Arrest Kanama Hızı</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_SETTING_hardcoreDiagnose">
             <English>Enable Hardcore HR and BP Diagnose</English>
@@ -3459,6 +3611,7 @@
             <Japanese>ハードコア脈拍および血圧診断を有効化</Japanese>
             <Chinese>啟用硬核心率和血壓診斷</Chinese>
             <Dutch>Zet hardcore metingen van hartfrequentie en bloeddruk aan</Dutch>
+            <Turkish>Hardcore HR ve BP Tanısını Etkinleştir</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_SETTING_hardcoreDiagnose_DESC">
             <English>Makes measuring BP and HR imprecise without tools (Stethoscope or BP cuff)</English>
@@ -3470,6 +3623,7 @@
             <Japanese>器具(聴診器または血圧カフ)なしでは脈拍および血圧を正確に測定出来なくします</Japanese>
             <Chinese>在沒有工具（聽診器或血壓計）的情況下，測量血壓和心率會不準確</Chinese>
             <Dutch>Maakt het meten van hartfrequentie en bloeddruk inaccuraat zonder hulpmiddelen (Stethoscoop of bloeddrukmanchet)</Dutch>
+            <Turkish>Araçlar (Stethoscope veya BP cuff) olmadan BP ve HR ölçümünü belirsiz yapar</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_SETTING_tamponadeChance">
             <English>Chance for tamponade in penetrating wounds</English>
@@ -3484,6 +3638,7 @@
             <Chinese>穿透性傷口填塞的可能性</Chinese>
             <Chinesesimp>穿透性伤口填塞的可能性</Chinesesimp>
             <Dutch>Kans voor tamponade door penetrerende wonden</Dutch>
+            <Turkish>Derin Delici Yaralanmalarda tamponad olasılığı</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_SETTING_tamponadeChance_deterioration">
             <English>Tamponade progression chance</English>
@@ -3498,6 +3653,7 @@
             <Chinese>心包填塞進展的機率</Chinese>
             <Chinesesimp>填塞进展概率</Chinesesimp>
             <Dutch>Tamponade progressie kans</Dutch>
+            <Turkish>Tamponad ilerleme olasılığı</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_SETTING_tamponadeInterval">
             <English>Tamponade progression timer</English>
@@ -3512,6 +3668,7 @@
             <Chinese>填塞進度計時器</Chinese>
             <Chinesesimp>填塞进展计时器</Chinesesimp>
             <Dutch>Tamponade progressie timer</Dutch>
+            <Turkish>Tamponad ilerleme zamanlayıcısı</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_StartCPR">
             <English>CPR Started</English>
@@ -3527,6 +3684,7 @@
             <Chinesesimp>心肺复苏开始</Chinesesimp>
             <Finnish>Elvytys alkoi</Finnish>
             <Dutch>CPR gestart</Dutch>
+            <Turkish>CPR Başladı</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_StopCPR">
             <English>Stop CPR</English>
@@ -3543,6 +3701,7 @@
             <Chinesesimp>停止心肺复苏</Chinesesimp>
             <Finnish>Lopeta elvytys</Finnish>
             <Dutch>Stop CPR</Dutch>
+            <Turkish>CPR’yi Durdur</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_SubCategory_AED">
             <English>AED + AED-X Settings</English>
@@ -3560,6 +3719,7 @@
             <Chinesesimp>自动体外除颤器及X系列自动体外除颤器设置</Chinesesimp>
             <Finnish>AUD + AUD-X asetukset</Finnish>
             <Dutch>AED + AED-X instellingen</Dutch>
+            <Turkish>AED + AED-X Ayarları</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_SubCategory_AdvRhythms">
             <English>Advanced Rhythms</English>
@@ -3576,6 +3736,7 @@
             <Chinesesimp>高级节奏</Chinesesimp>
             <Finnish>Edistyneet sydämen rytmit</Finnish>
             <Dutch>Geadvanceerde hartritmen</Dutch>
+            <Turkish>Gelişmiş Ritimler</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_SubCategory_BloodDraw">
             <English>Blood draw Settings</English>
@@ -3593,6 +3754,7 @@
             <Chinesesimp>抽血设置</Chinesesimp>
             <Finnish>Verenoton asetukset</Finnish>
             <Dutch>Bloedonttrekkings instellingen</Dutch>
+            <Turkish>Kan Alma Ayarları</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_SubCategory_CPR">
             <English>CPR Settings</English>
@@ -3610,6 +3772,7 @@
             <Chinesesimp>CPR 设置</Chinesesimp>
             <Finnish>Elvytys asetukset</Finnish>
             <Dutch>CPR instellingen</Dutch>
+            <Turkish>CPR Ayarları</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_TRAINING_LEVEL_AED">
             <English>Training level required to use an AED</English>
@@ -3662,6 +3825,7 @@
             <Chinesesimp>查看 生命监护仪</Chinesesimp>
             <Finnish>Näytä monitori</Finnish>
             <Dutch>Kijk op monitor</Dutch>
+            <Turkish>Monitörü Görüntüle</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_VitalsMonitor_StatusLog">
             <English>AED-X: HR: %1 BP: %2/%3 SpO2: %4</English>
@@ -3679,6 +3843,7 @@
             <Chinesesimp>AED-X: 心率(HR): %1 血压(BP): %2/%3 血氧饱和度(SpO2): %4</Chinesesimp>
             <Finnish>AUD-X: HR: %1 BP: %2/%3 SpO2: %4</Finnish>
             <Dutch>AED-X: HR %1 BD: %2/%3 SpO2: %4</Dutch>
+            <Turkish>AED-X: HR: %1 BP: %2/%3 SpO₂: %4</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_VitalsMonitor_StatusLog_HasEtco2Monitor">
             <English>AED-X: HR: %1 BP: %2/%3 SpO2: %4  ETCo2: %5 Breaths/min: %6</English>
@@ -3693,6 +3858,7 @@
             <Chinese>AED-X：心率：%1 血壓：%2/%3 SpO2：%4 ETCo2：%5 呼吸/分：%6</Chinese>
             <Chinesesimp>AED-X: 心率(HR): %1 血压(BP):%2/%3血氧饱和度(SpO2):%4呼气末二氧化碳浓度(ETCo2):%5呼吸/分钟：%6</Chinesesimp>
             <Dutch>AED-X: HR %1 BD: %2/%3 SpO2: %4 ETCo2: %5 Ademhalingen/min: %6</Dutch>
+            <Turkish>AED-X: HR: %1 BP: %2/%3 SpO₂: %4 ETCO₂: %5 Nefes/dk: %6</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_VitalsMonitor_VMActive_StatusLog">
             <English>AED-X: PR: %1 BP: %2/%3 SpO2: %4</English>
@@ -3709,6 +3875,7 @@
             <Chinesesimp>AED-X: 脉搏(PR): %1 血压(BP): %2/%3 血氧饱和度(SpO2): %4</Chinesesimp>
             <Finnish>AUD-X: PR: %1 BP: %2/%3 SpO2: %4</Finnish>
             <Dutch>AED-X: PR %1 BD: %2/%3 SpO2: %4</Dutch>
+            <Turkish>AED-X: PR: %1 BP: %2/%3 SpO₂: %4</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_VitalsMonitor_VMActive_StatusLog_HasEtco2Monitor">
             <English>AED-X: PR: %1 BP: %2/%3 SpO2: %4 ETCo2: %5 Breaths/min: %6</English>
@@ -3723,6 +3890,7 @@
             <Chinese>AED-X：脈搏：%1 血壓：%2/%3 SpO2：%4 ETCo2：%5 呼吸/分：%6</Chinese>
             <Chinesesimp>AED-X: 脉搏(PR): %1 血压(BP):%2/%3血氧饱和度(SpO2):%4呼气末二氧化碳浓度(ETCo2):%5呼吸/分钟：%6</Chinesesimp>
             <Dutch>AED-X: PR %1 BD: %2/%3 SpO2: %4 ETCo2: %5 Ademhalingen/min: %6</Dutch>
+            <Turkish>AED-X: PR: %1 BP: %2/%3 SpO₂: %4 ETCO₂: %5 Nefes/dk: %6</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_VitalsMonitor_VMInactive_StatusLog">
             <English>AED-X: HR: %1 BP: --/-- SpO2: ---</English>
@@ -3740,6 +3908,7 @@
             <Chinesesimp>AED-X: 心率(HR): %1 血压(BP):--/--血氧饱和度(SpO2):---</Chinesesimp>
             <Finnish>AUD-X: HR: %1 BP: --/-- SpO2: ---</Finnish>
             <Dutch>AED-X: HR %1 BD: --/-- SpO2: ---</Dutch>
+            <Turkish>AED-X: HR: %1 BP: --/-- SpO₂: ---</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_VitalsMonitor_VMInactive_StatusLog_HasEtco2Monitor">
             <English>AED-X: HR: %1 BP: --/-- SpO2: --- ETCo2: %2 Breaths/min: %3</English>
@@ -3754,6 +3923,7 @@
             <Chinese>AED-X：心率：%1 血壓：--/-- SpO2：--- ETCo2：%2 呼吸/分：%3</Chinese>
             <Chinesesimp>AED-X: 心率(HR): %1 血压(BP):--/--血氧饱和度(SpO2):---呼气末二氧化碳浓度(ETCo2):%2呼吸/分钟：%3</Chinesesimp>
             <Dutch>AED-X: HR %1 BD: --/-- SpO2: --- ETCo2: %2 Ademhalingen/min: %3</Dutch>
+            <Turkish>AED-X: HR: %1 BP: --/-- SpO₂: --- ETCO₂: %2 Nefes/dk: %3</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_X_Desc">
             <English>Used to monitor vitals and resuscitate patients</English>
@@ -3769,7 +3939,7 @@
             <Japanese>バイタルの値を監視し、人を蘇生させるために使用される</Japanese>
             <Chinese>具有生命跡象監測功能，可用於監測生命跡象和進行急救</Chinese>
             <Chinesesimp>具有生命迹象监测功能，可用于监测生命迹象和进行急救</Chinesesimp>
-            <Turkish>Hayati değerleri izlemek ve kişileri canlandırmak için kullanılır</Turkish>
+            <Turkish>Hayati bulguları izlemek ve hastalara resüsitasyon yapmak için kullanılır</Turkish>
             <Finnish>Käytetään elintoimintojen seurantaan ja potilaiden elvyttämiseen</Finnish>
             <Dutch>Wordt gebruikt om de vitale waarden te monitoren en patiënten te reanimeren</Dutch>
         </Key>
@@ -3805,7 +3975,7 @@
             <Japanese>[KAM] 医療用血液バンク</Japanese>
             <Chinese>[KAM] 醫療用血庫</Chinese>
             <Chinesesimp>[KAM] 医用血库</Chinesesimp>
-            <Turkish>[KAM] Tıbbi Kan bankası</Turkish>
+            <Turkish>[KAM] Tıbbi Kan Bankası</Turkish>
             <Finnish>[KAM] Lääketieteellinen veripankki</Finnish>
             <Dutch>[KAM] Medische bloedbank</Dutch>
         </Key>
@@ -3822,6 +3992,7 @@
             <Chinese>%1 檢查了狗牌的血型: %2</Chinese>
             <Chinesesimp>%1 检查狗牌上的血型：%2</Chinesesimp>
             <Dutch>%1 heeft de bloedgroep van het herkeningsplaatje gecontroleerd: %2</Dutch>
+            <Turkish>%1 künye kan grubunu kontrol etti: %2</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_cba_name">
             <English>KAT - ADV Medical: Circulation</English>
@@ -3831,6 +4002,7 @@
             <German>KAT - ADV Medical: Zirkulation</German>
             <Japanese>KAM - 循環器系 (Circulation)</Japanese>
             <Dutch>KAT - ADV Medical: Circulatie</Dutch>
+            <Turkish>KAT – Gelişmiş Tıp: Dolaşım</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_crosspanel">
             <English>Blood groups cheat sheet</English>
@@ -3864,7 +4036,7 @@
             <Japanese>ドナーと患者の血液の間違った組み合わせは、致命的な結果をもたらす可能性さえあります。</Japanese>
             <Chinese>使用不相容的血包輸血可能會導致病患死亡。</Chinese>
             <Chinesesimp>使用不相容的血包输血可能会导致病患死亡。</Chinesesimp>
-            <Turkish>Verici ve alıcı kanının yanlış bir kombinasyonu ölümcül sonuçlara bile yol açabilir.</Turkish>
+            <Turkish>Donör ve alıcı kanının yanlış kombinasyonu ölümcül sonuçlara bile yol açabilir.</Turkish>
             <Finnish>Luovutetun veren ja vastaanottajan veren väärällä yhdistelmällä voi olla tappavia seurauksia.</Finnish>
             <Dutch>Een verkeerde combinatie van donor- en ontvangersbloed kan zelfs dodelijke gevolgen hebben.</Dutch>
         </Key>
@@ -3919,6 +4091,7 @@
             <Chinesesimp>放置AED-X</Chinesesimp>
             <Finnish>Aseta AUD-X</Finnish>
             <Dutch>Plaats AED-X</Dutch>
+            <Turkish>AED-X Yerleştir</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_resultItemName">
             <English>ABG Result</English>
@@ -3931,6 +4104,7 @@
             <Chinese>ABG 結果</Chinese>
             <Chinesesimp>ABG 结果</Chinesesimp>
             <Dutch>ABG resultaat</Dutch>
+            <Turkish>ABG Sonucu</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_sampleItemName">
             <English>Blood Sample</English>
@@ -3943,6 +4117,7 @@
             <Chinese>血液樣本</Chinese>
             <Chinesesimp>血液样本</Chinesesimp>
             <Dutch>Bloedstaal</Dutch>
+            <Turkish>Kan Örneği</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_treatmentTime_BPCuff">
             <English>Time to measure BP with BP Cuff</English>
@@ -3954,6 +4129,7 @@
             <Japanese>血圧カフによる血圧測定の所要時間</Japanese>
             <Chinese>用血壓計量血壓所需時間</Chinese>
             <Dutch>Benodigde tijd voor bloeddrukmeting met manchet</Dutch>
+            <Turkish>BP Cuff ile BP ölçüm süresi</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_treatmentTime_BPCuff_DESC">
             <English>Time required to measure blood pressure with blood pressure cuff</English>
@@ -3961,6 +4137,7 @@
             <Spanish>Tiempo necesario para medir la presión arterial con el manguito de presión</Spanish>
             <German>Benötigte Zeit zur Blutdruckmessung mit der Blutdruckmanschette</German>
             <Japanese>血圧カフで血圧を測定するのにかかる時間</Japanese>
+            <Turkish>Blood pressure cuff ile kan basıncı ölçmek için gereken süre</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_treatmentTime_StethHR">
             <English>Time to measure HR with a Stethoscope</English>
@@ -3972,6 +4149,7 @@
             <Japanese>聴診器による脈拍測定の所要時間</Japanese>
             <Chinese>用聽診器測量心率所需時間</Chinese>
             <Dutch>Benodigde tijd voor het meten van hartfrequentie met een stethoscoop</Dutch>
+            <Turkish>Stethoscope ile HR ölçüm süresi</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_treatmentTime_StethHR_DESC">
             <English>Time required to measure heart rate with stethoscope</English>
@@ -3979,6 +4157,7 @@
             <Spanish>Tiempo necesario para medir la frecuencia cardíaca con el estetoscopio</Spanish>
             <German>Benötigte Zeit zur Pulsmessung mit dem Stethoskop</German>
             <Japanese>聴診器で心拍数を測定するのにかかる時間</Japanese>
+            <Turkish>Stethoscope ile kalp atım hızını ölçmek için gereken süre</Turkish>
         </Key>
     </Package>
 </Project>

--- a/addons/circulation/stringtable.xml
+++ b/addons/circulation/stringtable.xml
@@ -1976,8 +1976,7 @@
             <Chinesesimp>军医的最大心肺复苏几率</Chinesesimp>
             <Finnish>Suurin mahdollisuus menestyä elvytystä suorittaville taistelulääkäreille</Finnish>
             <Dutch>Maximale succeskans van CPR voor reguliere medici</Dutch>
-            <Turkish>Normal medikler için Maks. CPR Şansı
-</Turkish>
+            <Turkish>Normal medikler için Maks. CPR Şansı</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_CPR_MaxChance_RegularMedic_DESC">
             <English>Maximum CPR success chance for regular medics</English>
@@ -2055,8 +2054,7 @@
             <Chinesesimp>军医的最小心肺复苏几率</Chinesesimp>
             <Finnish>Pienin mahdollisuus menestyä elvytystyössä taistelulääkärinä</Finnish>
             <Dutch>Minimale succeskans van CPR voor reguliere medici</Dutch>
-            <Turkish>Normal medikler için Min. CPR Şansı
-</Turkish>
+            <Turkish>Normal medikler için Min. CPR Şansı</Turkish>
         </Key>
         <Key ID="STR_KAT_Circulation_CPR_MinChance_RegularMedic_DESC">
             <English>Minimum CPR success chance for regular medics</English>

--- a/addons/feedback/stringtable.xml
+++ b/addons/feedback/stringtable.xml
@@ -12,6 +12,7 @@
             <Chinese>啟用 K他命(氯胺酮)、芬太尼、冰毒(甲基苯丙胺) 等 鴉片類藥物的作用</Chinese>
             <Chinesesimp>使阿片类药物对氯胺酮、芬太尼和帕维汀产生作用</Chinesesimp>
             <Dutch>Maakt het mogelijk om opioid-effecten te verkrijgen bij het gebruik van ketamine, fentanyl en pervitin</Dutch>
+            <Turkish>Ketamin, fentanil ve pervitin üzerinde opioid etkisini etkinleştirir</Turkish>
         </Key>
         <Key ID="STR_KAT_Feedback_SETTING_OpioidEffect_display">
             <English>Enable opioid effect</English>
@@ -24,6 +25,7 @@
             <Chinese>啟用鴉片類藥物效果</Chinese>
             <Chinesesimp>启用阿片类药物作用</Chinesesimp>
             <Dutch>Zet opioid-effecten aan</Dutch>
+            <Turkish>Opioid etkisini etkinleştir</Turkish>
         </Key>
         <Key ID="STR_KAT_Feedback_SETTING_lowSpO2_DESC">
             <English>Lets you change the SpO2 Value at which you get the Flashing warning indicator and stamina loss effect</English>
@@ -41,6 +43,7 @@
             <Chinesesimp>允许您更改SpO2警告值，在该值下，您将获得闪烁警告指示器和耐力损失效果</Chinesesimp>
             <Finnish>Voit muuttaa SpO2-arvoa, jolla saat vilkkuvan varoituksen ja kestävyyden heikkenemisen</Finnish>
             <Dutch>Defineert de SpO2 waarde waarbij uithoudingsproblemen ontstaan en er een visueel pulseren effect getoond wordt</Dutch>
+            <Turkish>Yanıp sönen uyarı göstergesi ve dayanıklılık kaybı etkisinin başlayacağı SpO₂ değerini değiştirmenizi sağlar</Turkish>
         </Key>
         <Key ID="STR_KAT_Feedback_SETTING_lowSpO2_display">
             <English>Low SpO2 warning level</English>
@@ -58,6 +61,7 @@
             <Chinesesimp>低SpO2警告级别</Chinesesimp>
             <Finnish>Matala SpO2-varoitustaso</Finnish>
             <Dutch>Waarschuwingswaarde voor SpO2</Dutch>
+            <Turkish>Düşük SpO2 uyarı seviyesi</Turkish>
         </Key>
         <Key ID="STR_KAT_Feedback_cba_name">
             <English>KAT - ADV Medical: Feedback</English>
@@ -67,6 +71,7 @@
             <German>KAT - ADV Medical: Feedback</German>
             <Japanese>KAM - フィードバック</Japanese>
             <Dutch>KAT - ADV Medical: Feedback</Dutch>
+            <Turkish>KAT – Gelişmiş Tıp: Geri Bildirim</Turkish>
         </Key>
     </Package>
 </Project>

--- a/addons/gui/stringtable.xml
+++ b/addons/gui/stringtable.xml
@@ -12,6 +12,7 @@
             <Chinese>ABG 結果</Chinese>
             <Chinesesimp>ABG结果</Chinesesimp>
             <Dutch>ABG resultaten</Dutch>
+            <Turkish>ABG Sonuçları</Turkish>
         </Key>
         <Key ID="STR_KAT_GUI_BGBlank">
             <English>--.-</English>
@@ -23,6 +24,7 @@
             <Japanese>--.-</Japanese>
             <Chinesesimp>--.-</Chinesesimp>
             <Dutch>--.-</Dutch>
+            <Turkish>--.-</Turkish>
         </Key>
         <Key ID="STR_KAT_GUI_ChestCover">
             <English>CHEST - NO LINE</English>
@@ -35,6 +37,7 @@
             <Chinese>胸部 - 無線</Chinese>
             <Chinesesimp>胸部--无线路</Chinesesimp>
             <Dutch>TORSO - GEEN LIJN</Dutch>
+            <Turkish>GÖĞÜS – HAT YOK</Turkish>
         </Key>
         <Key ID="STR_KAT_GUI_ChestTitle">
             <English>Chest</English>
@@ -47,6 +50,7 @@
             <Chinese>胸部</Chinese>
             <Chinesesimp>胸部</Chinesesimp>
             <Dutch>Torso</Dutch>
+            <Turkish>Göğüs</Turkish>
         </Key>
         <Key ID="STR_KAT_GUI_HeadCover">
             <English>HEAD - NO LINE</English>
@@ -59,6 +63,7 @@
             <Chinese>頭部 - 無線</Chinese>
             <Chinesesimp>头部-无线路</Chinesesimp>
             <Dutch>HOOFD - GEEN LIJN</Dutch>
+            <Turkish>KAFA – HAT YOK</Turkish>
         </Key>
         <Key ID="STR_KAT_GUI_HeadTitle">
             <English>Head</English>
@@ -71,6 +76,7 @@
             <Chinese>頭部</Chinese>
             <Chinesesimp>Head</Chinesesimp>
             <Dutch>Hoofd</Dutch>
+            <Turkish>Kafa</Turkish>
         </Key>
         <Key ID="STR_KAT_GUI_IVFlowTitle">
             <English>IV Flow Control</English>
@@ -83,6 +89,7 @@
             <Chinese>IV輸液流速控制</Chinese>
             <Chinesesimp>IV 流量控制</Chinesesimp>
             <Dutch>IV-Stroomregeling</Dutch>
+            <Turkish>IV Akış Kontrolü</Turkish>
         </Key>
         <Key ID="STR_KAT_GUI_IVValue">
             <English>0.0</English>
@@ -94,6 +101,7 @@
             <Japanese>0.0</Japanese>
             <Chinesesimp>0</Chinesesimp>
             <Dutch>0.0</Dutch>
+            <Turkish>0.0</Turkish>
         </Key>
         <Key ID="STR_KAT_GUI_LArmCover">
             <English>LEFT ARM - NO LINE</English>
@@ -106,6 +114,7 @@
             <Chinese>左臂 - 無線</Chinese>
             <Chinesesimp>左臂--无线路</Chinesesimp>
             <Dutch>LINKERARM - GEEN LIJN</Dutch>
+            <Turkish>SOL KOL – HAT YOK</Turkish>
         </Key>
         <Key ID="STR_KAT_GUI_LArmTitle">
             <English>LA</English>
@@ -118,6 +127,7 @@
             <Chinese>左臂</Chinese>
             <Chinesesimp>左臂</Chinesesimp>
             <Dutch>LA</Dutch>
+            <Turkish>SOLK</Turkish>
         </Key>
         <Key ID="STR_KAT_GUI_LLegCover">
             <English>LEFT LEG - NO LINE</English>
@@ -130,6 +140,7 @@
             <Chinese>左腳 - 無線</Chinese>
             <Chinesesimp>左腿--无线路</Chinesesimp>
             <Dutch>LINKERBEEN - GEEN LIJN</Dutch>
+            <Turkish>SOL BACAK – HAT YOK</Turkish>
         </Key>
         <Key ID="STR_KAT_GUI_LLegTitle">
             <English>LL</English>
@@ -142,6 +153,7 @@
             <Chinese>左腳</Chinese>
             <Chinesesimp>左脚</Chinesesimp>
             <Dutch>LB</Dutch>
+            <Turkish>SOLB</Turkish>
         </Key>
         <Key ID="STR_KAT_GUI_RArmCover">
             <English>RIGHT ARM - NO LINE</English>
@@ -154,6 +166,7 @@
             <Chinese>右臂 - 無線</Chinese>
             <Chinesesimp>右臂--无线路</Chinesesimp>
             <Dutch>RECHTERARM - GEEN LIJN</Dutch>
+            <Turkish>SAĞ KOL – HAT YOK</Turkish>
         </Key>
         <Key ID="STR_KAT_GUI_RArmTitle">
             <English>RA</English>
@@ -166,6 +179,7 @@
             <Chinese>右臂</Chinese>
             <Chinesesimp>右臂</Chinesesimp>
             <Dutch>RA</Dutch>
+            <Turkish>SAĞK</Turkish>
         </Key>
         <Key ID="STR_KAT_GUI_RLegCover">
             <English>RIGHT LEG - NO LINE</English>
@@ -178,6 +192,7 @@
             <Chinese>右腳 - 無線</Chinese>
             <Chinesesimp>右腿--无线路</Chinesesimp>
             <Dutch>RECHTERBEEN - GEEN LIJN</Dutch>
+            <Turkish>SAĞ BACAK – HAT YOK</Turkish>
         </Key>
         <Key ID="STR_KAT_GUI_RLegTitle">
             <English>RL</English>
@@ -190,6 +205,7 @@
             <Chinese>右腳</Chinese>
             <Chinesesimp>右脚</Chinesesimp>
             <Dutch>RB</Dutch>
+            <Turkish>SAĞB</Turkish>
         </Key>
         <Key ID="STR_KAT_GUI_SETTING_ColoredLogs">
             <English>Colored activitylogs (AED-X/Pulseoximeter)</English>
@@ -205,7 +221,7 @@
             <Japanese>色付きの活動ログ (AED-X / パルスオキシメーター)</Japanese>
             <Chinese>彩色活動記錄(AED-X/脈搏血氧儀)</Chinese>
             <Chinesesimp>彩色活动记录(AED-X/脉冲氧饱和度仪)</Chinesesimp>
-            <Turkish>Renkli aktivite günlükleri (AED-X / Pulseoximeter)</Turkish>
+            <Turkish>Renkli aktivite kayıtları (AED-X / Pulseoksimetre)</Turkish>
             <Finnish>Värilliset aktiivisuuslokit (AUD-X/pulssioksimetri)</Finnish>
             <Dutch>Gekleurde activiteitslogs (AED-X/Pulseoximeter)</Dutch>
         </Key>
@@ -223,7 +239,7 @@
             <Japanese>重要な値の場合、AED-Xやパルスオキシメーターの活動ログを赤色にします。</Japanese>
             <Chinese>當AED-X或脈搏血氧儀的任何數值達到危急值時，活動記錄將以紅色顯示。</Chinese>
             <Chinesesimp>若任何数据处于危险中(处于临界值以下),将AED-X或脉搏血氧仪的数值显示为红色</Chinesesimp>
-            <Turkish>Herhangi bir değer kritikse, AED-X veya Pulseoximeter Activitylog'larını kırmızı renklendirir</Turkish>
+            <Turkish>Herhangi bir değer kritikse AED-X veya Pulseoksimetre aktivite kayıtlarını kırmızı renkte gösterir</Turkish>
             <Finnish>Värjää AED-X:n tai pulssioksimetrin toimintalokit punaisiksi, jos jokin arvo on kriittinen.</Finnish>
             <Dutch>Kleurt de activiteitslogs van de AED-X of de pulsoximeter rood als een waarde kritiek is.</Dutch>
         </Key>
@@ -242,6 +258,7 @@
             <Chinesesimp>查看患者标签</Chinesesimp>
             <Finnish>Merkitse potilaan sivut</Finnish>
             <Dutch>Label zijden van patiënt</Dutch>
+            <Turkish>Herhangi bir değer kritikse AED-X veya Pulseoksimetre aktivite kayıtlarını kırmızı renkte gösterir</Turkish>
         </Key>
         <Key ID="STR_KAT_GUI_SubCategory_Basic">
             <English>Basic Settings</English>
@@ -259,6 +276,7 @@
             <Chinesesimp>基础设置</Chinesesimp>
             <Finnish>Perus asetukset</Finnish>
             <Dutch>Basisinstellingen</Dutch>
+            <Turkish>Temel Ayarlar</Turkish>
         </Key>
         <Key ID="STR_KAT_GUI_TestReset">
             <English>Reset</English>
@@ -280,6 +298,7 @@
             <German>KAT - ADV Medical: GUI</German>
             <Japanese>KAM - GUI</Japanese>
             <Dutch>KAT - ADV Medical: GUI</Dutch>
+            <Turkish>KAT – Gelişmiş Tıp: Arayüz</Turkish>
         </Key>
     </Package>
 </Project>

--- a/addons/gui/stringtable.xml
+++ b/addons/gui/stringtable.xml
@@ -289,6 +289,7 @@
             <Chinese>重置</Chinese>
             <Chinesesimp>重置</Chinesesimp>
             <Dutch>Reset</Dutch>
+            <Turkish>Sıfırla</Turkish>
         </Key>
         <Key ID="STR_KAT_GUI_cba_name">
             <English>KAT - ADV Medical: GUI</English>

--- a/addons/hypothermia/stringtable.xml
+++ b/addons/hypothermia/stringtable.xml
@@ -12,6 +12,7 @@
             <Chinese>連接輸液加溫器</Chinese>
             <Chinesesimp>连接油液加热器</Chinesesimp>
             <Dutch>Maak vloeistofverwarmer vast</Dutch>
+            <Turkish>Sıvı Isıtıcıyı Tak</Turkish>
         </Key>
         <Key ID="STR_KAT_Hypothermia_Check_Hand_Warmers">
             <English>Check Hand Warmers</English>
@@ -24,6 +25,7 @@
             <Chinese>正在檢查暖暖包</Chinese>
             <Chinesesimp>检查暖手器</Chinesesimp>
             <Dutch>Check handwarmers</Dutch>
+            <Turkish>El Isıtıcılarını Kontrol Et</Turkish>
         </Key>
         <Key ID="STR_KAT_Hypothermia_Check_Temperature">
             <English>Check Temperature</English>
@@ -36,6 +38,7 @@
             <Chinese>測量體溫</Chinese>
             <Chinesesimp>检查温度</Chinesesimp>
             <Dutch>Check temperatuur</Dutch>
+            <Turkish>Sıcaklığı Kontrol Et</Turkish>
         </Key>
         <Key ID="STR_KAT_Hypothermia_Check_Temperature_Progress">
             <English>Checking Temperature</English>
@@ -48,6 +51,7 @@
             <Chinese>正在測量體溫</Chinese>
             <Chinesesimp>检查温度</Chinesesimp>
             <Dutch>Temperatuur wordt gecheckt</Dutch>
+            <Turkish>Sıcaklık Kontrol Ediliyor</Turkish>
         </Key>
         <Key ID="STR_KAT_Hypothermia_ENABLE_HYPOTHERMIA">
             <English>Enable Hypothermia</English>
@@ -60,6 +64,7 @@
             <Chinese>啟用身溫降低</Chinese>
             <Chinesesimp>启用低温</Chinesesimp>
             <Dutch>Schakel hypothermie in</Dutch>
+            <Turkish>Hipotermiyi Etkinleştir</Turkish>
         </Key>
         <Key ID="STR_KAT_Hypothermia_ENABLE_HYPOTHERMIA_DESC">
             <English>Enables the hypothermia system</English>
@@ -67,6 +72,7 @@
             <Spanish>Activa el sistema de hipotermia</Spanish>
             <German>Aktiviert das Hypothermie-System</German>
             <Japanese>低体温症システムを有効化します</Japanese>
+            <Turkish>Hipotermi sistemini etkinleştirir</Turkish>
         </Key>
         <Key ID="STR_KAT_Hypothermia_FluidWarmer_DescShort">
             <English>Provides heating to IV fluids. Must be placed on an already existing line</English>
@@ -79,6 +85,7 @@
             <Chinese>為IV輸液加溫。必須置於現有輸液管線上。</Chinese>
             <Chinesesimp>为静脉输液提供加热。必须放置在已存在的线上</Chinesesimp>
             <Dutch>Verwarmt IV-vloeistoffen. Moet geplaatst worden op een al aangelegde lijn.</Dutch>
+            <Turkish>IV sıvılara ısı sağlar. Mevcut bir hatta takılmalıdır</Turkish>
         </Key>
         <Key ID="STR_KAT_Hypothermia_FluidWarmer_displayName">
             <English>Fluid Line Warmer</English>
@@ -91,6 +98,7 @@
             <Chinese>輸液管加溫器</Chinese>
             <Chinesesimp>流体管路加热器</Chinesesimp>
             <Dutch>IV-lijn verwarmers</Dutch>
+            <Turkish>Sıvı Hat Isıtıcısı</Turkish>
         </Key>
         <Key ID="STR_KAT_Hypothermia_HandWarmer_Body">
             <English>Body: %1</English>
@@ -103,6 +111,7 @@
             <Chinese>軀幹：%1</Chinese>
             <Chinesesimp>躯干：%1</Chinesesimp>
             <Dutch>Torso: %1</Dutch>
+            <Turkish>Sıvı Hat Isıtıcısı</Turkish>
         </Key>
         <Key ID="STR_KAT_Hypothermia_HandWarmer_Body_None">
             <English>Body: None</English>
@@ -115,6 +124,7 @@
             <Chinese>軀幹：無</Chinese>
             <Chinesesimp>躯干：无</Chinesesimp>
             <Dutch>Torso: Geen</Dutch>
+            <Turkish>Vücut: Yok</Turkish>
         </Key>
         <Key ID="STR_KAT_Hypothermia_HandWarmer_DescShort">
             <English>Small hand warmers to provide warmth in colder climates</English>
@@ -127,6 +137,7 @@
             <Chinese>在寒冷氣候下提供溫暖的小型暖暖包</Chinese>
             <Chinesesimp>小型暖手器，在寒冷气候下提供温暖</Chinesesimp>
             <Dutch>Kleine handwarmers die warmte bieden in koude klimaten</Dutch>
+            <Turkish>Soğuk iklimlerde ısı sağlamak için küçük el ısıtıcıları</Turkish>
         </Key>
         <Key ID="STR_KAT_Hypothermia_HandWarmer_LArm">
             <English>Left Arm: %1</English>
@@ -139,6 +150,7 @@
             <Chinese>左臂：%1</Chinese>
             <Chinesesimp>左臂：%1</Chinesesimp>
             <Dutch>Linkerarm: %1</Dutch>
+            <Turkish>Sol Kol: %1</Turkish>
         </Key>
         <Key ID="STR_KAT_Hypothermia_HandWarmer_LArm_None">
             <English>Left Arm: None</English>
@@ -151,6 +163,7 @@
             <Chinese>左臂：無</Chinese>
             <Chinesesimp>左臂：无</Chinesesimp>
             <Dutch>Linkerarm: Geen</Dutch>
+            <Turkish>Sol Kol: Yok</Turkish>
         </Key>
         <Key ID="STR_KAT_Hypothermia_HandWarmer_LLeg">
             <English>Left Leg: %1</English>
@@ -163,6 +176,7 @@
             <Chinese>左腳：%1</Chinese>
             <Chinesesimp>左腿：%1</Chinesesimp>
             <Dutch>Linkerbeen: %1</Dutch>
+            <Turkish>Sol Bacak: %1</Turkish>
         </Key>
         <Key ID="STR_KAT_Hypothermia_HandWarmer_LLeg_None">
             <English>Left Leg: None</English>
@@ -175,6 +189,7 @@
             <Chinese>左腳：無</Chinese>
             <Chinesesimp>左腿：无</Chinesesimp>
             <Dutch>Linkerbeen: Geen</Dutch>
+            <Turkish>Sol Bacak: Yok</Turkish>
         </Key>
         <Key ID="STR_KAT_Hypothermia_HandWarmer_None">
             <English>No Hand Warmers are active at this time</English>
@@ -187,6 +202,7 @@
             <Chinese>目前沒有啟動任何暖暖包</Chinese>
             <Chinesesimp>此时没有激活的暖手器</Chinesesimp>
             <Dutch>Momenteel zijn er geen handwarmers actief</Dutch>
+            <Turkish>Şu anda aktif el ısıtıcısı yok</Turkish>
         </Key>
         <Key ID="STR_KAT_Hypothermia_HandWarmer_RArm">
             <English>Right Arm: %1</English>
@@ -199,6 +215,7 @@
             <Chinese>右臂：%1</Chinese>
             <Chinesesimp>右臂：%1</Chinesesimp>
             <Dutch>Rechterarm: %1</Dutch>
+            <Turkish>Sağ Kol: %1</Turkish>
         </Key>
         <Key ID="STR_KAT_Hypothermia_HandWarmer_RArm_None">
             <English>Right Arm: None</English>
@@ -210,6 +227,7 @@
             <Japanese>右腕: なし</Japanese>
             <Chinesesimp>右臂：无</Chinesesimp>
             <Dutch>Rechterarm: Geen</Dutch>
+            <Turkish>Sağ Kol: Yok</Turkish>
         </Key>
         <Key ID="STR_KAT_Hypothermia_HandWarmer_RLeg">
             <English>Right Leg: %1</English>
@@ -222,6 +240,7 @@
             <Chinese>右腳：%1</Chinese>
             <Chinesesimp>右腿：%1</Chinesesimp>
             <Dutch>Rechterbeen: %1</Dutch>
+            <Turkish>Sağ Bacak: %1</Turkish>
         </Key>
         <Key ID="STR_KAT_Hypothermia_HandWarmer_RLeg_None">
             <English>Right Leg: None</English>
@@ -234,6 +253,7 @@
             <Chinese>右腳：無</Chinese>
             <Chinesesimp>右腿：无</Chinesesimp>
             <Dutch>Rechterbeen: Geen</Dutch>
+            <Turkish>Sağ Bacak: Yok</Turkish>
         </Key>
         <Key ID="STR_KAT_Hypothermia_HandWarmer_displayName">
             <English>Hand Warmer</English>
@@ -246,6 +266,7 @@
             <Chinese>暖暖包</Chinese>
             <Chinesesimp>暖手器</Chinesesimp>
             <Dutch>Handwarmers</Dutch>
+            <Turkish>El Isıtıcısı</Turkish>
         </Key>
         <Key ID="STR_KAT_Hypothermia_LineWarmer">
             <English>Line Warmer Active</English>
@@ -258,6 +279,7 @@
             <Chinese>輸液加溫器已啟動</Chinese>
             <Chinesesimp>线路加热器已激活</Chinesesimp>
             <Dutch>Lijnwarmer actief</Dutch>
+            <Turkish>Hat Isıtıcısı Aktif</Turkish>
         </Key>
         <Key ID="STR_KAT_Hypothermia_Other_Handwarmer_Output">
             <English>This patient has handwarmers and they will probably last this many more minutes at this locations: %1, %2, %3, %4, %5</English>
@@ -270,6 +292,7 @@
             <Chinese>該患者目前使用的暖暖包位置及剩餘可用時間（分鐘）：%1、%2、%3、%4、%5</Chinese>
             <Chinesesimp>该患者有暖手器，他们还有多长的持续时间：%1、%2、%3、%4、%5</Chinesesimp>
             <Dutch>Deze patient heeft handwarmers op deze locaties en dit is hoelang ze ongeveer nog werken: %1, %2, %3, %4, %5</Dutch>
+            <Turkish>Bu hastada el ısıtıcıları var ve şu bölgelerde yaklaşık şu kadar dakika daha dayanacaklar: %1, %2, %3, %4, %5</Turkish>
         </Key>
         <Key ID="STR_KAT_Hypothermia_Remove_Warmer">
             <English>Remove Fluid Warmer</English>
@@ -282,6 +305,7 @@
             <Chinese>移除輸液加溫器</Chinese>
             <Chinesesimp>拆下油液加热器</Chinesesimp>
             <Dutch>Maak vloeistofverwarmer los</Dutch>
+            <Turkish>Sıvı Isıtıcıyı Çıkar</Turkish>
         </Key>
         <Key ID="STR_KAT_Hypothermia_Self_Handwarmer_Output">
             <English>This is where you have handwarmers and how much longer you think they have in minutes: %1, %2, %3, %4, %5</English>
@@ -294,6 +318,7 @@
             <Chinese>您目前使用的暖暖包位置及剩餘可用時間（分鐘）：%1、%2、%3、%4、%5</Chinese>
             <Chinesesimp>这是您有暖手器的地方，以及您认为他们还有多长的持续时间：%1、%2、%3、%4、%5</Chinesesimp>
             <Dutch>Dit is waar je handwarmers hebt en hoelang je denkt dat ze nog werken in minuten: %1, %2, %3, %4, %5</Dutch>
+            <Turkish>El ısıtıcılarının bulunduğu yerler ve tahmini kalan süreleri (dakika): %1, %2, %3, %4, %5</Turkish>
         </Key>
         <Key ID="STR_KAT_Hypothermia_SubCategory_Hypothermia">
             <English>Hypothermia Settings</English>
@@ -303,6 +328,7 @@
             <German>Hypothermieeinstellungen</German>
             <Japanese>低体温症設定</Japanese>
             <Dutch>Hypothermie instellingen</Dutch>
+            <Turkish>Hipotermi Ayarları</Turkish>
         </Key>
         <Key ID="STR_KAT_Hypothermia_Use_Handwarmer">
             <English>Use Hand Warmer</English>
@@ -315,6 +341,7 @@
             <Chinese>使用暖暖包</Chinese>
             <Chinesesimp>使用暖手器</Chinesesimp>
             <Dutch>Gebruik handwarmer</Dutch>
+            <Turkish>El Isıtıcısı Kullan</Turkish>
         </Key>
         <Key ID="STR_KAT_Hypothermia_Using">
             <English>Using</English>
@@ -342,6 +369,7 @@
             <German>KAT - ADV Medical: Hypothermie</German>
             <Japanese>KAM - 低体温症 (Hypothermia)</Japanese>
             <Dutch>KAT - ADV Medical: Hypothermie</Dutch>
+            <Turkish>KAT – Gelişmiş Tıp: Hipotermi</Turkish>
         </Key>
         <Key ID="STR_KAT_Hypothermia_perform">
             <English>Performing</English>
@@ -354,6 +382,7 @@
             <Chinese>正在執行</Chinese>
             <Chinesesimp>执行</Chinesesimp>
             <Dutch>Wordt uitgevoerd</Dutch>
+            <Turkish>Uygulanıyor</Turkish>
         </Key>
         <Key ID="STR_KAT_Hypothermia_temperature_cold">
             <English>Patient feels remarkably cold</English>
@@ -366,6 +395,7 @@
             <Chinese>患者感到非常寒冷</Chinese>
             <Chinesesimp>患者感觉非常冷</Chinesesimp>
             <Dutch>Patiënt voel opmerkelijk koud aan</Dutch>
+            <Turkish>Hasta aşırı derecede üşüyor</Turkish>
         </Key>
         <Key ID="STR_KAT_Hypothermia_temperature_cool">
             <English>Patient feels moderately cold</English>
@@ -378,6 +408,7 @@
             <Chinese>患者感到有些寒冷</Chinese>
             <Chinesesimp>患者感觉中度寒冷</Chinesesimp>
             <Dutch>Patiënt voelt redelijk koud aan</Dutch>
+            <Turkish>Hasta orta derecede üşüyor</Turkish>
         </Key>
         <Key ID="STR_KAT_Hypothermia_temperature_dead">
             <English>Patient feels frigid</English>
@@ -390,6 +421,7 @@
             <Chinese>患者感到極度寒冷</Chinese>
             <Chinesesimp>患者感觉发冷</Chinesesimp>
             <Dutch>Patiënt voelt ijskoud aan</Dutch>
+            <Turkish>Hasta donacak kadar soğuk hissediyor</Turkish>
         </Key>
         <Key ID="STR_KAT_Hypothermia_temperature_hot">
             <English>Patient feels hot</English>
@@ -401,6 +433,7 @@
             <Japanese>患者は熱を帯びている</Japanese>
             <Chinese>患者覺得熱</Chinese>
             <Dutch>Patiënt voelt heet aan</Dutch>
+            <Turkish>Hasta donacak kadar soğuk hissediyor</Turkish>
         </Key>
         <Key ID="STR_KAT_Hypothermia_temperature_mild">
             <English>Patient feels mildly cool</English>
@@ -413,6 +446,7 @@
             <Chinese>患者感到稍微涼爽</Chinese>
             <Chinesesimp>患者感觉有点凉</Chinesesimp>
             <Dutch>Patiënt voelt een klein beetje koud aan</Dutch>
+            <Turkish>Hasta hafif serin hissediyor</Turkish>
         </Key>
         <Key ID="STR_KAT_Hypothermia_temperature_warm">
             <English>Patient feels warm</English>
@@ -425,6 +459,7 @@
             <Chinese>患者感到溫暖</Chinese>
             <Chinesesimp>患者感觉温暖</Chinesesimp>
             <Dutch>Patiënt voelt warm aan</Dutch>
+            <Turkish>Hasta sıcak hissediyor</Turkish>
         </Key>
     </Package>
 </Project>

--- a/addons/main/stringtable.xml
+++ b/addons/main/stringtable.xml
@@ -14,6 +14,7 @@
             <Japanese>https://github.com/KAT-Advanced-Medical/KAM</Japanese>
             <Finnish>https://github.com/KAT-Advanced-Medical/KAM</Finnish>
             <Dutch>https://github.com/KAT-Advanced-Medical/KAM</Dutch>
+            <Turkish>https://github.com/KAT-Advanced-Medical/KAM</Turkish>
         </Key>
     </Package>
 </Project>

--- a/addons/misc/stringtable.xml
+++ b/addons/misc/stringtable.xml
@@ -15,6 +15,7 @@
             <Chinesesimp>AFAK可以拆开包装，提供有用的医疗用品</Chinesesimp>
             <Finnish>AFAK voidaan purkaa pakkauksestaan hyödyllisten lääketieteellisten tarvikkeiden saamiseksi</Finnish>
             <Dutch>de AFAK kan uitgepakt worden om nuttige producten te verschaffen</Dutch>
+            <Turkish>AFAK, faydalı tıbbi eşyalar sağlamak için açılabilir</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_AFAK_Display">
             <English>Advanced First Aid Kit</English>
@@ -30,6 +31,7 @@
             <Chinesesimp>高级急救包 (AFAK)</Chinesesimp>
             <Finnish>Edistyksellinen ensiapulaukku</Finnish>
             <Dutch>Geadvanceerde Eerste hulpskit</Dutch>
+            <Turkish>Gelişmiş İlk Yardım Kiti (AFAK)</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_AFAK_Unpack">
             <English>AFAK</English>
@@ -44,6 +46,7 @@
             <Chinesesimp>AFAK</Chinesesimp>
             <Finnish>AFAK</Finnish>
             <Dutch>AFAK</Dutch>
+            <Turkish>AFAK</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_Action_add_IV">
             <English>Attaching IV</English>
@@ -132,6 +135,7 @@
             <Chinesesimp>医生Doctor臂章</Chinesesimp>
             <Finnish>Käsivarsinauha lääkärille</Finnish>
             <Dutch>Armband doktor</Dutch>
+            <Turkish>Kol Bandı – Doktor</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_Armband_Kat_ItemName">
             <English>Armband KAT</English>
@@ -148,6 +152,7 @@
             <Chinesesimp>KAT臂章</Chinesesimp>
             <Finnish>Käsivarsinauha KAT</Finnish>
             <Dutch>Armband KAT</Dutch>
+            <Turkish>Kol Bandı – KAT</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_Armband_Medic_ItemName">
             <English>Armband Medic</English>
@@ -164,6 +169,7 @@
             <Chinesesimp>医务兵臂章</Chinesesimp>
             <Finnish>Käsivarsinauha taistelulääkärille</Finnish>
             <Dutch>Armband medici</Dutch>
+            <Turkish>Kol Bandı – Medik</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_Armband_Red_Cross_ItemName">
             <English>Armband Red Cross</English>
@@ -180,6 +186,7 @@
             <Chinesesimp>红十字臂章</Chinesesimp>
             <Finnish>Käsivarsinauha punainen risti</Finnish>
             <Dutch>Armband Rode kruiz</Dutch>
+            <Turkish>Kol Bandı – Kızıl Haç</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_Armband_Sling">
             <English>Armband</English>
@@ -196,6 +203,7 @@
             <Chinesesimp>臂章</Chinesesimp>
             <Finnish>Käsivarsinauha</Finnish>
             <Dutch>Armband</Dutch>
+            <Turkish>Kol Bandı</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_Armband_Sling_Left_Arm">
             <English>Sling to left arm</English>
@@ -212,6 +220,7 @@
             <Chinesesimp>吊至左臂</Chinesesimp>
             <Finnish>Ripusta vasempaan käsivarteen</Finnish>
             <Dutch>Bind aan linkerarm</Dutch>
+            <Turkish>Sol kola askı tak</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_Armband_Sling_Left_Leg">
             <English>Sling to left leg</English>
@@ -228,6 +237,7 @@
             <Chinesesimp>吊至左腿</Chinesesimp>
             <Finnish>Ripusta vasemmassa jalassa</Finnish>
             <Dutch>Bind aan linkerbeen</Dutch>
+            <Turkish>Sol bacağa askı tak</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_Armband_Sling_Right_Arm">
             <English>Sling to right arm</English>
@@ -244,6 +254,7 @@
             <Chinesesimp>吊至右臂</Chinesesimp>
             <Finnish>Ripusta oikeaan käsivarteen</Finnish>
             <Dutch>Bind aan rechterarm</Dutch>
+            <Turkish>Sol bacağa askı tak</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_Armband_Sling_Right_Leg">
             <English>Sling to right leg</English>
@@ -260,6 +271,7 @@
             <Chinesesimp>吊至右腿</Chinesesimp>
             <Finnish>Ripusta oikeaan jalkaan</Finnish>
             <Dutch>Bind aan rechterbeen</Dutch>
+            <Turkish>Sağ kola askı tak</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_Armband_UnSling_Left_Arm">
             <English>Unsling left arm</English>
@@ -276,6 +288,7 @@
             <Chinesesimp>从左臂移除</Chinesesimp>
             <Finnish>Irrotus vasemmasta kädestä</Finnish>
             <Dutch>Van linkerarm losmaken</Dutch>
+            <Turkish>Sol kol askısını çıkar</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_Armband_UnSling_Left_Leg">
             <English>Unsling left leg</English>
@@ -292,6 +305,7 @@
             <Chinesesimp>从左腿移除</Chinesesimp>
             <Finnish>Irrotus vasemmasta jalasta</Finnish>
             <Dutch>Van linkerbeen losmaken</Dutch>
+            <Turkish>Sol kol askısını çıkar</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_Armband_UnSling_Right_Arm">
             <English>Unsling right arm</English>
@@ -308,6 +322,7 @@
             <Chinesesimp>从右臂移除</Chinesesimp>
             <Finnish>Irrotus oikeasta kädestä</Finnish>
             <Dutch>Van rechterarm losmaken</Dutch>
+            <Turkish>Sağ kol askısını çıkar</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_Armband_UnSling_Right_Leg">
             <English>Unsling right leg</English>
@@ -324,6 +339,7 @@
             <Chinesesimp>从右腿移除</Chinesesimp>
             <Finnish>Irrotus oikeasta jalasta</Finnish>
             <Dutch>Van rechterbeen losmaken</Dutch>
+            <Turkish>Sağ kol askısını çıkar</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_BloodGroupPatch_0_N">
             <English>Blood Group Patch 0-</English>
@@ -340,6 +356,7 @@
             <Chinesesimp>血型臂章 O-</Chinesesimp>
             <Finnish>Veriryhmälaastari O-</Finnish>
             <Dutch>Bloedgroep lapje 0-</Dutch>
+            <Turkish>Kan Grubu Yaması 0-</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_BloodGroupPatch_0_P">
             <English>Blood Group Patch 0+</English>
@@ -356,6 +373,7 @@
             <Chinesesimp>血型臂章 O+</Chinesesimp>
             <Finnish>Veriryhmälaastari O+</Finnish>
             <Dutch>Bloedgroep lapje 0+</Dutch>
+            <Turkish>Kan Grubu Yaması 0+</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_BloodGroupPatch_AB_N">
             <English>Blood Group Patch AB-</English>
@@ -372,6 +390,7 @@
             <Chinesesimp>血型臂章 AB-</Chinesesimp>
             <Finnish>Veriryhmälaastari AB-</Finnish>
             <Dutch>Bloedgroep lapje AB-</Dutch>
+            <Turkish>Kan Grubu Yaması AB-</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_BloodGroupPatch_AB_P">
             <English>Blood Group Patch AB+</English>
@@ -388,6 +407,7 @@
             <Chinesesimp>血型臂章 AB+</Chinesesimp>
             <Finnish>Veriryhmälaastari AB+</Finnish>
             <Dutch>Bloedgroep lapje AB+</Dutch>
+            <Turkish>Kan Grubu Yaması AB+</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_BloodGroupPatch_A_N">
             <English>Blood Group Patch A-</English>
@@ -404,6 +424,7 @@
             <Chinesesimp>血型臂章 A-</Chinesesimp>
             <Finnish>Veriryhmälaastari A-</Finnish>
             <Dutch>Bloedgroep lapje A-</Dutch>
+            <Turkish>Kan Grubu Yaması A-</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_BloodGroupPatch_A_P">
             <English>Blood Group Patch A+</English>
@@ -420,6 +441,7 @@
             <Chinesesimp>血型臂章 A+</Chinesesimp>
             <Finnish>Veriryhmälaastari A+</Finnish>
             <Dutch>Bloedgroep lapje A+</Dutch>
+            <Turkish>Kan Grubu Yaması A+</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_BloodGroupPatch_B_N">
             <English>Blood Group Patch B-</English>
@@ -436,6 +458,7 @@
             <Chinesesimp>血型臂章 B-</Chinesesimp>
             <Finnish>Veriryhmälaastari B-</Finnish>
             <Dutch>Bloedgroep lapje B-</Dutch>
+            <Turkish>Kan Grubu Yaması B-</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_BloodGroupPatch_B_P">
             <English>Blood Group Patch B+</English>
@@ -452,6 +475,7 @@
             <Chinesesimp>血型臂章 B+</Chinesesimp>
             <Finnish>Veriryhmälaastari B+</Finnish>
             <Dutch>Bloedgroep lapje B+</Dutch>
+            <Turkish>Kan Grubu Yaması B+</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_Bubble_Wrap_Ace_Action">
             <English>Pop a Bubble</English>
@@ -468,6 +492,7 @@
             <Chinesesimp>戳破一个气泡</Chinesesimp>
             <Finnish>Poksauta</Finnish>
             <Dutch>Pop een luchtbel</Dutch>
+            <Turkish>Balon Patlat</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_Bubble_Wrap_Desc">
             <English>A Bubble Wrap that you can squeeze to relive some pain</English>
@@ -484,6 +509,7 @@
             <Chinesesimp>一个你可以挤压的泡泡膜来舒缓一些痛苦</Chinesesimp>
             <Finnish>Kuplakääre, jota voit puristaa lievittääksesi kipua</Finnish>
             <Dutch>Noppenfolie, wat je kan gebruiken om pijn te verlichten</Dutch>
+            <Turkish>Biraz ağrıyı hafifletmek için sıkabileceğin balonlu naylon</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_Bubble_Wrap_Display">
             <English>Bubble Wrap</English>
@@ -500,6 +526,7 @@
             <Chinesesimp>气泡膜</Chinesesimp>
             <Finnish>Kuplamuovia</Finnish>
             <Dutch>Noppenfolie</Dutch>
+            <Turkish>Balonlu Naylon</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_CancelCarrying">
             <English>Cancel Carrying</English>
@@ -516,6 +543,7 @@
             <Chinesesimp>取消携带</Chinesesimp>
             <Finnish>Peruuta potilaan kuljettaminen</Finnish>
             <Dutch>Dragen annuleren</Dutch>
+            <Turkish>Taşımayı İptal Et</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_CarryPatient">
             <English>Carry Patient</English>
@@ -532,6 +560,7 @@
             <Chinesesimp>携带患者</Chinesesimp>
             <Finnish>Kanna potilasta</Finnish>
             <Dutch>Draag patiënt</Dutch>
+            <Turkish>Hastayı Taşı</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_Display_IVStand">
             <English>Stand: Saline IV (1000ml)</English>
@@ -600,6 +629,7 @@
             <Chinese>查看裝箱清單</Chinese>
             <Chinesesimp>查看装箱清单</Chinesesimp>
             <Dutch>Zie paklijst</Dutch>
+            <Turkish>Paketleme Listesini Görüntüle</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_FAK_Slot_1">
             <English>Unpack Trauma Section</English>
@@ -614,6 +644,7 @@
             <Chinese>拆封創傷部分</Chinese>
             <Chinesesimp>打开创伤部分</Chinesesimp>
             <Dutch>Pak trauma sectie uit</Dutch>
+            <Turkish>Travma Bölümünü Aç</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_FAK_Slot_1_Hint">
             <English>Trauma Section:</English>
@@ -628,6 +659,7 @@
             <Chinese>創傷部分:</Chinese>
             <Chinesesimp>创伤部分:</Chinesesimp>
             <Dutch>Trauma sectie:</Dutch>
+            <Turkish>Travma Bölümü:</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_FAK_Slot_1_Repack">
             <English>Repack Trauma Section</English>
@@ -642,6 +674,7 @@
             <Chinese>裝回創傷部分</Chinese>
             <Chinesesimp>重装创伤部分</Chinesesimp>
             <Dutch>Herpak trauma sectie</Dutch>
+            <Turkish>Travma Bölümünü Yeniden Paketle</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_FAK_Slot_2">
             <English>Unpack Bandage Section</English>
@@ -656,6 +689,7 @@
             <Chinese>拆封繃帶部分</Chinese>
             <Chinesesimp>拆包绷带部分</Chinesesimp>
             <Dutch>Pak verbandssectie uit</Dutch>
+            <Turkish>Bandaj Bölümünü Aç</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_FAK_Slot_2_Hint">
             <English>Bandage Section:</English>
@@ -670,6 +704,7 @@
             <Chinese>繃帶部分:</Chinese>
             <Chinesesimp>绷带部分:</Chinesesimp>
             <Dutch>Verbandssectie:</Dutch>
+            <Turkish>Bandaj Bölümü:</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_FAK_Slot_2_Repack">
             <English>Repack Bandage Section</English>
@@ -684,6 +719,7 @@
             <Chinese>裝回繃帶部分</Chinese>
             <Chinesesimp>重装绷带部分</Chinesesimp>
             <Dutch>Herpak verbandssectie</Dutch>
+            <Turkish>Bandaj Bölümünü Aç</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_FAK_Slot_3">
             <English>Unpack Pain Management Section</English>
@@ -698,6 +734,7 @@
             <Chinese>拆封疼痛管理部分</Chinese>
             <Chinesesimp>打开疼痛管理部分</Chinesesimp>
             <Dutch>Pak pijnbestrijdingssectie uit</Dutch>
+            <Turkish>Ağrı Yönetimi Bölümünü Aç</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_FAK_Slot_3_Hint">
             <English>Pain Management Section:</English>
@@ -712,6 +749,7 @@
             <Chinese>疼痛管理部分:</Chinese>
             <Chinesesimp>疼痛管理部分:</Chinesesimp>
             <Dutch>Pijnbestrijdingssectie:</Dutch>
+            <Turkish>Ağrı Yönetimi Bölümü:</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_FAK_Slot_3_Repack">
             <English>Repack Pain Management Section</English>
@@ -726,6 +764,7 @@
             <Chinese>裝回疼痛管理部分</Chinese>
             <Chinesesimp>重装疼痛管理部分</Chinesesimp>
             <Dutch>Herpack pijnbestrijdingssectie</Dutch>
+            <Turkish>Ağrı Yönetimi Bölümünü Yeniden Paketle</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_FAK_Slot_4">
             <English>Unpack Breathing Section</English>
@@ -740,6 +779,7 @@
             <Chinese>拆封呼吸部分</Chinese>
             <Chinesesimp>打开呼吸部分</Chinesesimp>
             <Dutch>Pak ademhalingssectie uit</Dutch>
+            <Turkish>Solunum Bölümünü Aç</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_FAK_Slot_4_Hint">
             <English>Breathing Section:</English>
@@ -754,6 +794,7 @@
             <Chinese>呼吸部分:</Chinese>
             <Chinesesimp>呼吸部分:</Chinesesimp>
             <Dutch>Ademhalingssectie:</Dutch>
+            <Turkish>Solunum Bölümü:</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_FAK_Slot_4_Repack">
             <English>Repack Breathing Section</English>
@@ -768,6 +809,7 @@
             <Chinese>裝回呼吸部分</Chinese>
             <Chinesesimp>重新包装呼吸部分</Chinesesimp>
             <Dutch>Herpack ademhalingssectie</Dutch>
+            <Turkish>Solunum Bölümünü Yeniden Paketle</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_FAK_Slot_5">
             <English>Unpack Airway Section</English>
@@ -782,6 +824,7 @@
             <Chinese>拆封氣道部分</Chinese>
             <Chinesesimp>打开气道部分</Chinesesimp>
             <Dutch>Pak luchtweg sectie uit</Dutch>
+            <Turkish>Hava Yolu Bölümünü Aç</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_FAK_Slot_5_Hint">
             <English>Airway Section:</English>
@@ -796,6 +839,7 @@
             <Chinese>呼吸道部分:</Chinese>
             <Chinesesimp>气道部分:</Chinesesimp>
             <Dutch>Luchtweg sectie:</Dutch>
+            <Turkish>Hava Yolu Bölümü:</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_FAK_Slot_5_Repack">
             <English>Repack Airway Section</English>
@@ -810,6 +854,7 @@
             <Chinese>裝回氣道部分</Chinese>
             <Chinesesimp>重新包装气道部分</Chinesesimp>
             <Dutch>Herpack luchtweg sectie</Dutch>
+            <Turkish>Hava Yolu Bölümünü Yeniden Paketle</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_FAK_Slot_6">
             <English>Unpack Pharmaceutical Section</English>
@@ -824,6 +869,7 @@
             <Chinese>拆封藥劑部分</Chinese>
             <Chinesesimp>拆包药剂部分</Chinesesimp>
             <Dutch>Pak pharmaceutische sectie uit</Dutch>
+            <Turkish>Farmasötik Bölümü Aç</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_FAK_Slot_6_Hint">
             <English>Pharmaceutical Section:</English>
@@ -838,6 +884,7 @@
             <Chinese>藥物部分:</Chinese>
             <Chinesesimp>药物部分:</Chinesesimp>
             <Dutch>Pharmaceutische sectie:</Dutch>
+            <Turkish>Farmasötik Bölüm:</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_FAK_Slot_6_Repack">
             <English>Repack Pharmaceutical Section</English>
@@ -852,6 +899,7 @@
             <Chinese>裝回藥劑部分</Chinese>
             <Chinesesimp>再包装药剂部分</Chinesesimp>
             <Dutch>Herpak pharmaceutische sectie</Dutch>
+            <Turkish>Farmasötik Bölümü Yeniden Paketle</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_FAK_Slot_7">
             <English>Unpack Fluid Section</English>
@@ -866,6 +914,7 @@
             <Chinese>拆封液體部分</Chinese>
             <Chinesesimp>解封流体部分</Chinesesimp>
             <Dutch>Pak vloeistoffen sectie uit</Dutch>
+            <Turkish>Sıvı Bölümünü Aç</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_FAK_Slot_7_Hint">
             <English>Fluid Section:</English>
@@ -880,6 +929,7 @@
             <Chinese>液體部分:</Chinese>
             <Chinesesimp>液体部分:</Chinesesimp>
             <Dutch>Vloeistofsectie:</Dutch>
+            <Turkish>Sıvı Bölümü:</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_FAK_Slot_7_Repack">
             <English>Repack Fluid Section</English>
@@ -894,6 +944,7 @@
             <Chinese>裝回液體部分</Chinese>
             <Chinesesimp>重新充填流体部分</Chinesesimp>
             <Dutch>Herpak vloeistoffen sectie</Dutch>
+            <Turkish>Sıvı Bölümünü Yeniden Paketle</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_FAK_Slot_8">
             <English>Unpack Miscellaneous Section</English>
@@ -908,6 +959,7 @@
             <Chinese>拆封雜項部分</Chinese>
             <Chinesesimp>拆包杂项部分</Chinesesimp>
             <Dutch>Pak overige sectie uit</Dutch>
+            <Turkish>Çeşitli Bölümünü Aç</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_FAK_Slot_8_Hint">
             <English>Miscellaneous Section:</English>
@@ -922,6 +974,7 @@
             <Chinese>雜項部分:</Chinese>
             <Chinesesimp>杂项部分:</Chinesesimp>
             <Dutch>Overige sectie:</Dutch>
+            <Turkish>Çeşitli Bölümü:</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_FAK_Slot_8_Repack">
             <English>Repack Miscellaneous Section</English>
@@ -936,6 +989,7 @@
             <Chinese>裝回雜項部分</Chinese>
             <Chinesesimp>重新包装及杂项部分</Chinesesimp>
             <Dutch>Herpak overige sectie</Dutch>
+            <Turkish>Çeşitli Bölümünü Yeniden Paketle</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_IFAK_DESC">
             <English>The IFAK can be unpacked to provide useful medical items</English>
@@ -951,6 +1005,7 @@
             <Chinesesimp>IFAK可以拆开包装，提供有用的医疗用品</Chinesesimp>
             <Finnish>IFAK voidaan purkaa pakkauksesta hyödyllisten lääketieteellisten tarvikkeiden saamiseksi</Finnish>
             <Dutch>De IFAK kan uitgepakt worden om nuttige producten te verschaffen</Dutch>
+            <Turkish>IFAK, faydalı tıbbi eşyalar sağlamak için açılabilir</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_IFAK_Display">
             <English>Individual First Aid Kit</English>
@@ -966,6 +1021,7 @@
             <Chinesesimp>个人急救箱</Chinesesimp>
             <Finnish>Yksilöllinen ensiapulaukku</Finnish>
             <Dutch>Individuele Eerste hulpskit</Dutch>
+            <Turkish>Bireysel İlk Yardım Kiti (IFAK)</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_IFAK_Unpack">
             <English>IFAK</English>
@@ -980,6 +1036,7 @@
             <Chinesesimp>IFAK</Chinesesimp>
             <Finnish>IFAK</Finnish>
             <Dutch>IFAK</Dutch>
+            <Turkish>IFAK</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_Kat_Equipment">
             <English>KAT Equipment</English>
@@ -994,6 +1051,7 @@
             <Chinese>KAT 裝備</Chinese>
             <Chinesesimp>KAT设备</Chinesesimp>
             <Dutch>KAT apparatuur</Dutch>
+            <Turkish>KAT Ekipmanları</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_MFAK_DESC">
             <English>The MFAK can be unpacked to provide useful medical items</English>
@@ -1009,6 +1067,7 @@
             <Chinesesimp>MFAK可以拆开包装，提供有用的医疗用品</Chinesesimp>
             <Finnish>MFAK voidaan purkaa pakkauksesta hyödyllisten lääketieteellisten tarvikkeiden saamiseksi</Finnish>
             <Dutch>De MFAK kan uitgepakt worden om nuttige producten te verschaffen</Dutch>
+            <Turkish>MFAK, faydalı tıbbi eşyalar sağlamak için açılabilir</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_MFAK_Display">
             <English>Multiple First Aid Kit</English>
@@ -1024,6 +1083,7 @@
             <Chinesesimp>多重急救包</Chinesesimp>
             <Finnish>Useita ensiapulaukkuja</Finnish>
             <Dutch>Meervoudige Eerste hulpskit</Dutch>
+            <Turkish>Çoklu İlk Yardım Kiti (MFAK)</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_MFAK_Unpack">
             <English>MFAK</English>
@@ -1038,6 +1098,7 @@
             <Chinesesimp>MFAK</Chinesesimp>
             <Finnish>MFAK</Finnish>
             <Dutch>MFAK</Dutch>
+            <Turkish>MFAK</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_SETTING_ArmbandSlingLeftArmPos_Desc">
             <English>Defines the position (x, y, z) where the armband is slung to the left arm.</English>
@@ -1054,6 +1115,7 @@
             <Chinesesimp>定义臂章挂在左臂上的位置(x，y，z)。</Chinesesimp>
             <Finnish>Määrittää paikan (x, y, z), jossa käsivarsinauha on ripustettu vasempaan käsivarteen.</Finnish>
             <Dutch>Bepaald de positie (x, y, z) waar de armband om de linkerarm zit.</Dutch>
+            <Turkish>Kol bandının sol kola takıldığı konumu (x, y, z) tanımlar</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_SETTING_ArmbandSlingLeftArmPos_Display">
             <English>Armband position left arm</English>
@@ -1070,6 +1132,7 @@
             <Chinesesimp>左臂臂带位置</Chinesesimp>
             <Finnish>Käsivarsinauhan asento vasen käsi</Finnish>
             <Dutch>Armband positie linkerarm</Dutch>
+            <Turkish>Kol bandı konumu – sol kol</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_SETTING_ArmbandSlingLeftArmRot_Desc">
             <English>Defines the rotation (yaw, pitch, roll) of the armband that is slung to the left arm.</English>
@@ -1086,6 +1149,7 @@
             <Chinesesimp>定义挂在左臂上的臂章的旋转(偏航、俯仰、滚转)。</Chinesesimp>
             <Finnish>Määrittää vasempaan käsivarteen ripustetun käsivarsinauhan kiertoliikkeen (kääntö, kallistus, rullaus).</Finnish>
             <Dutch>Bepaald de rotatie (draaiing, helling en kanteling) van de armband die om de linkerarm zit</Dutch>
+            <Turkish>Sol kola takılan kol bandının dönüşünü (yaw, pitch, roll) tanımlar</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_SETTING_ArmbandSlingLeftArmRot_Display">
             <English>Armband rotation left arm</English>
@@ -1102,6 +1166,7 @@
             <Chinesesimp>臂带旋转左臂</Chinesesimp>
             <Finnish>Käsivarsinauhan kierto vasemmassa kädessä</Finnish>
             <Dutch>Armband rotatie linkerarm</Dutch>
+            <Turkish>Kol bandı dönüşü – sol kol</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_SETTING_ArmbandSlingLeftLegPos_Desc">
             <English>Defines the position (x, y, z) where the armband is slung to the left leg.</English>
@@ -1118,6 +1183,7 @@
             <Chinesesimp>定义臂章挂在左腿上的位置(x，y，z)。</Chinesesimp>
             <Finnish>Määrittää vasempaan jalkaan kiinnitetyn käsivarsinauhan kiertoliikkeen (kääntö, nousu, rullaus).</Finnish>
             <Dutch>Bepaald de positie (x, y, z) waar de armband om de linkerbeen zit.</Dutch>
+            <Turkish>Kol bandının sol bacağa takıldığı konumu (x, y, z) tanımlar</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_SETTING_ArmbandSlingLeftLegPos_Display">
             <English>Armband position left leg</English>
@@ -1134,6 +1200,7 @@
             <Chinesesimp>左腿臂带位置</Chinesesimp>
             <Finnish>Käsivarsinauhan asento vasemmalla jalalla</Finnish>
             <Dutch>Armband positie linkerbeen</Dutch>
+            <Turkish>Kol bandı konumu – sol bacak</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_SETTING_ArmbandSlingLeftLegRot_Desc">
             <English>Defines the rotation (yaw, pitch, roll) of the armband that is slung to the left leg.</English>
@@ -1150,6 +1217,7 @@
             <Chinesesimp>定义挂在左腿上的臂章的旋转(偏航、俯仰、滚转)。</Chinesesimp>
             <Finnish>Määrittää vasempaan jalkaan kiinnitetyn käsivarsinauhan kiertoliikkeen (kääntö, nousu, rullaus).</Finnish>
             <Dutch>Bepaald de rotatie (draaiing, helling en kanteling) van de armband die om de linkerbeen zit</Dutch>
+            <Turkish>Sol bacağa takılan kol bandının dönüşünü (yaw, pitch, roll) tanımlar</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_SETTING_ArmbandSlingLeftLegRot_Display">
             <English>Armband rotation left leg</English>
@@ -1166,6 +1234,7 @@
             <Chinesesimp>左腿臂带旋转</Chinesesimp>
             <Finnish>Käsivarsinauhan kierto vasen jalka</Finnish>
             <Dutch>Armband rotatie linkerbeen</Dutch>
+            <Turkish>Kol bandı dönüşü – sol bacak</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_SETTING_ArmbandSlingRightArmPos_Desc">
             <English>Defines the position (x, y, z) where the armband is slung to the right arm.</English>
@@ -1182,6 +1251,7 @@
             <Chinesesimp>定义臂章挂在右臂上的位置(x，y，z)。</Chinesesimp>
             <Finnish>Määrittää paikan (x, y, z), jossa käsivarsinauha on ripustettu oikeaan käsivarteen.</Finnish>
             <Dutch>Bepaald de positie (x, y, z) waar de armband om de rechterarm zit.</Dutch>
+            <Turkish>Kol bandının sağ kola takıldığı konumu (x, y, z) tanımlar</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_SETTING_ArmbandSlingRightArmPos_Display">
             <English>Armband position right arm</English>
@@ -1198,6 +1268,7 @@
             <Chinesesimp>右臂臂带位置</Chinesesimp>
             <Finnish>Käsivarsinauhan asento oikea käsi</Finnish>
             <Dutch>Armbandpositie rechterarm</Dutch>
+            <Turkish>Kol bandı konumu – sağ kol</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_SETTING_ArmbandSlingRightArmRot_Desc">
             <English>Defines the rotation (yaw, pitch, roll) of the armband that is slung to the right arm.</English>
@@ -1214,6 +1285,7 @@
             <Chinesesimp>定义挂在右臂上的臂章的旋转(偏航、俯仰、滚转)。</Chinesesimp>
             <Finnish>Määrittää oikeaan käsivarteen kiinnitetyn käsivarsinauhan kiertoliikkeen (kääntö, nousu, rullaus).</Finnish>
             <Dutch>Bepaald de rotatie (draaiing, helling en kanteling) van de armband die om de rechterarm zit</Dutch>
+            <Turkish>Sağ kola takılan kol bandının dönüşünü (yaw, pitch, roll) tanımlar</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_SETTING_ArmbandSlingRightArmRot_Display">
             <English>Armband rotation right arm</English>
@@ -1230,6 +1302,7 @@
             <Chinesesimp>右臂臂带旋转</Chinesesimp>
             <Finnish>Käsivarsinauhan kierto oikealla kädellä.</Finnish>
             <Dutch>Armband rotatie rechterarm</Dutch>
+            <Turkish>Kol bandı dönüşü – sağ kol</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_SETTING_ArmbandSlingRightLegPos_Desc">
             <English>Defines the position (x, y, z) where the armband is slung to the right leg.</English>
@@ -1246,6 +1319,7 @@
             <Chinesesimp>定义臂章挂在右腿上的位置(x，y，z)。</Chinesesimp>
             <Finnish>Määrittää paikan (x, y, z), jossa käsivarsinauha on ripustettu oikeaan jalkaan</Finnish>
             <Dutch>Bepaald de rotatie (draaiing, helling en kanteling) van de armband die om de rechterbeen zit</Dutch>
+            <Turkish>Kol bandının sağ bacağa takıldığı konumu (x, y, z) tanımlar</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_SETTING_ArmbandSlingRightLegPos_Display">
             <English>Armband position right leg</English>
@@ -1262,6 +1336,7 @@
             <Chinesesimp>右腿臂带位置</Chinesesimp>
             <Finnish>Käsivarsinauhan asento oikea jalka.</Finnish>
             <Dutch>Armbandpositie rechterbeen</Dutch>
+            <Turkish>Kol bandı konumu – sağ bacak</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_SETTING_ArmbandSlingRightLegRot_Desc">
             <English>Defines the rotation (yaw, pitch, roll) of the armband that is slung to the right leg.</English>
@@ -1278,6 +1353,7 @@
             <Chinesesimp>定义挂在右腿上的臂章的旋转(偏航、俯仰、滚转)。</Chinesesimp>
             <Finnish>Määrittää oikeaan jalkaan kiinnitetyn käsivarsinauhan kiertoliikkeen (kääntö, nousu, rullaus).</Finnish>
             <Dutch>Bepaald de positie (x, y, z) waar de armband om de rechterbeen zit.</Dutch>
+            <Turkish>Sağ bacağa takılan kol bandının dönüşünü (yaw, pitch, roll) tanımlar</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_SETTING_ArmbandSlingRightLegRot_Display">
             <English>Armband rotation right leg</English>
@@ -1294,6 +1370,7 @@
             <Chinesesimp>右臂臂带旋转</Chinesesimp>
             <Finnish>Käsivarsinauhan kierto oikealla jalalla</Finnish>
             <Dutch>Armband rotatie rechterbeen</Dutch>
+            <Turkish>Kol bandı dönüşü – sağ bacak</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_SETTING_Container_Backpack">
             <English>Backpack</English>
@@ -1308,6 +1385,7 @@
             <Chinesesimp>背包</Chinesesimp>
             <Finnish>Reppu</Finnish>
             <Dutch>Rugzak</Dutch>
+            <Turkish>Sırt Çantası</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_SETTING_Container_Default">
             <English>Default</English>
@@ -1322,6 +1400,7 @@
             <Chinesesimp>预设</Chinesesimp>
             <Finnish>Oletus</Finnish>
             <Dutch>Standaard</Dutch>
+            <Turkish>Varsayılan</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_SETTING_Container_Uniform">
             <English>Uniform</English>
@@ -1336,6 +1415,7 @@
             <Chinesesimp>制服</Chinesesimp>
             <Finnish>Univormu</Finnish>
             <Dutch>Uniform</Dutch>
+            <Turkish>Üniforma</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_SETTING_Container_Vest">
             <English>Vest</English>
@@ -1350,6 +1430,7 @@
             <Chinesesimp>背心</Chinesesimp>
             <Finnish>Liivi</Finnish>
             <Dutch>Vest</Dutch>
+            <Turkish>Zırh</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_SETTING_ENABLE">
             <English>ACE-Misc activated?</English>
@@ -1365,7 +1446,7 @@
             <Japanese>KAMその他モジュールを有効化</Japanese>
             <Chinese>啟用ACE-雜項?</Chinese>
             <Chinesesimp>启用ACE-杂项?</Chinesesimp>
-            <Turkish>ACE-Misc activated?</Turkish>
+            <Turkish>ACE-Misc etkin mi?</Turkish>
             <Finnish>ACE-Sekalaista aktivoitu?</Finnish>
             <Dutch>ACE-Misc geactiveerd?</Dutch>
         </Key>
@@ -1375,6 +1456,7 @@
             <Spanish>Activa las funciones médicas diversas del sistema KAT (por ejemplo, soportes para sueros)</Spanish>
             <German>Aktiviert die KAT Misc Medizinsystem-Funktionen (z.B. IV-Ständer)</German>
             <Japanese>KAT その他の医療システム機能を有効化します (例: IVスタンド)</Japanese>
+            <Turkish>KAT Misc tıbbi sistem özelliklerini etkinleştirir (örn. IV Standları)</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_SETTING_EighthSlot_Item">
             <English>Miscellaneous Section Items &amp; Quantity</English>
@@ -1388,6 +1470,7 @@
             <Chinese>雜項物品與數量</Chinese>
             <Chinesesimp>杂项部分项目和数量</Chinesesimp>
             <Dutch>Overige sectie items &amp; hoeveelheden</Dutch>
+            <Turkish>Çeşitli Bölümü Eşyaları ve Miktarı</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_SETTING_EnableStitchFullBody">
             <English>Enable Full Body Stitching</English>
@@ -1401,6 +1484,7 @@
             <Chinese>啟用全身縫合</Chinese>
             <Chinesesimp>启用全身缝合</Chinesesimp>
             <Dutch>Schakel hechten van het volledige lichaam in</Dutch>
+            <Turkish>Tam Vücut Dikişini Etkinleştir</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_SETTING_EnableStitchFullBody_DESC">
             <English>Adds a full-body stitching option alongside the individual body part stitching, using ACE's established settings and values for consistency</English>
@@ -1414,6 +1498,7 @@
             <Chinese>除了單獨縫合身體各部位之外，還新增了全身縫合的選項，並且為了保持一致性，使用了 ACE 既有的設定和數值。</Chinese>
             <Chinesesimp>使用ACE的既定设置和值，在单个身体部位缝合的同时添加全身缝合选项，以保持一致性</Chinesesimp>
             <Dutch>Voegt een hechtingsactie toe voor het gehele lichaam, naast de standaard individuele hechtingsopties, die de waarden en instellingen van ACE gebruikt voor consistentie</Dutch>
+            <Turkish>ACE’nin yerleşik ayar ve değerlerini kullanarak, tekil vücut bölgesi dikişine ek olarak tam vücut dikişi seçeneği ekler</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_SETTING_FAK_Container">
             <English>Items unload Container</English>
@@ -1428,6 +1513,7 @@
             <Chinesesimp>物品拆包</Chinesesimp>
             <Finnish>Säiliö tavaroiden purkamiseen</Finnish>
             <Dutch>Items ontlaad container</Dutch>
+            <Turkish>Eşyaların Boşaltılacağı Konteyner</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_SETTING_FAK_Container_DESC">
             <English>Defines where the items from the First Aid Kit are added into. If there is no space left they will be dropped on the ground. \n Default: Items are added where space is left.</English>
@@ -1442,6 +1528,7 @@
             <Chinesesimp>定义急救箱中物品的添加位置。如果没有剩余的空间，它们就会掉到地上。\n默认值：在留出空间的地方添加项目。</Chinesesimp>
             <Finnish>Määrittää, mihin ensiapulaukun tuotteet lisätään. jos tilaa ei ole jäljellä, ne pudotetaan maahan. \n Oletus: kohteet lisätään sinne, missä on vielä tilaa.</Finnish>
             <Dutch>Bepaald waar de items van een Eerste hulpkit worden geplaatst. Als er geen plek is, worden ze op de grond geplaatst. \n Standaard: Items worden geplaatst waar plek is.</Dutch>
+            <Turkish>İlk Yardım Kiti’nden çıkan eşyaların nereye ekleneceğini tanımlar. Yer kalmazsa eşyalar yere düşer. \n Varsayılan: Eşyalar boş alan olan yere eklenir.</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_SETTING_FAK_ItemColor">
             <English>Hint Item Color</English>
@@ -1455,6 +1542,7 @@
             <Chinese>"Hint"項目顏色</Chinese>
             <Chinesesimp>提示项目颜色</Chinesesimp>
             <Dutch>kleur van itemhint</Dutch>
+            <Turkish>İpucu Metni – Eşya Rengi</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_SETTING_FAK_ItemColor_DESC">
             <English>The item color of the text that is displayed via a hint</English>
@@ -1468,6 +1556,7 @@
             <Chinese>透過"Hint"顯示的文字的項目顏色</Chinese>
             <Chinesesimp>通过提示显示的文本的项目颜色</Chinesesimp>
             <Dutch>De kleur van de tekstitem die weergeven wordt via een hint</Dutch>
+            <Turkish>İpucu ile gösterilen metnin eşya rengi</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_SETTING_FAK_RemoveWhenEmpty">
             <English>Remove when empty</English>
@@ -1481,6 +1570,7 @@
             <Chinesesimp>空时删除</Chinesesimp>
             <Finnish>Poista tyhjänä</Finnish>
             <Dutch>Verwijder wanneer leeg</Dutch>
+            <Turkish>Boşalınca kaldır</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_SETTING_FAK_RemoveWhenEmpty_DESC">
             <English>Automatically removes first aid kits from inventory when they become empty</English>
@@ -1488,6 +1578,7 @@
             <Spanish>Elimina automáticamente los botiquines del inventario cuando se vacían</Spanish>
             <German>Entfernt automatisch Erste-Hilfe-Kästen aus dem Inventar, wenn sie leer werden</German>
             <Japanese>応急処置キット(FAK)が空になった場合、自動的にインベントリから削除します</Japanese>
+            <Turkish>İlk yardım kitleri boşaldığında envanterden otomatik olarak kaldırır</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_SETTING_FAK_SlotColor">
             <English>Hint Section Color</English>
@@ -1501,6 +1592,7 @@
             <Chinese>"Hint"區塊顏色</Chinese>
             <Chinesesimp>提示部分颜色</Chinesesimp>
             <Dutch>Hint sectie kleur</Dutch>
+            <Turkish>İpucu Bölüm Rengi</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_SETTING_FAK_SlotColor_DESC">
             <English>The Section color of the text that is displayed via a hint</English>
@@ -1514,6 +1606,7 @@
             <Chinese>透過"Hint"顯示的文字的區塊顏色</Chinese>
             <Chinesesimp>通过提示显示的文本的截面颜色</Chinesesimp>
             <Dutch>De kleur van de sectie die weergeven wordt met een hint</Dutch>
+            <Turkish>İpucu ile gösterilen metnin bölüm rengi</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_SETTING_FifthSlot_Item">
             <English>Airway Section Items &amp; Quantity</English>
@@ -1527,6 +1620,7 @@
             <Chinese>呼吸道物品與數量</Chinese>
             <Chinesesimp>气道部分项目和数量</Chinesesimp>
             <Dutch>Luchtweg sectie items &amp; hoeveelheden</Dutch>
+            <Turkish>Hava Yolu Bölümü Eşyaları ve Miktarı</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_SETTING_FirstSlot_Item">
             <English>Trauma Section Items &amp; Quantity</English>
@@ -1540,6 +1634,7 @@
             <Chinese>創傷物品與數量</Chinese>
             <Chinesesimp>创伤部分项目和数量</Chinesesimp>
             <Dutch>Trauma sectie items &amp; hoeveelheden</Dutch>
+            <Turkish>Travma Bölümü Eşyaları ve Miktarı</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_SETTING_FourthSlot_Item">
             <English>Breathing Section Items &amp; Quantity</English>
@@ -1553,6 +1648,7 @@
             <Chinese>呼吸物品與數量</Chinese>
             <Chinesesimp>呼吸部分项目和数量</Chinesesimp>
             <Dutch>Ademhalingssectie items &amp; hoeveelheden</Dutch>
+            <Turkish>Solunum Bölümü Eşyaları ve Miktarı</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_SETTING_ItemSlot_DESC">
             <English>The items &amp; quantity that is given to the player.\n If you want to add/change items remove existing entry &amp; insert item name-tag &amp; quantity you want. \n Example: [['ACE_packingBandage', 10], ['ACE_quikclot', 15]]  TO  [['ACE_packingBandage', 10], ['ACE_quikclot', 15], ['ACE_Banana', 10]]</English>
@@ -1567,6 +1663,7 @@
             <Chinesesimp>给玩家的物品和数量。\n如果要添加/更改项目，请删除现有条目并插入所需的项目名称标签和数量。\n示例:  [['ACE_packingBandage', 10], ['ACE_quikclot', 15]]  TO  [['ACE_packingBandage', 10], ['ACE_quikclot', 15], ['ACE_Banana', 10]]</Chinesesimp>
             <Finnish>Pelaajalle annetut tuotteet ja määrä. \n Jos haluat lisätä/muuttaa kohteita, poista olemassa oleva merkintä ja lisää haluamasi nimikkeen nimilappu ja nimikemäärä. \n Esimerkki: [[`ACE_packingBandage`, 10].</Finnish>
             <Dutch>De items en de hoeveelheid dat gegeven wordt aan de speler. \n Als je items wilt toevoegen of veranderen, verwijder dan de bestaande entree en voeg item naam en de hoeveelheid die je wilt in. \n Voorbeeld: [['ACE_packingBandage', 10], ['ACE_quikclot', 15]]  NAAR  [['ACE_packingBandage', 10], ['ACE_quikclot', 15], ['ACE_Banana', 10]]</Dutch>
+            <Turkish>Oyuncuya verilen eşyalar ve miktarları.\n Eşya eklemek/değiştirmek için mevcut girdiyi kaldırın ve istediğiniz eşya ad-etiketini ve miktarı ekleyin. \n Örnek: [['ACE_packingBandage', 10], ['ACE_quikclot', 15]] TO [['ACE_packingBandage', 10], ['ACE_quikclot', 15], ['ACE_Banana', 10]]</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_SETTING_SecondSlot_Item">
             <English>Bandage Section Items &amp; Quantity</English>
@@ -1580,6 +1677,7 @@
             <Chinese>繃帶物品與數量</Chinese>
             <Chinesesimp>绷带部分项目和数量</Chinesesimp>
             <Dutch>Verbandssectie items &amp; hoeveelheden</Dutch>
+            <Turkish>Bandaj Bölümü Eşyaları ve Miktarı</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_SETTING_SeventhSlot_Item">
             <English>Fluid Section Items &amp; Quantity</English>
@@ -1593,6 +1691,7 @@
             <Chinese>液體物品與數量</Chinese>
             <Chinesesimp>流体部分项目和数量</Chinesesimp>
             <Dutch>Vloeistofsectie items &amp; hoeveelheden</Dutch>
+            <Turkish>Sıvı Bölümü Eşyaları ve Miktarı</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_SETTING_SixthSlot_Item">
             <English>Pharmaceutical Section Items &amp; Quantity</English>
@@ -1606,6 +1705,7 @@
             <Chinese>藥物物品與數量</Chinese>
             <Chinesesimp>药品部分项目和数量</Chinesesimp>
             <Dutch>Pharmaceutische sectie items &amp; hoeveelheden</Dutch>
+            <Turkish>Farmasötik Bölüm Eşyaları ve Miktarı</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_SETTING_ThirdSlot_Item">
             <English>Pain Management Section Items &amp; Quantity</English>
@@ -1619,6 +1719,7 @@
             <Chinese>止痛物品與數量</Chinese>
             <Chinesesimp>疼痛管理部分项目和数量</Chinesesimp>
             <Dutch>Pijnbestrijdingssectie items &amp; hoeveelheden</Dutch>
+            <Turkish>Ağrı Yönetimi Bölümü Eşyaları ve Miktarı</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_SETTING_allowSharedVehicleEquipment">
             <English>Allow Shared Vehicle Equipment</English>
@@ -1635,6 +1736,7 @@
             <Chinesesimp>允许共享车辆设备</Chinesesimp>
             <Finnish>Salli jaetut ajoneuvovarusteet</Finnish>
             <Dutch>Sta het delen van apparatuur in voertuigen toe</Dutch>
+            <Turkish>Paylaşılan Araç Ekipmanına İzin Ver</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_SETTING_allowSharedVehicleEquipment_DESC">
             <English>Sets whether vehicle's medical supplies can be used while treating and in which order</English>
@@ -1651,6 +1753,7 @@
             <Chinesesimp>设置治疗时是否可以使用车辆的医疗用品以及使用顺序</Chinesesimp>
             <Finnish>Asettaa, voidaanko ajoneuvon lääketieteellisiä tarvikkeita käyttää hoidon aikana ja missä järjestyksessä</Finnish>
             <Dutch>Bepaald of de medische middelen in een voertuig gebruikt kan worden voor behandelingen en in welke volgorde</Dutch>
+            <Turkish>Tedavi sırasında araçtaki tıbbi malzemelerin kullanılıp kullanılamayacağını ve sırasını belirler</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_SETTING_allowSharedVehicleEquipment_PriorityVehicleAlways">
             <English>Vehicle's Equipment First (Always)</English>
@@ -1667,6 +1770,7 @@
             <Chinesesimp>车辆设备优先(始终)</Chinesesimp>
             <Finnish>Ajoneuvon varusteita käytetään ensin (aina)</Finnish>
             <Dutch>Voertuigsmiddelen eerst (altijd)</Dutch>
+            <Turkish>Önce Araç Ekipmanı (Her Zaman)</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_SETTING_allowSharedVehicleEquipment_PriorityVehicleExceptSelfTreatment">
             <English>Vehicle's Equipment First (Except self-treatment)</English>
@@ -1683,6 +1787,7 @@
             <Chinesesimp>车辆设备优先(自我处理除外)</Chinesesimp>
             <Finnish>Ajoneuvon varusteet käytetään ensin (paitsi itsehoito)</Finnish>
             <Dutch>Voertuigsmiddelen eers (behalve bij zelfbehandeling)</Dutch>
+            <Turkish>Önce Araç Ekipmanı (Kendi kendine tedavi hariç)</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_SETTING_allowSharedVehicleEquipment_PriorityVehicleNoSelfTreatment">
             <English>Vehicle's Equipment First (No self-treatment)</English>
@@ -1699,6 +1804,7 @@
             <Chinesesimp>车辆设备优先(非自我处理)</Chinesesimp>
             <Finnish>Ajoneuvon varusteet käytetään ensin (ei itsehoitoa)</Finnish>
             <Dutch>Voertuigsmiddelen eerst (geen zelfbehandeling)</Dutch>
+            <Turkish>Önce Araç Ekipmanı (Kendi kendine tedavi yok)</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_SETTING_incompatibilityWarning">
             <English>Incompatible addon warning</English>
@@ -1716,6 +1822,7 @@
             <Chinesesimp>不兼容插件警告</Chinesesimp>
             <Finnish>Yhteensopimaton lisäosien varoitus</Finnish>
             <Dutch>Waarschuwing voor onverenigbare mods</Dutch>
+            <Turkish>Uyumsuz eklenti uyarısı</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_SETTING_incompatibilityWarning_Desc">
             <English>Throws a warning and add line to RPT log if incompatible addons(Listed by us - developers) that could negatively affect correct functionality of KAT are used. \nWarning disappears after 60 seconds.</English>
@@ -1733,6 +1840,7 @@
             <Chinesesimp>如果使用了可能对KAT的正确功能产生负面影响的不兼容插件(由我们开发人员列出)，则会发出警告并在RPT日志中添加行。\n 60秒后警告消失。</Chinesesimp>
             <Finnish>Lähettää varoituksen ja lisää rivin RPT-lokiin, jos käytössä on yhteensopimattomia lisäosia (me, kehittäjät ovat luetteloineet), jotka voivat vaikuttaa negatiivisesti KAT:n oikeaan toimintaan. \nVaroitus häviää 60 sekunnin kuluttua.</Finnish>
             <Dutch>Gooit een waarschuwing op en voegt een lijn toe aan de RPT als er onverenigbare mods (Genoemd door ons, de developers) die KAM negatief kunnen beïnvloeden worden gebruikt. \nWaarschuwing verdwijnt na 60 seconden.</Dutch>
+            <Turkish>KAT’in doğru çalışmasını olumsuz etkileyebilecek (geliştiriciler tarafından listelenen) uyumsuz eklentiler kullanıldığında uyarı verir ve RPT günlüğüne satır ekler. \nUyarı 60 saniye sonra kaybolur.</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_SETTING_tourniquetEffects_Enable">
             <English>Enable tourniquet effects</English>
@@ -1747,6 +1855,7 @@
             <Chinese>啟用止血帶效果</Chinese>
             <Chinesesimp>启用止血带效果</Chinesesimp>
             <Dutch>Schakel tourniquet effecten in</Dutch>
+            <Turkish>Turnike etkilerini etkinleştir</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_SETTING_tourniquetEffects_Enable_DESC">
             <English>Enables tourniquet effects on patient health and stamina</English>
@@ -1754,6 +1863,7 @@
             <Spanish>Activa los efectos del torniquete sobre la salud y la resistencia del paciente</Spanish>
             <German>Aktiviert Tourniquet-Effekte auf Patientengesundheit und Ausdauer</German>
             <Japanese>患者の体力とスタミナに対する止血帯の影響を有効化します</Japanese>
+            <Turkish>Turnikenin hasta sağlığı ve dayanıklılığı üzerindeki etkilerini etkinleştirir</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_SETTING_tourniquetEffects_NegativeMultiplier">
             <English>Tourniquet effects negative multiplier</English>
@@ -1769,6 +1879,7 @@
             <Chinesesimp>止血带效应负乘数</Chinesesimp>
             <Finnish>Tourniquet-vaikutusten negatiivinen kerroin</Finnish>
             <Dutch>Negatieve multiplicator voor tourniquet effecten</Dutch>
+            <Turkish>Turnike negatif etki çarpanı</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_SETTING_tourniquetEffects_NegativeMultiplier_DESC">
             <English>Multiplier for negative tourniquet effects</English>
@@ -1776,6 +1887,7 @@
             <Spanish>Multiplicador para los efectos negativos del torniquete</Spanish>
             <German>Multiplikator für negative Tourniquet-Effekte</German>
             <Japanese>止血帯のマイナス効果の乗数</Japanese>
+            <Turkish>Turnikenin olumsuz etkileri için çarpan</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_SETTING_tourniquetEffects_PositiveMultiplier">
             <English>Tourniquet effects positive multiplier</English>
@@ -1790,6 +1902,7 @@
             <Chinese>止血帶效果正向乘數</Chinese>
             <Chinesesimp>止血带效果正乘数</Chinesesimp>
             <Dutch>Positieve multiplicator voor tourniquet effecten</Dutch>
+            <Turkish>Turnike pozitif etki çarpanı</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_SETTING_tourniquetEffects_PositiveMultiplier_DESC">
             <English>Multiplier for positive tourniquet effects</English>
@@ -1797,6 +1910,7 @@
             <Spanish>Multiplicador para los efectos positivos del torniquete</Spanish>
             <German>Multiplikator für positive Tourniquet-Effekte</German>
             <Japanese>止血帯のプラス効果の乗数</Japanese>
+            <Turkish>Turnikenin olumlu etkileri için çarpan</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_SETTING_treatmentTimeDetachTourniquet">
             <English>Time to take off tourniquet</English>
@@ -1814,6 +1928,7 @@
             <Chinesesimp>移除止血带的时间</Chinesesimp>
             <Finnish>Aika ottaa kiristysside pois</Finnish>
             <Dutch>Benodigde tijd om een tourniquet af te nemen</Dutch>
+            <Turkish>Turnikeyi çıkarma süresi</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_SETTING_treatmentTimeDetachTourniquet_DESC">
             <English>Time required to detach a tourniquet from a patient</English>
@@ -1821,6 +1936,7 @@
             <Spanish>Tiempo necesario para retirar un torniquete de un paciente</Spanish>
             <German>Benötigte Zeit zum Entfernen eines Tourniquets vom Patienten</German>
             <Japanese>患者から止血帯を外すのにかかる時間</Japanese>
+            <Turkish>Turnikenin hastadan çıkarılması için gereken süre</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_StoppedCarrying%1">
             <English>Stopped carrying %1</English>
@@ -1837,6 +1953,7 @@
             <Chinesesimp>已停止携带 %1</Chinesesimp>
             <Finnish>Lakkasi kantamisen %1</Finnish>
             <Dutch>Gestopt met het dragen van %1</Dutch>
+            <Turkish>%1 taşımayı bıraktı</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_SubCategory_AFAK">
             <English>(AFAK) Advanced First Aid Kit</English>
@@ -1852,6 +1969,7 @@
             <Chinesesimp>(AFAK)高级急救包</Chinesesimp>
             <Finnish>(AFAK) Edistyksellinen ensiapulaukku</Finnish>
             <Dutch>(AFAK) Geadvanceerde Eerste hulpkit</Dutch>
+            <Turkish>(AFAK) Gelişmiş İlk Yardım Kiti</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_SubCategory_Armband">
             <English>Armband</English>
@@ -1868,6 +1986,7 @@
             <Chinesesimp>臂章</Chinesesimp>
             <Finnish>Käsivarsinauha</Finnish>
             <Dutch>Armband</Dutch>
+            <Turkish>Kol Bandı</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_SubCategory_IFAK">
             <English>(IFAK) Individual First Aid Kit</English>
@@ -1883,6 +2002,7 @@
             <Chinesesimp>(IFAK)个人急救包</Chinesesimp>
             <Finnish>(IFAK) Yksilöllinen ensiapulaukku</Finnish>
             <Dutch>(IFAK) Individuele Eerste hulpkit</Dutch>
+            <Turkish>(IFAK) Bireysel İlk Yardım Kiti</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_SubCategory_MFAK">
             <English>(MFAK) Multiple First Aid Kit</English>
@@ -1898,6 +2018,7 @@
             <Chinesesimp>(MFAK)多功能急救箱</Chinesesimp>
             <Finnish>(MFAK) Useita ensiapulaukkuja</Finnish>
             <Dutch>(MFAK) Meervoudige Eerste hulpkit</Dutch>
+            <Turkish>(MFAK) Çoklu İlk Yardım Kiti</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_SubCategory_Tourniquet">
             <English>Tourniquet Settings</English>
@@ -1912,6 +2033,7 @@
             <Chinese>止血帶設定</Chinese>
             <Chinesesimp>止血带设置</Chinesesimp>
             <Dutch>Tourniquet instellingen</Dutch>
+            <Turkish>Turnike Ayarları</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_Use_SurgicalKitFullBody">
             <English>Use Surgical Kit (Full Body)</English>
@@ -1926,6 +2048,7 @@
             <Chinese>使用手術包（全身）</Chinese>
             <Chinesesimp>全身缝合</Chinesesimp>
             <Dutch>Gebruik chirurgische kit (volledig lichaam)</Dutch>
+            <Turkish>Cerrahi Kiti Kullan (Tam Vücut)</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_basicSupplyCrate_display">
             <English>[KAM] General Items</English>
@@ -1943,6 +2066,7 @@
             <Chinesesimp>[KAM]一般项目</Chinesesimp>
             <Finnish>[KAM] Yleiset kohteet</Finnish>
             <Dutch>[KAM] Algemene items</Dutch>
+            <Turkish>[KAM] Genel Eşyalar</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_cba_name">
             <English>KAT - ADV Medical: Misc</English>
@@ -1952,6 +2076,7 @@
             <German>KAT - ADV Medical: Sonstiges</German>
             <Japanese>KAM - その他</Japanese>
             <Dutch>KAT - ADV Medical: Overig</Dutch>
+            <Turkish>KAT – Gelişmiş Tıp: Çeşitli</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_incompatibilityWarning_Desc">
             <English>[KAM WARNING] Incompatible addon(s) that could negatively affect correct functionality detected. KAT - Advanced Medical REWRITE Development Team strongly advises to remove these addons: %1</English>
@@ -1969,6 +2094,7 @@
             <Chinesesimp>[KAM警告]检测到可能对正确功能产生负面影响的不兼容插件。KAT-高级医疗重写开发团队强烈建议删除这些插件：%1</Chinesesimp>
             <Finnish>[KAM WARNING] Havaittiin yhteensopimattomia lisäosia, jotka voivat vaikuttaa oikeaan toimintaan. KAT - Advanced Medical REWRITE -kehitystiimi suosittelee näiden lisäosien poistamista: %1</Finnish>
             <Dutch>[KAM WAARSCHUWING] Onverenigbare mods die de ervaring negatief kunnen beïnvloeden gedetecteerd. KAT - Advanced Medical REWRITE development team raadt je sterk aan om de volgende mods te verwijderen: %1</Dutch>
+            <Turkish>[KAM UYARI] Doğru işleyişi olumsuz etkileyebilecek uyumsuz eklenti(ler) tespit edildi. KAT - Advanced Medical REWRITE Geliştirme Ekibi bu eklentilerin kaldırılmasını şiddetle tavsiye eder: %1</Turkish>
         </Key>
         <Key ID="STR_KAT_Misc_miscSupplyCrate_display">
             <English>[KAM] Misc Items</English>
@@ -1977,6 +2103,7 @@
             <Italian>[KAM] Oggetti vari</Italian>
             <Japanese>[KAM] その他物資箱</Japanese>
             <Dutch>[KAM] Overige items</Dutch>
+            <Turkish>[KAM] Çeşitli Eşyalar</Turkish>
         </Key>
     </Package>
 </Project>

--- a/addons/ophthalmology/stringtable.xml
+++ b/addons/ophthalmology/stringtable.xml
@@ -9,6 +9,7 @@
             <German>Ein Augenschild wird zur Behandlung von schweren Augenverletzungen verwendet</German>
             <Japanese>眼球保護帯は重傷となった目の治療に使用します</Japanese>
             <Dutch>Een oogschild wordt gebruikt om ernstig letsel aan het oog te behandelen</Dutch>
+            <Turkish>Göz kapakları, gözdeki ağır yaralanmaları tedavi etmek için kullanılır</Turkish>
         </Key>
         <Key ID="STR_KAT_Ophthalmology_EyeCover_Item">
             <English>Eye Shield</English>
@@ -18,6 +19,7 @@
             <German>Augenschild</German>
             <Japanese>眼球保護帯</Japanese>
             <Dutch>Oogschild</Dutch>
+            <Turkish>Göz Koruyucu</Turkish>
         </Key>
         <Key ID="STR_KAT_Ophthalmology_EyeCover_Left">
             <English>Left EyeCover</English>
@@ -27,6 +29,7 @@
             <German>Linkes Augenschild</German>
             <Japanese>左眼球保護帯</Japanese>
             <Dutch>Linker oogschild</Dutch>
+            <Turkish>Sol Göz Kapağı</Turkish>
         </Key>
         <Key ID="STR_KAT_Ophthalmology_EyeCover_Right">
             <English>Right EyeCover</English>
@@ -36,6 +39,7 @@
             <German>Rechtes Augenschild</German>
             <Japanese>右眼球保護帯</Japanese>
             <Dutch>Rechter oogschild</Dutch>
+            <Turkish>Sol Göz Kapağı</Turkish>
         </Key>
         <Key ID="STR_KAT_Ophthalmology_blink_action">
             <English>Blinking</English>
@@ -45,6 +49,7 @@
             <German>Blinzeln</German>
             <Japanese>まばたき</Japanese>
             <Dutch>Knipperen</Dutch>
+            <Turkish>Göz Kırpma</Turkish>
         </Key>
         <Key ID="STR_KAT_Ophthalmology_cba_name">
             <English>KAT - ADV Medical: Ophthalmology</English>
@@ -54,6 +59,7 @@
             <German>KAT - ADV Medical: Augenheilkunde</German>
             <Japanese>KAM - 眼科 (Ophthalmology)</Japanese>
             <Dutch>KAT - ADV Medical: Oogheelkunde</Dutch>
+            <Turkish>KAT – Gelişmiş Tıp: Oftalmoloji</Turkish>
         </Key>
         <Key ID="STR_KAT_Ophthalmology_eyeInjuryPresent">
             <English>Eye Injury</English>
@@ -63,6 +69,7 @@
             <German>Augenverletzung</German>
             <Japanese>眼外傷</Japanese>
             <Dutch>Oogletsel</Dutch>
+            <Turkish>Göz Yaralanması</Turkish>
         </Key>
         <Key ID="STR_KAT_Ophthalmology_eyeshield_action">
             <English>Applying</English>
@@ -72,6 +79,7 @@
             <German>Anwenden</German>
             <Japanese>装着中</Japanese>
             <Dutch>Wordt aangelegd</Dutch>
+            <Turkish>Uygulanıyor</Turkish>
         </Key>
         <Key ID="STR_KAT_Ophthalmology_eyeshield_display">
             <English>Apply Eye Shield</English>
@@ -81,6 +89,7 @@
             <German>Augenschild anwenden</German>
             <Japanese>眼帯を装着</Japanese>
             <Dutch>Leg oogschild aan</Dutch>
+            <Turkish>Göz Koruyucu Uygula</Turkish>
         </Key>
         <Key ID="STR_KAT_Ophthalmology_eyeshield_item">
             <English>Eye Shield</English>
@@ -90,6 +99,7 @@
             <German>Augenschild</German>
             <Japanese>眼帯</Japanese>
             <Dutch>Oogschild</Dutch>
+            <Turkish>Göz Koruyucu</Turkish>
         </Key>
         <Key ID="STR_KAT_Ophthalmology_eyewash_action">
             <English>Washing</English>
@@ -99,6 +109,7 @@
             <German>Spülen</German>
             <Japanese>洗浄中</Japanese>
             <Dutch>Wordt gespoelt</Dutch>
+            <Turkish>Yıkama</Turkish>
         </Key>
         <Key ID="STR_KAT_Ophthalmology_eyewash_display">
             <English>Wash eyes with saline</English>
@@ -108,6 +119,7 @@
             <German>Augen mit Kochsalzlösung spülen</German>
             <Japanese>生理食塩液で目を洗う</Japanese>
             <Dutch>Ogen met saline spoelen</Dutch>
+            <Turkish>Gözleri salin ile yıka</Turkish>
         </Key>
         <Key ID="STR_KAT_Ophthalmology_eyewash_display_water">
             <English>Wash eyes with water</English>
@@ -117,6 +129,7 @@
             <German>Augen mit Wasser spülen</German>
             <Japanese>水で目を洗う</Japanese>
             <Dutch>Ogen met water spoelen</Dutch>
+            <Turkish>Gözleri su ile yıka</Turkish>
         </Key>
         <Key ID="STR_KAT_Ophthalmology_eyewash_item">
             <English>Eye Wash</English>
@@ -126,6 +139,7 @@
             <German>Augenspülung</German>
             <Japanese>洗眼器</Japanese>
             <Dutch>Oogspoeling</Dutch>
+            <Turkish>Göz Yıkama</Turkish>
         </Key>
         <Key ID="STR_KAT_Ophthalmology_eyewasher_desc">
             <English>Eyewash bottles allow an individual to flush the injured area immediately</English>
@@ -135,6 +149,7 @@
             <German>Augenspühlungen ermöglichen das sofortige ausspülen von verletzten Augen</German>
             <Japanese>外傷部をすぐに洗い流すことができる洗眼ボトル</Japanese>
             <Dutch>Oogspoelingsflesjes staan onmiddelijke spoeling van de ogen toe</Dutch>
+            <Turkish>Göz yıkama şişeleri, yaralı bölgenin anında yıkanmasını sağlar</Turkish>
         </Key>
         <Key ID="STR_KAT_Ophthalmology_eyewasher_display">
             <English>Eye Washer</English>
@@ -144,6 +159,7 @@
             <German>Augenspüler</German>
             <Japanese>洗眼器</Japanese>
             <Dutch>Ogenspoeler</Dutch>
+            <Turkish>Göz Yıkayıcı</Turkish>
         </Key>
         <Key ID="STR_KAT_Ophthalmology_eyewasher_display_item">
             <English>Wash eyes</English>
@@ -153,6 +169,7 @@
             <German>Augen spülen</German>
             <Japanese>洗眼する</Japanese>
             <Dutch>Ogen spoelen</Dutch>
+            <Turkish>Gözleri yıka</Turkish>
         </Key>
         <Key ID="STR_KAT_Ophthalmology_setting_enable">
             <English>Enable eye injuries</English>
@@ -162,6 +179,7 @@
             <German>Aktiviere Augenverletzungen</German>
             <Japanese>眼外傷を有効化</Japanese>
             <Dutch>Sta oogletsel toe</Dutch>
+            <Turkish>Göz yaralanmalarını etkinleştir</Turkish>
         </Key>
         <Key ID="STR_KAT_Ophthalmology_setting_eyeShield_medic_required">
             <English>Medic required for eye shield</English>
@@ -171,6 +189,7 @@
             <German>Sanitäter benötigt zur Anwendung des Augenschutzes</German>
             <Japanese>眼帯の許可</Japanese>
             <Dutch>Medic benodigd voor aanleggen van een oogschild</Dutch>
+            <Turkish>Göz koruyucu için sağlık görevlisi gerekli</Turkish>
         </Key>
         <Key ID="STR_KAT_Ophthalmology_setting_eyeShield_treatment_time">
             <English>Treatment time for eye shield</English>
@@ -180,6 +199,7 @@
             <German>Anwendungszeit des Augenschutzes</German>
             <Japanese>眼帯装着の所要時間</Japanese>
             <Dutch>Benodigde tijd voor het aanleggen van een oogschild</Dutch>
+            <Turkish>Göz koruyucu uygulama süresi</Turkish>
         </Key>
         <Key ID="STR_KAT_Ophthalmology_setting_eyewash_medic_required">
             <English>Medic required to Eye Wash</English>
@@ -189,6 +209,7 @@
             <German>Sanitäter benötigt zur Augenspülung</German>
             <Japanese>洗眼の許可</Japanese>
             <Dutch>Medic benodigd voor het spoelen van oogen</Dutch>
+            <Turkish>Göz yıkama için sağlık görevlisi gerekli</Turkish>
         </Key>
         <Key ID="STR_KAT_Ophthalmology_setting_eyewash_treatment_time">
             <English>Treatment time of Eye Wash</English>
@@ -198,6 +219,7 @@
             <German>Anwendungszeit der Augenspülung</German>
             <Japanese>洗眼の所要時間</Japanese>
             <Dutch>Benodigde tijd voor het spoelen van ogen</Dutch>
+            <Turkish>Göz yıkama işlem süresi</Turkish>
         </Key>
         <Key ID="STR_KAT_Ophthalmology_setting_probability_dust">
             <English>Probability to get eye injury</English>
@@ -207,6 +229,7 @@
             <German>Wahrscheinlichkeit einer Augenverletzung</German>
             <Japanese>眼外傷を受ける確率</Japanese>
             <Dutch>Kans om een oogletsel te verkrijgen</Dutch>
+            <Turkish>Göz yaralanması olasılığı</Turkish>
         </Key>
         <Key ID="STR_KAT_Ophthalmology_setting_probability_dust_heavy">
             <English>Probability to get heavy eye injury</English>
@@ -216,6 +239,7 @@
             <German>Wahrscheinlichkeit einer schweren Augenverletzung</German>
             <Japanese>重度の眼外傷を受ける確率</Japanese>
             <Dutch>Kans om een erstig letsel aan het oog te verkrijgen</Dutch>
+            <Turkish>Ağır göz yaralanması olasılığı</Turkish>
         </Key>
         <Key ID="STR_KAT_Ophthalmology_setting_probability_treatment_dust">
             <English>Probability to treat (non-heavy) eye injury with blinking</English>
@@ -225,6 +249,7 @@
             <German>Wahrscheinlichkeit, eine (nicht-schwere) Augenverletzung durch blinzeln zu beseitigen</German>
             <Japanese>まばたきすることによって(重度ではない)眼外傷を治療する確率</Japanese>
             <Dutch>Kans om (niet ernstig) oogletsel te behandelen met knipperen</Dutch>
+            <Turkish>(Ağır olmayan) göz yaralanmasının göz kırpma ile tedavi edilme olasılığı</Turkish>
         </Key>
         <Key ID="STR_KAT_Ophthalmology_setting_subcategory_injury">
             <English>Eye injuries</English>
@@ -234,6 +259,7 @@
             <German>Augenverletzungen</German>
             <Japanese>眼外傷</Japanese>
             <Dutch>Oogletsel</Dutch>
+            <Turkish>Göz Yaralanmaları</Turkish>
         </Key>
         <Key ID="STR_KAT_Ophthalmology_setting_subcategory_manual_blink">
             <English>Manual blinking</English>
@@ -243,6 +269,7 @@
             <German>Manuelles Blinzeln</German>
             <Japanese>手動でまばたき</Japanese>
             <Dutch>Handmatig knipperen</Dutch>
+            <Turkish>Manuel göz kırpma</Turkish>
         </Key>
     </Package>
 </Project>

--- a/addons/pharma/stringtable.xml
+++ b/addons/pharma/stringtable.xml
@@ -1797,8 +1797,7 @@
             <Chinese>此時間除以 2，隨機化並加上除以 2 的相同值。\n例如，如果該值設定為 10 秒，則可能出現一種變化： (random (10 / 2)) + (10 / 2) = 8 秒</Chinese>
             <Chinesesimp>此时间除以2，随机化并加上除以2的相同值。\n例如，如果该值设置为10秒，则可能出现一种变化： (random (10 / 2)) + (10 / 2) = 8s</Chinesesimp>
             <Dutch>Deze tijd wordt door 2 gedeeld, gerandomiseerd en dan met dezelfde waarde gedeeld door 2 opgeteld. \nBijvoorbeeld: als deze waarde op 10 seconden ingesteld staat dan is één mogelijke variatie:(random(10/2))+(10/2) = 8s</Dutch>
-            <Turkish>Bu süre ikiye bölünür, rastgeleleştirilir ve tekrar yarısı eklenir.
-Örnek: 10 sn → (random (10 / 2)) + (10 / 2) = 8 sn</Turkish>
+            <Turkish>Bu süre ikiye bölünür, rastgeleleştirilir ve tekrar yarısı eklenir. Örnek: 10 sn → (random (10 / 2)) + (10 / 2) = 8 sn</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SETTING_Coagulation_Time_DESC">
             <English>The time between each wound clotting cycle that start wound clotting. (low number may cause lag)</English>
@@ -1876,8 +1875,7 @@
             <Chinese>允許凝固影響 AI 單位。\n如果開啟，仍需要其他值。（如果存在許多 AI，可能會導致延遲）</Chinese>
             <Chinesesimp>允许凝固影响AI单位。\n如果打开，仍需要其他值。（如果存在许多AI，可能会导致延迟）</Chinesesimp>
             <Dutch>Laat coagulatie AI/KI beïnvloeden.\nElke andere waarde wordt ook voor AI/KI gecheckt wanneer dit aanstaat. (Kan prestatieproblemen opleveren als er veel AI's/KI's aanwezig zijn.)</Dutch>
-            <Turkish>Koagülasyonun AI birimleri etkilemesine izin verir.
-(Not: Çok sayıda AI varsa gecikmeye yol açabilir)</Turkish>
+            <Turkish>Koagülasyonun AI birimleri etkilemesine izin verir. (Not: Çok sayıda AI varsa gecikmeye yol açabilir)</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SETTING_Coagulation_allow_EACA_script">
             <English>Allow Additional EACA Stiching</English>
@@ -2111,8 +2109,7 @@
             <Chinese>凝血需要心率超過 20 BPM 嗎？（做心肺復甦術將使心率保持在 20 BPM 以上）</Chinese>
             <Chinesesimp>凝血需要心率超过20BPM吗？（做心肺复苏术将使心率保持在20BPM以上）</Chinesesimp>
             <Dutch>Is een hartslag van meer dan 20SPM benodigt voor coagulatie? (Het uitvoeren van CPR houdt de hartslag boven 20SPM)</Dutch>
-            <Turkish>Koagülasyon için kalp atım hızının 20 BPM üzerinde olması gerekir mi?
-(CPR, HR’yi 20 BPM üzerinde tutar)</Turkish>
+            <Turkish>Koagülasyon için kalp atım hızının 20 BPM üzerinde olması gerekir mi? (CPR, HR’yi 20 BPM üzerinde tutar)</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SETTING_Coagulation_tourniquetBlock">
             <English>Tournique Blocks Blood Clotting</English>

--- a/addons/pharma/stringtable.xml
+++ b/addons/pharma/stringtable.xml
@@ -15,7 +15,7 @@
             <Japanese>アミオダロン</Japanese>
             <Chinese>胺碘酮 (Amiodarone)</Chinese>
             <Chinesesimp>胺碘酮</Chinesesimp>
-            <Turkish>Amiodaron</Turkish>
+            <Turkish>Amiodarone</Turkish>
             <Finnish>Amiodaroni</Finnish>
             <Dutch>Amiodaron</Dutch>
         </Key>
@@ -33,7 +33,7 @@
             <Japanese>心停止に対応する為に使用される</Japanese>
             <Chinese>用於防治心臟驟停</Chinese>
             <Chinesesimp>用于防治心脏骤停</Chinesesimp>
-            <Turkish>Kalp durmasıyla mücadele için kullanılır</Turkish>
+            <Turkish>Kardiyak arrestle mücadele etmek için kullanılır</Turkish>
             <Finnish>Käytetään sydämenpysähdyksen torjuntaan</Finnish>
             <Dutch>Wordt gebruikt om hartstilstand te bestrijden</Dutch>
         </Key>
@@ -51,7 +51,7 @@
             <Japanese>FAST IOを刺入</Japanese>
             <Chinese>建立FAST IO</Chinese>
             <Chinesesimp>建立FAST IO</Chinesesimp>
-            <Turkish>HIZLI IO kurun</Turkish>
+            <Turkish>FAST IO Yerleştir</Turkish>
             <Finnish>Perusta FAST IO</Finnish>
             <Dutch>Leg FAST IO aan</Dutch>
         </Key>
@@ -69,7 +69,7 @@
             <Japanese>16g IVを刺入</Japanese>
             <Chinese>建立16g IV</Chinese>
             <Chinesesimp>建立16g IV</Chinesesimp>
-            <Turkish>16g IV oluşturun</Turkish>
+            <Turkish>16g IV Yerleştir</Turkish>
             <Finnish>Aseta 16g IV</Finnish>
             <Dutch>Leg 16g IV aan</Dutch>
         </Key>
@@ -87,7 +87,7 @@
             <Japanese>IOの刺入中</Japanese>
             <Chinese>建立IO中</Chinese>
             <Chinesesimp>建立IO中</Chinesesimp>
-            <Turkish>IO'nun kurulması</Turkish>
+            <Turkish>IO Yerleştiriliyor</Turkish>
             <Finnish>IO:n perustaminen</Finnish>
             <Dutch>IO wordt aangelegd</Dutch>
         </Key>
@@ -105,7 +105,7 @@
             <Japanese>IV/IOの刺入中</Japanese>
             <Chinese>建立IV中</Chinese>
             <Chinesesimp>建立IV中</Chinesesimp>
-            <Turkish>IV/IO'nun kurulması</Turkish>
+            <Turkish>IV/IO Yerleştiriliyor</Turkish>
             <Finnish>IV/IO:n perustaminen</Finnish>
             <Dutch>IV/IO wordt aangelegd</Dutch>
         </Key>
@@ -123,7 +123,7 @@
             <Japanese>アトロピン</Japanese>
             <Chinese>阿托品自動注射器 (Atropine)</Chinese>
             <Chinesesimp>阿托品</Chinesesimp>
-            <Turkish>Atropin</Turkish>
+            <Turkish>Atropine Otoenjektör</Turkish>
             <Finnish>Atropiini</Finnish>
             <Dutch>Atropine autoinjector</Dutch>
         </Key>
@@ -141,7 +141,7 @@
             <Japanese>徐脈の治療に使用される</Japanese>
             <Chinese>用於治療心動過緩</Chinese>
             <Chinesesimp>用于治疗心动过缓</Chinesesimp>
-            <Turkish>Bradikardi tedavisinde kullanılır</Turkish>
+            <Turkish>Kimyasal maruziyeti tedavi etmek için kullanılır</Turkish>
             <Finnish>Käytetään bradykardian hoitoon</Finnish>
             <Dutch>Wordt gebruikt om chemische blootstelling en bradycardie te behandelen</Dutch>
         </Key>
@@ -157,6 +157,7 @@
             <Chinese>刺激中樞神經系統並使其充滿活力</Chinese>
             <Chinesesimp>刺激中枢神经系统并使其充满活力</Chinesesimp>
             <Dutch>Stimuleert het centraal zenuwstelsel en geeft energie</Dutch>
+            <Turkish>Merkezi sinir sistemini uyarır ve enerji verir</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_Caffeine_Bottle_Display">
             <English>Caffeine bottle</English>
@@ -174,6 +175,7 @@
             <Chinesesimp>咖啡因瓶</Chinesesimp>
             <Finnish>Kofeiinipullo</Finnish>
             <Dutch>Caffeïne doosje</Dutch>
+            <Turkish>Kafein şişesi</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_Carbonate_Box_Display">
             <English>Ammonium Carbonate</English>
@@ -207,7 +209,7 @@
             <Japanese>意識を回復するために使用される</Japanese>
             <Chinese>用於恢復知覺</Chinese>
             <Chinesesimp>用于恢复知觉</Chinesesimp>
-            <Turkish>Bilinci geri yüklemek için kullanılır</Turkish>
+            <Turkish>Bilinci geri kazandırmak için kullanılır</Turkish>
             <Finnish>Käytetään tajunnan palauttamiseen</Finnish>
             <Dutch>Wordt gebruikt om bewustzijn te herstellen</Dutch>
         </Key>
@@ -223,6 +225,7 @@
             <Chinese>測量 PT/INR</Chinese>
             <Chinesesimp>测量PT/INR</Chinesesimp>
             <Dutch>Meet PT-INR</Dutch>
+            <Turkish>PT/INR Ölç</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_CheckCoag_DisplayNameProgress">
             <English>Taking Blood Sample,</English>
@@ -236,6 +239,7 @@
             <Chinese>略低於正常INR</Chinese>
             <Chinesesimp>采集血液样本，</Chinesesimp>
             <Dutch>Bloedstaal wordt genomen</Dutch>
+            <Turkish>Kan Örneği Alınıyor,</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_CheckCoag_highly_aboveINR">
             <English>Very high INR</English>
@@ -249,6 +253,7 @@
             <Chinese>INR 非常高</Chinese>
             <Chinesesimp>INR非常高</Chinesesimp>
             <Dutch>Zeer hoog INR</Dutch>
+            <Turkish>Çok yüksek INR</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_CheckCoag_highly_lowINR">
             <English>Very Low INR</English>
@@ -262,6 +267,7 @@
             <Chinese>INR 非常低</Chinese>
             <Chinesesimp>INR非常低</Chinesesimp>
             <Dutch>Zeer laag INR</Dutch>
+            <Turkish>Çok düşük INR</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_CheckCoag_normalINR">
             <English>Normal INR</English>
@@ -275,6 +281,7 @@
             <Chinese>正常 INR</Chinese>
             <Chinesesimp>正常INR</Chinesesimp>
             <Dutch>Normaal INR</Dutch>
+            <Turkish>Normal INR</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_CheckCoag_slightly_aboveINR">
             <English>Slightly Above normal INR</English>
@@ -288,6 +295,7 @@
             <Chinese>略高於正常 INR</Chinese>
             <Chinesesimp>略高于正常INR</Chinesesimp>
             <Dutch>Lichtelijk boven normaal INR</Dutch>
+            <Turkish>Normalin biraz üzerinde INR</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_CheckCoag_slightly_lowINR">
             <English>Slightly Below Normal INR</English>
@@ -301,6 +309,7 @@
             <Chinese>略低於正常 INR</Chinese>
             <Chinesesimp>略低于正常INR</Chinesesimp>
             <Dutch>Lichtelijk onder normaal INR</Dutch>
+            <Turkish>Normalin biraz altında INR</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_Coag_Sense_Display">
             <English>Coag-Sense</English>
@@ -314,6 +323,7 @@
             <Chinese>凝血酶原監測系統(Coag-Sense)</Chinese>
             <Chinesesimp>凝血酶原监测系统(Coag-Sense)</Chinesesimp>
             <Dutch>Coag-Sense</Dutch>
+            <Turkish>Coag-Sense</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_Coag_Sense_Display_DESC">
             <English>The Coag-Sense is a PT/INR monitoring system that can measure the efficiency of your blood clotting</English>
@@ -327,6 +337,7 @@
             <Chinese>Coag-Sense 是一種 PT/INR 監測系統，可以測量您的凝血效率</Chinese>
             <Chinesesimp>Coag-Sense是一种PT/INR监测系统，可以测量您的凝血效率</Chinesesimp>
             <Dutch>De Coag-Sense is een PT-INR monitoringssysteem dat de effectiviteit van jouw wondstolling kan bepalen</Dutch>
+            <Turkish>Coag-Sense, kan pıhtılaşmasının etkinliğini ölçebilen bir PT/INR izleme sistemidir</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_Coag_Sense_Log">
             <English>Coag-Sense concludes: %1</English>
@@ -340,6 +351,7 @@
             <Chinese>Coag-Sense 得出結論：%1</Chinese>
             <Chinesesimp>Coag-Sense得出结论：%1</Chinesesimp>
             <Dutch>Coag-Sense concludeerd: %1</Dutch>
+            <Turkish>Coag-Sense sonucu: %1</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_Dialysis_DisplayName">
             <English>Perform Dialysis</English>
@@ -357,6 +369,7 @@
             <Chinesesimp>进行透析</Chinesesimp>
             <Finnish>Suorita dialyysi</Finnish>
             <Dutch>Voer dialyse uit</Dutch>
+            <Turkish>Diyaliz Uygula</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_Dialysis_DisplayNameProgress">
             <English>Performing</English>
@@ -374,6 +387,7 @@
             <Chinesesimp>表演</Chinesesimp>
             <Finnish>esiintymässä</Finnish>
             <Dutch>Wordt uitgevoerd</Dutch>
+            <Turkish>Yapılıyor</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_EACA_DescShort">
             <English>Encourages clot formation</English>
@@ -391,6 +405,7 @@
             <Chinesesimp>促进凝块形成</Chinesesimp>
             <Finnish>Edistää hyytymien muodostumista</Finnish>
             <Dutch>Bevorderd bloedstolling</Dutch>
+            <Turkish>Pıhtı oluşumunu teşvik eder</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_EACA_Display">
             <English>EACA</English>
@@ -408,6 +423,7 @@
             <Chinesesimp>EACA</Chinesesimp>
             <Finnish>EACA</Finnish>
             <Dutch>EACA</Dutch>
+            <Turkish>EACA</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_EpinephrineIV_DescShort">
             <English>IV Epinephrine</English>
@@ -420,6 +436,7 @@
             <Chinese>IV 腎上腺素</Chinese>
             <Chinesesimp>IV肾上腺素</Chinesesimp>
             <Dutch>IV Adrenaline</Dutch>
+            <Turkish>IV Epinefrin</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_EpinephrineIV_displayName">
             <English>IV Epinephrine</English>
@@ -432,6 +449,7 @@
             <Chinese>IV 腎上腺素</Chinese>
             <Chinesesimp>IV肾上腺素</Chinesesimp>
             <Dutch>IV Adrenaline</Dutch>
+            <Turkish>IV Epinefrin</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_Etomidate_DescShort">
             <English>General Anesthetic</English>
@@ -449,6 +467,7 @@
             <Chinesesimp>全身麻醉</Chinesesimp>
             <Finnish>Yleinen anestesia</Finnish>
             <Dutch>Algemeen anestheticum</Dutch>
+            <Turkish>Genel Anestezik</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_Etomidate_DescUse">
             <English>Used as a general anesthetic for surgical procedures</English>
@@ -466,6 +485,7 @@
             <Chinesesimp>用作外科手术的全身麻醉剂</Chinesesimp>
             <Finnish>Käytetään yleisanestesiana kirurgisissa toimenpiteissä</Finnish>
             <Dutch>Wordt gebruikt als algemeen anestheticum voor chirurgische procedures</Dutch>
+            <Turkish>Cerrahi işlemlerde genel anestezik olarak kullanılır</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_Etomidate_Use">
             <English>Push Etomidate</English>
@@ -483,6 +503,7 @@
             <Chinesesimp>推注依托咪酯</Chinesesimp>
             <Finnish>Työnnä etomidaattia</Finnish>
             <Dutch>Injecteer Etomidaat</Dutch>
+            <Turkish>Etomidat Ver</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_Etomidate_displayName">
             <English>Etomidate</English>
@@ -500,6 +521,7 @@
             <Chinesesimp>依托咪酯</Chinesesimp>
             <Finnish>Etomidaatti</Finnish>
             <Dutch>Etomidaat</Dutch>
+            <Turkish>Etomidat</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_Fentanyl_Box_Display">
             <English>Fentanyl</English>
@@ -517,6 +539,7 @@
             <Chinesesimp>芬太尼</Chinesesimp>
             <Finnish>fentanyyli</Finnish>
             <Dutch>Fentanyl</Dutch>
+            <Turkish>Fentanil</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_Fentanyl_DescShort">
             <English>Opioid analgesic, used to suppress severe pain</English>
@@ -530,6 +553,7 @@
             <Chinese>阿片類鎮痛藥，用於抑制劇烈疼痛</Chinese>
             <Chinesesimp>阿片类镇痛药，用于抑制剧烈疼痛</Chinesesimp>
             <Dutch>Opïode analgeticum, wordt gebruikt om ernstige pijn te onderdrukken</Dutch>
+            <Turkish>Şiddetli ağrıyı baskılamak için kullanılan opioid analjezik</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_Flumazenil_DescShort">
             <English>Counter to Lorazepam</English>
@@ -547,6 +571,7 @@
             <Chinesesimp>用于对抗劳拉西泮</Chinesesimp>
             <Finnish>Loratsepaamin vastainen</Finnish>
             <Dutch>Antagonist van Lorazepam</Dutch>
+            <Turkish>Lorazepam’a karşıt etki</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_Flumazenil_DescUse">
             <English>Used to bring patients out of sedation</English>
@@ -564,6 +589,7 @@
             <Chinesesimp>用于使患者脱离镇静状态</Chinesesimp>
             <Finnish>Käytetään potilaiden poistamiseen sedaatiosta</Finnish>
             <Dutch>Wordt gebruikt om patiënten uit sedatie te halen</Dutch>
+            <Turkish>Hastayı sedasyondan çıkarmak için kullanılır</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_Flumazenil_Use">
             <English>Push Flumazenil</English>
@@ -581,6 +607,7 @@
             <Chinesesimp>推注氟马西尼</Chinesesimp>
             <Finnish>Paina flumatseniiliä</Finnish>
             <Dutch>Injecteer Flumazenil</Dutch>
+            <Turkish>Flumazenil Ver</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_Flumazenil_displayName">
             <English>Flumazenil</English>
@@ -598,6 +625,7 @@
             <Chinesesimp>氟马西尼</Chinesesimp>
             <Finnish>Flumatseniili</Finnish>
             <Dutch>Flumazenil</Dutch>
+            <Turkish>Flumazenil</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_Give_CWMP">
             <English>Use CWMP</English>
@@ -611,6 +639,7 @@
             <Chinese>使用 CWMP*(戰鬥藥物)</Chinese>
             <Chinesesimp>使用 CWMP*(战斗药物)</Chinesesimp>
             <Dutch>Gebruik CWMP</Dutch>
+            <Turkish>CWMP Kullan</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_IO_45_Display">
             <English>FAST IO</English>
@@ -644,7 +673,7 @@
             <Japanese>経骨髄注射 (IO) 針</Japanese>
             <Chinese>骨髓注射(IO)針頭</Chinese>
             <Chinesesimp>骨髓注射(IO)针头</Chinesesimp>
-            <Turkish>Ağrıyı bastırmak için kullanılır</Turkish>
+            <Turkish>Intraosseous Needle</Turkish>
             <Finnish>Luonsisäinen neula</Finnish>
             <Dutch>Intraossale canule</Dutch>
         </Key>
@@ -682,6 +711,7 @@
             <Chinesesimp>IV/IO 脱落时间</Chinesesimp>
             <Finnish>IV/IO pudotusaika</Finnish>
             <Dutch>IV/IO uitvaltijd</Dutch>
+            <Turkish>IV/IO Düşme Süresi</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_IV_DROP_ENABLE">
             <English>Enables IV/IO drop times</English>
@@ -697,7 +727,7 @@
             <Japanese>IV/IOの時間経過での脱落を有効化</Japanese>
             <Chinese>啟用 IV/IO 的脫落時間</Chinese>
             <Chinesesimp>启用 IV/IO 的脱落时间</Chinesesimp>
-            <Turkish>IV/IO bırakma sürelerini etkinleştir</Turkish>
+            <Turkish>IV/IO düşme sürelerini etkinleştirir</Turkish>
             <Finnish>Mahdollistaa IV/IO-pudotusajat</Finnish>
             <Dutch>Schakel IV/IO uitvaltijd in</Dutch>
         </Key>
@@ -705,6 +735,7 @@
             <English>Enable IV drop time simulation</English>
             <German>IV-Tropfzeitensimulation aktivieren</German>
             <Japanese>IVが自然に脱落するようになる機能を有効化します</Japanese>
+            <Turkish>IV düşme süresi simülasyonunu etkinleştir</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_IV_DROP_TIME_DESC">
             <English>Changes the time at which IVs/IOs fall out of a patient</English>
@@ -720,7 +751,7 @@
             <Japanese>患者からIV/IOが抜け落ちるのにかかる時間を設定します</Japanese>
             <Chinese>IVs/IOs 脫落的時間</Chinese>
             <Chinesesimp>IVs/IOs 脱落的时间</Chinesesimp>
-            <Turkish>IV'lerin/IO'ların bir hastadan düştüğü zamanı değiştirir</Turkish>
+            <Turkish>IV/IO’ların hastadan çıkma süresini değiştirir</Turkish>
             <Finnish>Muuttaa aikaa, jolloin IVs/IO</Finnish>
             <Dutch>Veranderd de benodigde uitvaltijd voor IV's/IO's</Dutch>
         </Key>
@@ -738,7 +769,7 @@
             <Japanese>経静脈注射 (IV) 針</Japanese>
             <Chinese>靜脈注射(IV)針頭</Chinese>
             <Chinesesimp>静脉注射(IV)针头</Chinesesimp>
-            <Turkish>Ağrıyı bastırmak için kullanılır</Turkish>
+            <Turkish>Intravenous Needle</Turkish>
             <Finnish>Laskimonsisäinen neula</Finnish>
             <Dutch>intraveneuze canule</Dutch>
         </Key>
@@ -756,7 +787,7 @@
             <Japanese>IV/IO針を再利用可能にする</Japanese>
             <Chinese>如果 IV/IO 注射針頭是可重複使用的, 則應啟用。</Chinese>
             <Chinesesimp>如果 IV/IO 注射针头是可重复使用的, 则应启用。</Chinesesimp>
-            <Turkish>IV/IO iğnelerinin yeniden kullanılabilir olup olmadığını ayarlar</Turkish>
+            <Turkish>IV/IO iğnelerinin tekrar kullanılabilir olup olmadığını belirler</Turkish>
             <Finnish>Asettaa, jos IV/IO-neulat ovat uudelleenkäytettäviä</Finnish>
             <Dutch>Bepaald of IV/IO naalden herbruikbaar zijn</Dutch>
         </Key>
@@ -764,6 +795,7 @@
             <English>Allow reuse of IV Equipment</English>
             <German>Wiederverwendung von IV Ausrüstung erlauben</German>
             <Japanese>IV装備品の再使用を許可します</Japanese>
+            <Turkish>IV ekipmanının tekrar kullanımına izin ver</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_IVblock_clear">
             <English>Patient's IV is clear</English>
@@ -781,6 +813,7 @@
             <Chinesesimp>患者的IV是干净的</Chinesesimp>
             <Finnish>Potilaan IV on selvä</Finnish>
             <Dutch>Patiënt's IV is niet geblokkeerd</Dutch>
+            <Turkish>Hastanın IV’si açık</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_IVblock_closed">
             <English>Patient's IV is blocked</English>
@@ -798,6 +831,7 @@
             <Chinesesimp>患者的IV受到阻塞</Chinesesimp>
             <Finnish>Potilaan IV on tukossa</Finnish>
             <Dutch>Patiënt's IV is geblokkeerd</Dutch>
+            <Turkish>Hastanın IV’si tıkalı</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_Inspect_Catheter">
             <English>Inspect Catheter</English>
@@ -815,6 +849,7 @@
             <Chinesesimp>检查导管</Chinesesimp>
             <Finnish>Tarkista katetri</Finnish>
             <Dutch>Inspecteer canule</Dutch>
+            <Turkish>Kateteri İncele</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_Ketamine_Box_Display">
             <English>Ketamine</English>
@@ -832,6 +867,7 @@
             <Chinesesimp>氯胺酮</Chinesesimp>
             <Finnish>Ketamiini</Finnish>
             <Dutch>Ketamine</Dutch>
+            <Turkish>Ketamin</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_Ketamine_DescShort">
             <English>Dissociative anesthetics, used to suppress severe pain</English>
@@ -844,6 +880,7 @@
             <Chinese>解離性麻醉劑，用於抑制劇烈疼痛</Chinese>
             <Chinesesimp>解离性麻醉剂，用于抑制剧烈疼痛</Chinesesimp>
             <Dutch>Dissociatieve anestheticum, wordt gebruikt om ernstige pijn te onderdrukken</Dutch>
+            <Turkish>Ketamin</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_Lidocaine_Box_Display">
             <English>Lidocaine</English>
@@ -877,7 +914,7 @@
             <Japanese>心停止に対応する為に使用される</Japanese>
             <Chinese>用於對抗心臟驟停</Chinese>
             <Chinesesimp>用于对抗心脏骤停</Chinesesimp>
-            <Turkish>Kalp durmasıyla mücadele için kullanılır</Turkish>
+            <Turkish>Kardiyak arrestle mücadele etmek için kullanılır</Turkish>
             <Finnish>Käytetään sydämenpysähdyksen torjuntaan</Finnish>
             <Dutch>Wordt gebruikt om hartstilstand te bestrijden</Dutch>
         </Key>
@@ -897,6 +934,7 @@
             <Chinesesimp>镇静药物</Chinesesimp>
             <Finnish>Rauhoittava lääkitys</Finnish>
             <Dutch>Sedatiemiddel</Dutch>
+            <Turkish>Sedasyon ilacı</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_Lorazepam_DescUse">
             <English>Used to sedate patients and prepare them for surgery</English>
@@ -914,6 +952,7 @@
             <Chinesesimp>用于镇静患者并为手术做好准备</Chinesesimp>
             <Finnish>Käytetään potilaiden rauhoittamiseen ja valmistelemiseen leikkausta varten</Finnish>
             <Dutch>Wordt gebruikt om patiënten te sederen en ze voor te bereiden voor een operatie</Dutch>
+            <Turkish>Sedasyon ilacı</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_Lorazepam_Use">
             <English>Push Lorazepam</English>
@@ -931,6 +970,7 @@
             <Chinesesimp>推注劳拉西泮</Chinesesimp>
             <Finnish>Paina loratsepaamia</Finnish>
             <Dutch>Injecteer Lorazepam</Dutch>
+            <Turkish>Lorazepam Ver</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_Lorazepam_displayName">
             <English>Lorazepam</English>
@@ -948,6 +988,7 @@
             <Chinesesimp>劳拉西泮</Chinesesimp>
             <Finnish>Loratsepaami</Finnish>
             <Dutch>Lorazepam</Dutch>
+            <Turkish>Lorazepam</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_Nalbuphine_Box_Display">
             <English>Nalbuphine</English>
@@ -965,6 +1006,7 @@
             <Chinesesimp>纳布啡</Chinesesimp>
             <Finnish>Nalbufiini</Finnish>
             <Dutch>Nalbufine</Dutch>
+            <Turkish>Nalbuphin</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_Nalbuphine_DescShort">
             <English>Opioid analgesic, used to suppress moderate pain</English>
@@ -978,6 +1020,7 @@
             <Chinese>阿片類鎮痛藥，用於抑制中度疼痛</Chinese>
             <Chinesesimp>阿片类镇痛药，用于抑制中度疼痛</Chinesesimp>
             <Dutch>Opïode analgeticum, wordt gebruikt om matige pijn te onderdrukken</Dutch>
+            <Turkish>Orta dereceli ağrıyı baskılamak için kullanılan opioid analjezik</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_Naloxone_Box_Display">
             <English>Naloxone</English>
@@ -1011,7 +1054,7 @@
             <Japanese>オピオイド過剰摂取を元に戻すために使用される</Japanese>
             <Chinese>用於逆轉阿片類藥物的過量使用</Chinese>
             <Chinesesimp>用于逆转阿片类药物的过量使用</Chinesesimp>
-            <Turkish>Opioid aşırı dozlarını tersine çevirmek için kullanılır</Turkish>
+            <Turkish>Nalokson</Turkish>
             <Finnish>Käytetään opioidien yliannostusten kumoamiseen</Finnish>
             <Dutch>Wordt gebruikt om opïode overdossisen tegen te gaan</Dutch>
         </Key>
@@ -1099,6 +1142,7 @@
             <Chinese>戰鬥止痛藥 (PainKiller)</Chinese>
             <Chinesesimp>战斗药丸包</Chinesesimp>
             <Dutch>Gevechtspillendoosje</Dutch>
+            <Turkish>Combat Pill Pack</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_Painkillers_DescShort">
             <English>Combat Wound Medication Pill Pack&lt;br/&gt;Used to suppress minor pain and relieve blood incompatibility symptoms</English>
@@ -1111,6 +1155,7 @@
             <Chinese>戰鬥傷口藥物藥丸包&lt;br/&gt;用於抑制輕微疼痛和緩解血液不相容症狀</Chinese>
             <Chinesesimp>战斗伤口药物药丸包&lt;br/&gt;用于抑制轻微疼痛和缓解血液不相容症状</Chinesesimp>
             <Dutch>Gevechts wond medicatie pil pak&lt;br/&gt;Wordt gebruikt om milde pijn en bloed incompatibiliteit op te lossen</Dutch>
+            <Turkish>Combat Wound Medication Pill Pack&lt;br/&gt;Hafif ağrıyı baskılamak ve kan uyumsuzluğu belirtilerini hafifletmek için kullanılır</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_Penthrox_DescShort">
             <English>Volatile anesthetic, used to suppress moderate pain</English>
@@ -1123,6 +1168,7 @@
             <Chinese>揮發性麻醉劑，用於減輕中度疼痛</Chinese>
             <Chinesesimp>挥发性麻醉剂，用于抑制中度疼痛</Chinesesimp>
             <Dutch>volatiel anestheticum, wordt gebruik om stevige pijn te onderdrukken</Dutch>
+            <Turkish>Orta dereceli ağrıyı baskılamak için kullanılan uçucu anestezik</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_Penthrox_Display">
             <English>Penthrox Inhaler</English>
@@ -1139,6 +1185,7 @@
             <Chinesesimp>Penthrox吸入器</Chinesesimp>
             <Finnish>Penthrox inhalaattori</Finnish>
             <Dutch>Penthrox inhalator</Dutch>
+            <Turkish>Penthrox Inhaler</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_Pervitin_Capsule_DescShort">
             <English>Performance enhancing drug, used to suppress moderate pain</English>
@@ -1152,6 +1199,7 @@
             <Chinese>性能增強藥物，用於抑制中度疼痛</Chinese>
             <Chinesesimp>性能增强药物，用于抑制中度疼痛</Chinesesimp>
             <Dutch>Prestatieverhogend medicijn, wordt gebruikt om matige pijn te onderdrukken</Dutch>
+            <Turkish>Performans artırıcı ilaç, orta dereceli ağrıyı baskılamak için kullanılır</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_Pervitin_Capsule_Display">
             <English>Pervitin capsule</English>
@@ -1169,6 +1217,7 @@
             <Chinesesimp>柏飞汀(Pervitin)胶囊</Chinesesimp>
             <Finnish>Pervitiini kapseli</Finnish>
             <Dutch>Pervitin capsule</Dutch>
+            <Turkish>Pervitin kapsülü</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_Pervitin_chrom">
             <English>You start to see everything twice.</English>
@@ -1186,6 +1235,7 @@
             <Chinesesimp>你开始看到一切两次。</Chinesesimp>
             <Finnish>Alat nähdä kaiken kahdesti.</Finnish>
             <Dutch>Je begint met alles dubbelzien</Dutch>
+            <Turkish>Her şeyi çift görmeye başlıyorsun.</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_Pervitin_chrom2">
             <English>You start to twitch...</English>
@@ -1203,6 +1253,7 @@
             <Chinesesimp>你开始抽搐。。。</Chinesesimp>
             <Finnish>Alkaa nykimään</Finnish>
             <Dutch>Je begint te trillen</Dutch>
+            <Turkish>Kasılmaya başlıyorsun…</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_Pervitin_chrom3">
             <English>Your head starts to clear up and you stop twitching...</English>
@@ -1220,6 +1271,7 @@
             <Chinesesimp>你的头开始清醒，不再抽搐。。。</Chinesesimp>
             <Finnish>Pääsi alkaa selkiytyä ja lopetat nykimisen</Finnish>
             <Dutch>Je hoofd begint zich op te helderen, en je stopt met trillen</Dutch>
+            <Turkish>Başın netleşiyor ve kasılmalar duruyor…</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_Pervitin_end">
             <English>You start to feel normal again</English>
@@ -1237,6 +1289,7 @@
             <Chinesesimp>你又开始感觉正常了</Chinesesimp>
             <Finnish>Alkaa taas tuntua normaalilta</Finnish>
             <Dutch>Je begint je weer normaal te voelen</Dutch>
+            <Turkish>Tekrar normal hissetmeye başlıyorsun</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_Pervitin_mid">
             <English>You begin to lose your breath...</English>
@@ -1254,6 +1307,7 @@
             <Chinesesimp>你开始喘不过气来。。。</Chinesesimp>
             <Finnish>Alkaa menettää hengitystä...</Finnish>
             <Dutch>Je begint je adem te verliezen...</Dutch>
+            <Turkish>Nefesin kesilmeye başlıyor…</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_Pervitin_mid2">
             <English>You gain a sudden rush!</English>
@@ -1271,6 +1325,7 @@
             <Chinesesimp>你突然冲动起来！</Chinesesimp>
             <Finnish>Saat äkillisen kiireen!</Finnish>
             <Dutch>Je krijgt een spontane boost!</Dutch>
+            <Turkish>Ani bir enerji patlaması hissediyorsun!</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_Pervitin_mid3">
             <English>You gain another rush!</English>
@@ -1288,6 +1343,7 @@
             <Chinesesimp>你获得了另一个冲刺！</Chinesesimp>
             <Finnish>Saat uuden kiireen!</Finnish>
             <Dutch>Je krijgt nog een boost!</Dutch>
+            <Turkish>Bir enerji patlaması daha!</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_Pervitin_mid4">
             <English>The exhaustion starts to settle in...</English>
@@ -1305,6 +1361,7 @@
             <Chinesesimp>疲惫开始消退。。。</Chinesesimp>
             <Finnish>Väsymys alkaa laskeutua...</Finnish>
             <Dutch>Je begint in te zakken</Dutch>
+            <Turkish>Yorgunluk çökmeye başlıyor…</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_Pervitin_start">
             <English>The pervitin makes you feel awake and full of endless POWER</English>
@@ -1322,6 +1379,7 @@
             <Chinesesimp>柏飞汀(Pervitin)让你感到清醒，充满无尽的力量</Chinesesimp>
             <Finnish>Pervitiini saa sinut tuntemaan olosi hereille ja täynnä loputonta VOIMAA</Finnish>
             <Dutch>De Pervitin geeft je een wakker gevoel vol met oneinde ENERGIE</Dutch>
+            <Turkish>Pervitin seni uyanık ve sonsuz GÜÇ dolu hissettiriyor</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_PhenylAuto_Box_Display">
             <English>Phenylephrine Autoinjector</English>
@@ -1336,6 +1394,7 @@
             <Chinese>去氧腎上腺素自動注射器 (Phenylephrine)</Chinese>
             <Chinesesimp>苯肾上腺素自动注射器</Chinesesimp>
             <Dutch>Fenylefrine autoinjector</Dutch>
+            <Turkish>Fenilefrin Otoenjektör</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_PhenylAuto_DescShort">
             <English>Used to raise blood pressure</English>
@@ -1348,6 +1407,7 @@
             <Chinese>用於升高血壓</Chinese>
             <Chinesesimp>用于提高血压</Chinesesimp>
             <Dutch>Wordt gebruikt om de bloeddruk te laten stijgen</Dutch>
+            <Turkish>Kan basıncını yükseltmek için kullanılır</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_Phenyl_Box_Display">
             <English>Phenylephrine</English>
@@ -1435,7 +1495,7 @@
             <Japanese>IV/IOを抜去中</Japanese>
             <Chinese>移除中</Chinese>
             <Chinesesimp>移除中</Chinesesimp>
-            <Turkish>Kaldırma</Turkish>
+            <Turkish>IV/IO  Kaldırılıyor</Turkish>
             <Finnish>IV/IO poisto</Finnish>
             <Dutch>IV/IO wordt verwijderd</Dutch>
         </Key>
@@ -1471,7 +1531,7 @@
             <Japanese>患者は強打で飛び起きた!</Japanese>
             <Chinese>患者甦醒了!</Chinese>
             <Chinesesimp>患者苏醒了!</Chinesesimp>
-            <Turkish>Hasta sert bir vuruşla uyandı!</Turkish>
+            <Turkish>Hasta sert bir darbeyle uyandı!</Turkish>
             <Finnish>Potilas heräsi kovalla iskulla!</Finnish>
             <Dutch>Patiënt werd wakker na een harde klap!</Dutch>
         </Key>
@@ -1489,7 +1549,7 @@
             <Japanese>あなたは頬を叩いたが、 患者はまだ眠っている!</Japanese>
             <Chinese>患者仍未甦醒</Chinese>
             <Chinesesimp>患者仍未苏醒</Chinesesimp>
-            <Turkish>Yanağına vurdun ama hasta hala uyuyor!</Turkish>
+            <Turkish>Hasta sert bir darbeyle uyandı!</Turkish>
             <Finnish>Lyöt poskelle, mutta potilas nukkuu edelleen!</Finnish>
             <Dutch>Je hebt de wang geraakt, maar de patiënt slaapt nog!</Dutch>
         </Key>
@@ -1545,6 +1605,7 @@
             <Chinesesimp>IV 阻塞几率</Chinesesimp>
             <Finnish>Mahdollisuus estää IV:t</Finnish>
             <Dutch>IV blokkade kans</Dutch>
+            <Turkish>IV Tıkanma Olasılığı</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SETTING_Block_Chance_DESC">
             <English>Chance of IV blockage due to medication pushes without saline flush</English>
@@ -1562,6 +1623,7 @@
             <Chinesesimp>由于没有盐水协助的药物注射导致 IV 阻塞的机会</Chinesesimp>
             <Finnish>IV-tukoksen mahdollisuus lääkityksen painamisesta ilman suolaliuosta</Finnish>
             <Dutch>Kans voor blokkade van IV's door medicaties zonder salinespoeling</Dutch>
+            <Turkish>Salin flush yapılmadan ilaç verilmesi sonucu IV hattının tıkanma olasılığı</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SETTING_CheckCoag_Location">
             <English>Locations Coag-Sense</English>
@@ -1575,11 +1637,13 @@
             <Chinese>Coag-Sense 地點</Chinese>
             <Chinesesimp>Coag-Sense地点</Chinesesimp>
             <Dutch>Locaties voor gebruik Coag-Sense</Dutch>
+            <Turkish>Coag-Sense Konumları</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SETTING_CheckCoag_Location_DESC">
             <English>Locations where coagulation can be checked</English>
             <German>Orte, an denen die Gerinnung überprüft werden kann</German>
             <Japanese>凝固の検査が可能になる場所を設定します</Japanese>
+            <Turkish>Koagülasyonun kontrol edilebileceği konumlar</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SETTING_CheckCoag_MedLevel">
             <English>Medical level required for Coag-Sense</English>
@@ -1593,11 +1657,13 @@
             <Chinese>Coag-Sense 需要的醫療等級</Chinese>
             <Chinesesimp>Coag-Sense所需的医疗水平</Chinesesimp>
             <Dutch>Vereist medisch niveau voor gebruik Coag-Sense</Dutch>
+            <Turkish>Coag-Sense kullanımı için gerekli tıbbi seviye</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SETTING_CheckCoag_MedLevel_DESC">
             <English>Medical level required to check coagulation</English>
             <German>Erforderlicher medizinischer Level für Gerinnungsprüfung</German>
             <Japanese>凝固の検査が可能になる場所を設定します</Japanese>
+            <Turkish>Koagülasyon kontrolü için gerekli tıbbi seviye</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SETTING_CheckCoag_treatmentTime">
             <English>Treatment time for measuring PT/INR</English>
@@ -1611,11 +1677,13 @@
             <Chinese>PT/INR 測量的治療時間</Chinese>
             <Chinesesimp>PT/INR测量的治疗时间</Chinesesimp>
             <Dutch>Onderzoekstijd voor bepalen PT-INR</Dutch>
+            <Turkish>PT/INR ölçüm süresi</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SETTING_CheckCoag_treatmentTime_DESC">
             <English>Time required to check coagulation</English>
             <German>Zeit für die Gerinnungsprüfung</German>
             <Japanese>凝固の検査に掛かる時間</Japanese>
+            <Turkish>Koagülasyon kontrolü için gereken süre</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SETTING_Coagulation">
             <English>Enable Coagulation</English>
@@ -1633,6 +1701,7 @@
             <Chinesesimp>启用凝血</Chinesesimp>
             <Finnish>Ota koagulaatio käyttöön</Finnish>
             <Dutch>Schakel coagulatie in</Dutch>
+            <Turkish>Koagülasyonu Etkinleştir</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SETTING_Coagulation_DESC">
             <English>Enables advanced coagulation features and modifies TXA and EACA behaviour accordingly.</English>
@@ -1650,6 +1719,7 @@
             <Chinesesimp>启用高级凝血功能，并相应地修改血栓素(TXA)和EACA行为。</Chinesesimp>
             <Finnish>Ottaa käyttöön edistyneet koagulaatioominaisuudet ja muuttaa TXA- ja EACA-käyttäytymistä vastaavasti</Finnish>
             <Dutch>Schakelt geadvanceerde coagulatie functies in, en veranderd het gedrag van TXA en EACA naar behoren</Dutch>
+            <Turkish>Gelişmiş koagülasyon özelliklerini etkinleştirir ve TXA ile EACA davranışlarını buna göre değiştirir.</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SETTING_Coagulation_FactorCount">
             <English>Coagulation Factors</English>
@@ -1662,6 +1732,7 @@
             <Chinese>凝血因子</Chinese>
             <Chinesesimp>凝血因子</Chinesesimp>
             <Dutch>Stollingsfactoren</Dutch>
+            <Turkish>Koagülasyon Faktörleri</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SETTING_Coagulation_FactorCount_DESC">
             <English>The amount of coagulation factors that get set on unit spawn &amp; be kept as limit for factor regeneration</English>
@@ -1674,6 +1745,7 @@
             <Chinese>單位菌種上設定的凝血因子數量應作為因子再生的限制</Chinese>
             <Chinesesimp>单位菌种上设定的凝血因子数量应作为因子再生的限制</Chinesesimp>
             <Dutch>De hoeveelheid stollingsfactoren dat een eenheid krijgt op spawn en als limiet wordt gebruik voor hergeneratie</Dutch>
+            <Turkish>Birim doğduğunda ayarlanan ve faktör yenilenmesi için üst sınır olarak tutulan koagülasyon faktörü miktarı</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SETTING_Coagulation_Factor_Regenerate_Time">
             <English>Coagulation Factor Regeneration Cycle</English>
@@ -1686,6 +1758,7 @@
             <Chinese>凝血因子再生循環</Chinese>
             <Chinesesimp>凝血因子再生循环</Chinesesimp>
             <Dutch>Stollingsfactor hergeneratiecyclus</Dutch>
+            <Turkish>Koagülasyon Faktörü Yenilenme Döngüsü</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SETTING_Coagulation_Factor_Regenerate_Time_DESC">
             <English>The time between coagulation factor regeneration checks. Will add +1 factor on successful check. Uses Setting: "Coagulation Factors" as limit.\n Note: If the limit is exceeded, this time will be used and then remove -1 factor until Setting: "Coagulation Factors" is reached. Tipp: TXA or EACA stop losing factors\nRequirements for regeneration to work:\n- No wound being clotted in the last cycle check from this setting\n- Setting: "Require Heart Rate"\n- Setting: "Required Blood Volume"</English>
@@ -1698,6 +1771,7 @@
             <Chinese>凝血因子再生檢查之間的時間。成功檢查後將新增 +1 個因素。使用設定：「凝血因子」為限值。\n注意：如果超過限制，將使用此時間，然後刪除 -1 因子，直到達到設定：「凝血因子」。提示：血栓素(TXA)或 EACA 停止丟失因子\n再生工作的要求：\n-在此設定下的最後一個週期檢查中沒有傷口凝結\n-設定：「要求心率」\n-設定：「所需血容量」</Chinese>
             <Chinesesimp>凝血因子再生检查之间的时间。成功检查后将添加+1个因素。使用设置：“凝血因子”为限值。\n注意：如果超过限制，将使用此时间，然后删除-1因子，直到达到设置：“凝血因子”。提示：血栓素(TXA)或EACA停止丢失因子\n再生工作的要求：\n-在此设置下的最后一个周期检查中没有伤口凝结\n-设置：“要求心率”\n-设定：“所需血容量”</Chinesesimp>
             <Dutch>De tijd tussen stollingsfactor hergeneratie checks. Geeft +1 factor op een succesvolle check. Gebruikt instelling: "Stollingsfactoren" als limiet. \n Wees alert: als het limiet overschreden is, dan zal na deze check 1 factor verwijderd worden (-1 factoren) tot het limiet weer bereikt is. Tip: TXA en EACA stoppen het verlies van factoren.\nVereisten voor hergeneratie:\n- Geen wond gestold in de laaste cyclus van deze instelling,\n- Instelling: "Vereist hartslag"\n- "Benodigd bloedvolume"</Dutch>
+            <Turkish>Koagülasyon faktörü yenilenme kontrolleri arasındaki süredir. Başarılı bir kontrolde +1 faktör eklenir. Üst sınır olarak “Coagulation Factors” ayarı kullanılır.\n Not: Üst sınır aşılırsa bu süre kullanılmaya devam edilir ve “Coagulation Factors” değerine ulaşılana kadar -1 faktör çıkarılır. İpucu: TXA veya EACA faktör kaybını durdurur\nYenilenmenin çalışması için gerekenler:\n- Bu ayara ait son döngü kontrolünde pıhtılaşan bir yara olmamalı\n- Ayar: “Require Heart Rate”\n- Ayar: “Required Blood Volume”</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SETTING_Coagulation_Time">
             <English>Clotting Cycle Time</English>
@@ -1710,6 +1784,7 @@
             <Chinese>凝血週期時間</Chinese>
             <Chinesesimp>凝血周期时间</Chinesesimp>
             <Dutch>Stollingscyclustijd</Dutch>
+            <Turkish>Pıhtılaşma Döngü Süresi</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SETTING_Coagulation_Time_Clotting_DESC">
             <English>This time gets divided by 2, randomized &amp; added with the same value devided by 2.\nFor example, if the value was set to 10s this would be one possible varriation: (random (10 / 2)) + (10 / 2) = 8s</English>
@@ -1722,6 +1797,8 @@
             <Chinese>此時間除以 2，隨機化並加上除以 2 的相同值。\n例如，如果該值設定為 10 秒，則可能出現一種變化： (random (10 / 2)) + (10 / 2) = 8 秒</Chinese>
             <Chinesesimp>此时间除以2，随机化并加上除以2的相同值。\n例如，如果该值设置为10秒，则可能出现一种变化： (random (10 / 2)) + (10 / 2) = 8s</Chinesesimp>
             <Dutch>Deze tijd wordt door 2 gedeeld, gerandomiseerd en dan met dezelfde waarde gedeeld door 2 opgeteld. \nBijvoorbeeld: als deze waarde op 10 seconden ingesteld staat dan is één mogelijke variatie:(random(10/2))+(10/2) = 8s</Dutch>
+            <Turkish>Bu süre ikiye bölünür, rastgeleleştirilir ve tekrar yarısı eklenir.
+Örnek: 10 sn → (random (10 / 2)) + (10 / 2) = 8 sn</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SETTING_Coagulation_Time_DESC">
             <English>The time between each wound clotting cycle that start wound clotting. (low number may cause lag)</English>
@@ -1734,6 +1811,7 @@
             <Chinese>開始傷口凝血的每個傷口凝血週期之間的時間。（數字低可能會導致延遲）</Chinese>
             <Chinesesimp>开始伤口凝血的每个伤口凝血周期之间的时间。（数字低可能会导致滞后）</Chinesesimp>
             <Dutch>De hoeveelheid tijd tussen elke wondstollingscyclus. (een laag nummer kan leiden tot lag)</Dutch>
+            <Turkish>Her yara pıhtılaşma döngüsü arasındaki süredir. (Düşük değer gecikmeye sebep olabilir)</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SETTING_Coagulation_Time_Large">
             <English>Large Wounds Clotting Time</English>
@@ -1746,6 +1824,7 @@
             <Chinese>大傷口凝血時間</Chinese>
             <Chinesesimp>大伤口凝血时间</Chinesesimp>
             <Dutch>Grote wonden stollingstijd</Dutch>
+            <Turkish>Büyük Yaralar İçin Pıhtılaşma Süresi</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SETTING_Coagulation_Time_Medium">
             <English>Medium Wounds Clotting Time</English>
@@ -1758,6 +1837,7 @@
             <Chinese>中等傷口凝血時間</Chinese>
             <Chinesesimp>中等伤口凝血时间</Chinesesimp>
             <Dutch>Middelgrote wonden stollingstijd</Dutch>
+            <Turkish>Orta Yaralar İçin Pıhtılaşma Süresi</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SETTING_Coagulation_Time_Minor">
             <English>Minor Wounds Clotting Time</English>
@@ -1770,6 +1850,7 @@
             <Chinese>輕傷凝血時間</Chinese>
             <Chinesesimp>轻伤凝血时间</Chinesesimp>
             <Dutch>Kleine wonden stollingstijd</Dutch>
+            <Turkish>Küçük Yaralar İçin Pıhtılaşma Süresi</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SETTING_Coagulation_allowOnAI">
             <English>Affect AI</English>
@@ -1782,6 +1863,7 @@
             <Chinese>影響 AI</Chinese>
             <Chinesesimp>影响AI</Chinesesimp>
             <Dutch>Beïnvloed AI/KI</Dutch>
+            <Turkish>AI’yı Etkile</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SETTING_Coagulation_allowOnAI_DESC">
             <English>Allow coagulation to affect AI units.\nEvery other value will still be required if turned on. (May cause lag if many AI is present)</English>
@@ -1794,6 +1876,8 @@
             <Chinese>允許凝固影響 AI 單位。\n如果開啟，仍需要其他值。（如果存在許多 AI，可能會導致延遲）</Chinese>
             <Chinesesimp>允许凝固影响AI单位。\n如果打开，仍需要其他值。（如果存在许多AI，可能会导致延迟）</Chinesesimp>
             <Dutch>Laat coagulatie AI/KI beïnvloeden.\nElke andere waarde wordt ook voor AI/KI gecheckt wanneer dit aanstaat. (Kan prestatieproblemen opleveren als er veel AI's/KI's aanwezig zijn.)</Dutch>
+            <Turkish>Koagülasyonun AI birimleri etkilemesine izin verir.
+(Not: Çok sayıda AI varsa gecikmeye yol açabilir)</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SETTING_Coagulation_allow_EACA_script">
             <English>Allow Additional EACA Stiching</English>
@@ -1806,6 +1890,7 @@
             <Chinese>允許進行額外的 EACA 縫合</Chinese>
             <Chinesesimp>允许进行额外的EACA缝合</Chinesesimp>
             <Dutch>Sta additionele EACA hechtingen toe</Dutch>
+            <Turkish>Ek EACA Dikişine İzin Ver</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SETTING_Coagulation_allow_EACA_script_DESC">
             <English>If enabled EACA will keep all functionality and start stitching bandaged wounds</English>
@@ -1818,6 +1903,7 @@
             <Chinese>如果啟用，EACA 將保留所有功能並開始縫合繃帶傷口</Chinese>
             <Chinesesimp>如果启用，EACA将保留所有功能并开始缝合绷带伤口</Chinesesimp>
             <Dutch>EACA houdt zijn functionaliteit en zal wonden hechten wanneer deze instelling actief is.</Dutch>
+            <Turkish>Etkinleştirildiğinde EACA tüm işlevlerini korur ve bandajlı yaraları dikmeye başlar</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SETTING_Coagulation_allow_LargeWounds">
             <English>Affect Large Wounds</English>
@@ -1830,6 +1916,7 @@
             <Chinese>影響大傷口</Chinese>
             <Chinesesimp>影响大伤口</Chinesesimp>
             <Dutch>Beïnvloed grote wonden</Dutch>
+            <Turkish>Büyük Yaraları Etkile</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SETTING_Coagulation_allow_LargeWounds_DESC">
             <English>Allow coagulation to affect large wounds when clotting</English>
@@ -1842,6 +1929,7 @@
             <Chinese>凝血時允許凝血影響大傷口</Chinese>
             <Chinesesimp>凝血时允许凝血影响大伤口</Chinesesimp>
             <Dutch>Staat toe dat coagulatie grote wonden beïnvloed tijdens het stollen</Dutch>
+            <Turkish>Pıhtılaşma sırasında koagülasyonun büyük yaraları etkilemesine izin ver</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SETTING_Coagulation_allow_MediumWounds">
             <English>Affect Medium Wounds</English>
@@ -1854,6 +1942,7 @@
             <Chinese>影響中度傷口</Chinese>
             <Chinesesimp>影响中度伤口</Chinesesimp>
             <Dutch>Beïnvloed middelgrote wonden</Dutch>
+            <Turkish>Orta Yaraları Etkile</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SETTING_Coagulation_allow_MediumWounds_DESC">
             <English>Allow coagulation to affect medium wounds when clotting</English>
@@ -1866,6 +1955,7 @@
             <Chinese>凝血時允許凝血影響中度傷口</Chinese>
             <Chinesesimp>凝血时允许凝血影响中度伤口</Chinesesimp>
             <Dutch>Staat toe dat coagulatie middelgrote wonden beïnvloed tijdens het stollen</Dutch>
+            <Turkish>Ek TXA Bandajlamasına İzin Ver</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SETTING_Coagulation_allow_MinorWounds">
             <English>Affect Minor Wounds</English>
@@ -1878,6 +1968,7 @@
             <Chinese>影響輕微傷口</Chinese>
             <Chinesesimp>影响轻微伤口</Chinesesimp>
             <Dutch>Beïnvloed kleine wonden</Dutch>
+            <Turkish>Küçük Yaraları Etkile</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SETTING_Coagulation_allow_MinorWounds_DESC">
             <English>Allow coagulation to affect minor wounds when clotting</English>
@@ -1890,6 +1981,7 @@
             <Chinese>凝血時允許凝血影響輕微傷口</Chinese>
             <Chinesesimp>凝血时允许凝血影响轻微伤口</Chinesesimp>
             <Dutch>Staat toe dat coagulatie kleine wonden beïnvloed tijdens het stollen</Dutch>
+            <Turkish>Pıhtılaşma sırasında koagülasyonun orta yaraları etkilemesine izin ver</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SETTING_Coagulation_allow_TXA_script">
             <English>Allow Additional TXA Bandaging</English>
@@ -1902,6 +1994,7 @@
             <Chinese>允許額外的血栓素(TXA)包紮</Chinese>
             <Chinesesimp>允许额外的血栓素(TXA)包扎</Chinesesimp>
             <Dutch>Sta additionele TXA dichtingen toe</Dutch>
+            <Turkish>Ek TXA Bandajlamasına İzin Ver</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SETTING_Coagulation_allow_TXA_script_DESC">
             <English>If enabled TXA will keep all functionality and start bandaging wounds itself</English>
@@ -1914,6 +2007,7 @@
             <Chinese>如果啟用，血栓素(TXA)將保持所有功能並開始自行包紮傷口</Chinese>
             <Chinesesimp>如果启用，血栓素(TXA)将保持所有功能并开始自行包扎伤口</Chinesesimp>
             <Dutch>TXA houdt zijn functionaliteit en zal wonden dichten wanneer deze instelling actief is.</Dutch>
+            <Turkish>Etkinleştirildiğinde TXA yaraları otomatik olarak bandajlamaya başlar</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SETTING_Coagulation_allow_clot_text">
             <English>Allow Clots To Be Shown in Menu</English>
@@ -1926,6 +2020,7 @@
             <Chinese>允許在選單中顯示凝塊</Chinese>
             <Chinesesimp>允许在菜单中显示凝块</Chinesesimp>
             <Dutch>Sta toe dat stollingen worden weergeven in het menu</Dutch>
+            <Turkish>Pıhtıların Menüde Gösterilmesine İzin Ver</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SETTING_Coagulation_allow_clot_text_DESC">
             <English>If enabled, when coagulation is bandaging a wound it will add a interaction log to the medical menu.</English>
@@ -1938,6 +2033,7 @@
             <Chinese>如果啟用，當凝固包紮傷口時，它將在醫療選單中新增一個互動日誌。</Chinese>
             <Chinesesimp>如果启用，当凝固包扎伤口时，它将在医疗菜单中添加一个交互日志。</Chinesesimp>
             <Dutch>Wanneer dit is ingeschakeld is worden gestolde wonden toegevoegd aan de interactie log van het medisch menu.</Dutch>
+            <Turkish>Etkinleştirildiğinde koagülasyon bir yarayı bandajlarken medikal menüye etkileşim kaydı eklenir</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SETTING_Coagulation_on_all_Bodyparts">
             <English>Simultaneous Bodypart Coagulation</English>
@@ -1950,6 +2046,7 @@
             <Chinese>同時進行身體部位凝血</Chinese>
             <Chinesesimp>同时进行身体部位凝血</Chinesesimp>
             <Dutch>Gelijktijdige coagulatie</Dutch>
+            <Turkish>Eş Zamanlı Vücut Bölgesi Koagülasyonu</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SETTING_Coagulation_on_all_Bodyparts_DESC">
             <English>If enabled each bodypart will be treated simultaneously by coagulation.\nMeaning if you have a wound on the head and body they will both be treated in the same coagulation cycle.</English>
@@ -1962,6 +2059,7 @@
             <Chinese>如果啟用，每個身體部位將同時接受凝血治療。\n也就是說，如果你的頭部和身體都有傷口，它們都會在相同的凝血週期中接受治療。</Chinese>
             <Chinesesimp>如果启用，每个身体部位将同时接受凝血治疗。\n也就是说，如果你的头部和身体都有伤口，它们都会在相同的凝血周期中接受治疗。</Chinesesimp>
             <Dutch>Als dit ingeschakeld is, zal elk lichaamsdeel tegelijkertijd behandeld worden door coagulatie. \nWat betekent dat als je een wond aan je arm en been hebt, dat deze in dezelfde coagulatiecyclus behandeld worden</Dutch>
+            <Turkish>Etkinleştirildiğinde her bir vücut bölgesi koagülasyon tarafından eşzamanlı olarak tedavi edilir.\nYani baş ve gövdede yara varsa, her ikisi de aynı koagülasyon döngüsünde tedavi edilir.</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SETTING_Coagulation_requireBV">
             <English>Required Blood Volume</English>
@@ -1974,6 +2072,7 @@
             <Chinese>所需血容量</Chinese>
             <Chinesesimp>所需血容量</Chinesesimp>
             <Dutch>Benodigd bloedvolume</Dutch>
+            <Turkish>Gerekli Kan Hacmi</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SETTING_Coagulation_requireBV_DESC">
             <English>Minimum volume of blood required for coagulation to work</English>
@@ -1986,6 +2085,7 @@
             <Chinese>凝血所需的最小血容量</Chinese>
             <Chinesesimp>凝血所需的最小血容量</Chinesesimp>
             <Dutch>Het minimale bloedvolume dat vereist is voor coagulatie om te werken</Dutch>
+            <Turkish>Koagülasyonun çalışması için gerekli minimum kan hacmi</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SETTING_Coagulation_requireHR">
             <English>Require Heart Rate</English>
@@ -1998,6 +2098,7 @@
             <Chinese>要求心率</Chinese>
             <Chinesesimp>要求心率</Chinesesimp>
             <Dutch>Vereist hartslag</Dutch>
+            <Turkish>Kalp Atım Hızı Gereksinimi</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SETTING_Coagulation_requireHR_DESC">
             <English>Should coagulation require a heart rate above 20BPM? (Doing CPR will keep HR above 20BPM)</English>
@@ -2010,6 +2111,8 @@
             <Chinese>凝血需要心率超過 20 BPM 嗎？（做心肺復甦術將使心率保持在 20 BPM 以上）</Chinese>
             <Chinesesimp>凝血需要心率超过20BPM吗？（做心肺复苏术将使心率保持在20BPM以上）</Chinesesimp>
             <Dutch>Is een hartslag van meer dan 20SPM benodigt voor coagulatie? (Het uitvoeren van CPR houdt de hartslag boven 20SPM)</Dutch>
+            <Turkish>Koagülasyon için kalp atım hızının 20 BPM üzerinde olması gerekir mi?
+(CPR, HR’yi 20 BPM üzerinde tutar)</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SETTING_Coagulation_tourniquetBlock">
             <English>Tournique Blocks Blood Clotting</English>
@@ -2022,6 +2125,7 @@
             <Chinese>止血帶阻斷凝血</Chinese>
             <Chinesesimp>止血带阻断凝血</Chinesesimp>
             <Dutch>Tourniquets blokkeren wondstolling</Dutch>
+            <Turkish>Turnike Kan Pıhtılaşmasını Engeller</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SETTING_Coagulation_tourniquetBlock_DESC">
             <English>If enabled a applied tourniquet will stop wounds from being closed from coagulation on that bodypart</English>
@@ -2034,6 +2138,7 @@
             <Chinese>如果啟用止血帶，可以防止傷口因身體部位的凝血而閉合</Chinese>
             <Chinesesimp>如果启用止血带，可以防止伤口因身体部位的凝血而闭合</Chinesesimp>
             <Dutch>Tourniquets voorkomen dat wonden op hetzelfde ledemaat dichtgemaakt worden door coagulatie wanneer deze instelling actief is</Dutch>
+            <Turkish>Uygulanan turnike, o bölgedeki yaraların koagülasyonla kapanmasını engeller</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SETTING_EACA_Trauma">
             <English>EACA Clears Trauma</English>
@@ -2048,6 +2153,7 @@
             <Chinese>EACA 清除創傷</Chinese>
             <Chinesesimp>EACA清除创伤</Chinesesimp>
             <Dutch>EACA verwijderd trauma</Dutch>
+            <Turkish>EACA Travmayı Temizler</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SETTING_EACA_Trauma_Desc">
             <English>Allows Trauma to be cleared by EACA in addition to stitching</English>
@@ -2062,6 +2168,7 @@
             <Chinese>除了縫合外，EACA 還可以清除創傷</Chinese>
             <Chinesesimp>除了缝合外，EACA还可以清除创伤</Chinesesimp>
             <Dutch>Staat toe dat EACA trauma verwijderd, als additie van hechten</Dutch>
+            <Turkish>EACA’nın dikişe ek olarak travmayı temizlemesine izin verir</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SETTING_IV_FLOW_CONTROL">
             <English>Enable IV/IO Flow Control</English>
@@ -2074,6 +2181,7 @@
             <Chinese>啟用IV/IO流量控制</Chinese>
             <Chinesesimp>启用IV/IO流量控制</Chinesesimp>
             <Dutch>Sta IV/IO Loopsnelheidscontrole toe</Dutch>
+            <Turkish>IV/IO Akış Kontrolünü Etkinleştir</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SETTING_IV_FLOW_CONTROL_DESC">
             <English>Enables the IV/IO flow control menu which gives the medic fine control over the volume running through the active line</English>
@@ -2086,6 +2194,7 @@
             <Chinese>啟用IV/IO流量控制選單，使醫務人員能夠精細控制通過活動線路的音量</Chinese>
             <Chinesesimp>启用IV/IO流量控制菜单，使医务人员能够精细控制通过活动线路的音量</Chinesesimp>
             <Dutch>Activeert het IV/IO loopsnelheidscontrole menu wat het medisch personeel fijne controle geeft over de loopsnelheid in de active lijn</Dutch>
+            <Turkish>IV/IO hattından geçen sıvı miktarının ayrıntılı kontrolünü sağlar</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SETTING_Kidney_Action">
             <English>Kidney damage/failure</English>
@@ -2103,6 +2212,7 @@
             <Chinesesimp>肾损伤/衰竭</Chinesesimp>
             <Finnish>Munuaisvaurio/munuaisten vajaatoiminta</Finnish>
             <Dutch>Nierschade/-falen</Dutch>
+            <Turkish>Böbrek Hasarı / Yetmezliği</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SETTING_Kidney_Action_DESC">
             <English>Enables kidney damage caused by overuse of saline</English>
@@ -2120,6 +2230,7 @@
             <Chinesesimp>启用因过度使用生理盐水而造成的肾脏损害</Chinesesimp>
             <Finnish>Mahdollistaa suolaliuoksen liiallisen käytön aiheuttaman munuaisvaurion</Finnish>
             <Dutch>Schakelt nierschade veroorzaakt door overgebruik van saline in</Dutch>
+            <Turkish>Aşırı salin kullanımına bağlı böbrek hasarını etkinleştirir</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SETTING_Max_Stack">
             <English>Maximum Fluid Bag Stack</English>
@@ -2137,6 +2248,7 @@
             <Chinesesimp>注射液堆叠上限</Chinesesimp>
             <Finnish>Suurin nestepussipino</Finnish>
             <Dutch>Maximale vloeistofzak stapel</Dutch>
+            <Turkish>Maksimum Sıvı Torbası Yığılması</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SETTING_Max_Stack_DESC">
             <English>The maximum amount of fluid bags that can be stacked to increase IV flow rate</English>
@@ -2154,6 +2266,7 @@
             <Chinesesimp>可堆叠的最大液体袋量以增加 IV 流速</Chinesesimp>
             <Finnish>Suurin määrä nestepusseja, jotka voidaan pinota IV-virtausnopeuden lisäämiseksi</Finnish>
             <Dutch>De maximale hoeveelheid vloeistofzakken die gestapeld kunnen worden om de IV vloeisnelheid te verhogen</Dutch>
+            <Turkish>IV akış hızını artırmak için üst üste bağlanabilecek maksimum sıvı torbası sayısı</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SETTING_PervitinSpeed_DESC">
             <English>The animation speed that gets set in Stage 1 of Pervitin. (1 = normal, 2 = twice)</English>
@@ -2171,6 +2284,7 @@
             <Chinesesimp>在柏飞汀(Pervitin)的第一阶段中设置的动画速度。（1=正常，2=两次）</Chinesesimp>
             <Finnish>Animaationopeus, joka asetetaan pervitiinin vaiheessa 1. (1 = normaali, 2 = kahdesti)</Finnish>
             <Dutch>Animatiesnelheid van fase 1 van pervitin. (1 = normaal, 2 = dubbel)</Dutch>
+            <Turkish>Pervitin’in 1. aşamasında ayarlanan animasyon hızı (1 = normal, 2 = iki kat)</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SETTING_PervitinSpeed_displayName">
             <English>Pervitin Speed Boost</English>
@@ -2188,6 +2302,7 @@
             <Chinesesimp>柏飞汀(Pervitin)速度提升</Chinesesimp>
             <Finnish>Pervitiini nopeuden lisääminen</Finnish>
             <Dutch>Pervitin snelheidsboost</Dutch>
+            <Turkish>Pervitin Hız Artışı</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SETTING_REQUIRE_INS_IV">
             <English>Fluid Require inserted IV/IO</English>
@@ -2202,6 +2317,7 @@
             <Chinese>注射需要插入IV/IO</Chinese>
             <Chinesesimp>推注需要插入IV/IO</Chinesesimp>
             <Dutch>Vloeistoffen vereisen een aangelegde IV/IO</Dutch>
+            <Turkish>Sıvı vermek için IV/IO takılı olmalı</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SETTING_REQUIRE_INS_IV_BLOOD_DRAW">
             <English>Blood Drawing Require IV/IO</English>
@@ -2216,6 +2332,7 @@
             <Chinese>抽血需要插入IV/IO</Chinese>
             <Chinesesimp>抽血需要插入IV/IO</Chinesesimp>
             <Dutch>Bloedoptrekken vereist IV/IO</Dutch>
+            <Turkish>Kan almak için IV/IO gerekli</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SETTING_REQUIRE_INS_IV_BLOOD_DRAW_DESC">
             <English>Default false. If true, you will need to insert IV/IO first before being able to draw blood from someone. \nIf false, you can draw without it.</English>
@@ -2230,6 +2347,7 @@
             <Chinese>默認值為false。如果是真的，你需要先插入靜脈注射/IO，然後才能從某人身上抽血。\n如果是假的，你可以不用它畫畫。</Chinese>
             <Chinesesimp>默认值为false。如果是真的，你需要先插入静脉注射/IO，然后才能从某人身上抽血。\n如果是假的，你可以不用它画画。</Chinesesimp>
             <Dutch>Standaard vals. Wanneer waar moet er eerst een IV/IO toegediend worden voordat je bloed kan optrekken. \nWanneer vals is dit niet vereist.</Dutch>
+            <Turkish>Varsayılan: false. True ise birinden kan alabilmek için önce IV/IO takmanız gerekir. \nFalse ise IV/IO olmadan kan alabilirsiniz.</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SETTING_REQUIRE_INS_IV_DESC">
             <English>Default false. If true, you will need to insert IV/IO first before being able to give someone saline/blood/plasma. \nIf false, it retains standard ACE behaviour for using saline/blood/plasma.</English>
@@ -2245,7 +2363,7 @@
             <Japanese>デフォルトではfalseです。trueの場合、生理食塩液/血液/血漿の輸液を行う前にIV/IOの刺入が必要になります。 \nfalseの場合はACE標準の生理食塩液/血液/血漿と同様に作用します。</Japanese>
             <Chinese>默認為真。 如果為 false, 您需要先建立 IV/IO, 然後才能給某人注射鹽水/血液/血漿。 \n如果為 false, 它保留使用鹽水/血液/血漿的標準 ACE 行為。</Chinese>
             <Chinesesimp>默认为真。 如果为 false, 您需要先建立 IV/IO, 然后才能给某人注射盐水/血液/血浆。 \n如果为 false, 它保留使用盐水/血液/血浆的标准 ACE 行为。</Chinesesimp>
-            <Turkish>VDefault false. Doğruysa, birine salin/kan/plazma vermeden önce IV/IO eklemeniz gerekir. \nYanlışsa, salin/kan/plazma kullanımı için standart ACE davranışını korur.</Turkish>
+            <Turkish>Varsayılan: false. True ise birine salin/kan/plazma verebilmek için önce IV/IO takmanız gerekir. \nFalse ise salin/kan/plazma kullanımı standart ACE davranışını korur.</Turkish>
             <Finnish>Oletusarvo epätosi. Jos totta, sinun on lisättävä IV/IO ensin, ennen kuin voit antaa jollekulle suolaliuosta/verta/plasmaa \nJos väärin, se säilyttää normaalin ACE-käyttäytymisen suolaliuoksen/veren/plasman käytössä.</Finnish>
             <Dutch>Standaard vals. Wanneer waar moet er eerst een IV/IO aangelegd worden voordat je vloeistoffen kan toedienen.\nWanneer vals, wordt standaard ACE gedrag gebruikt voor vloeistoffen</Dutch>
         </Key>
@@ -2265,6 +2383,7 @@
             <Chinesesimp>药物需要通过IV/IO注射</Chinesesimp>
             <Finnish>Lääkkeet vaativat IV/IO:n</Finnish>
             <Dutch>Medicaties vereisen IV/IO</Dutch>
+            <Turkish>İlaçlar IV/IO gerektirir</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SETTING_REQUIRE_INS_IV_Medications_DESC">
             <English>Default false. If true, you will need to insert IV/IO first before being able to give someone medications. \nIf false, you can give them without it.</English>
@@ -2282,6 +2401,7 @@
             <Chinesesimp>默认假。 如果为真，您将需要先建立 IV/IO, 然后才能给某人注射药。 \n如果为假, 您可以在没有IV/IO的情况下注射药物他们。</Chinesesimp>
             <Finnish>Oletusarvo epätosi. Jos totta, sinun on lisättävä IV/IO ensin, ennen kuin voit antaa jollekin lääkkeitä. \nJos vääriä, voit antaa ne ilman sitä.</Finnish>
             <Dutch>Standaard vals. Wanneer waar moet er eerst een IV/IO aangelegd worden voordat medicatie toegedient kan worden. \nWanneer vals kunnen medicijnen gegeven worden zonder IV/IO</Dutch>
+            <Turkish>Varsayılan: false. True ise birine ilaç verebilmek için önce IV/IO takmanız gerekir. \nFalse ise IV/IO olmadan ilaç verebilirsiniz.</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SETTING_Reorientation_Enable">
             <English>Reorientation enabled?</English>
@@ -2371,6 +2491,7 @@
             <Chinesesimp>启用武器摇摆</Chinesesimp>
             <Finnish>Ota aseen heiluminen käyttöön</Finnish>
             <Dutch>Schakel wapenbeweging in</Dutch>
+            <Turkish>Silah sallanmasını etkinleştir</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SETTING_Weapon_Sway_Pervitin_DESC">
             <English>Enables if pervitin should influence your weapon sway</English>
@@ -2388,6 +2509,7 @@
             <Chinesesimp>启用柏飞汀(Pervitin)影响您的武器摆动</Chinesesimp>
             <Finnish>Mahdollistaa pervitiinin vaikutuksen aseen heilumiseen.</Finnish>
             <Dutch>Bepaald of pervitin invloed heeft op wapenbewegingen</Dutch>
+            <Turkish>Pervitin’in silah sallanmasını etkilemesini etkinleştirir</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SETTING_allowStackScript_EACA">
             <English>Allow Stacking</English>
@@ -2401,6 +2523,7 @@
             <Chinese>允許堆疊</Chinese>
             <Chinesesimp>允许堆叠</Chinesesimp>
             <Dutch>Sta stapelen toe</Dutch>
+            <Turkish>İstiflemeye izin ver</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SETTING_allowStackScript_EACA_DESC">
             <English>If enabled EACA will be stackable and double its efficiency</English>
@@ -2414,6 +2537,7 @@
             <Chinese>如果啟用，EACA 將可堆疊，效率提高一倍</Chinese>
             <Chinesesimp>如果启用，EACA将可堆叠，效率提高一倍</Chinesesimp>
             <Dutch>Staat het stapelen van EACA toe wanneer ingeschakeld, wat leidt tot een verdubbeling van de effectiviteit</Dutch>
+            <Turkish>Etkinleştirilirse EACA istiflenebilir olur ve etkinliği iki katına çıkar</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SETTING_allowStackScript_TXA">
             <English>Allow Stacking</English>
@@ -2426,6 +2550,7 @@
             <Chinese>允許堆疊</Chinese>
             <Chinesesimp>允许堆叠</Chinesesimp>
             <Dutch>Sta stapelen toe</Dutch>
+            <Turkish>İstiflemeye izin ver</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SETTING_allowStackScript_TXA_DESC">
             <English>If enabled TXA will be stackable and double it's efficiency</English>
@@ -2438,6 +2563,7 @@
             <Chinese>如果啟用血栓素(TXA)，它將是可堆疊的，效率提高一倍</Chinese>
             <Chinesesimp>如果启用血栓素(TXA)，它将是可堆叠的，效率提高一倍</Chinesesimp>
             <Dutch>Wanneer ingeschakeld: sta het stapelen van TXA toe, wat de effectiviteit verdubbeld)</Dutch>
+            <Turkish>Etkinleştirilirse TXA istiflenebilir olur ve etkinliği iki katına çıkar</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SETTING_bandageCycleTime_EACA">
             <English>EACA Cycle Time</English>
@@ -2451,6 +2577,7 @@
             <Chinese>EACA 循環時間</Chinese>
             <Chinesesimp>EACA循环时间</Chinesesimp>
             <Dutch>EACA cyclustimer</Dutch>
+            <Turkish>EACA Döngü Süresi</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SETTING_bandageCycleTime_EACA_DESC">
             <English>The time it takes for EACA to close a stich a wound</English>
@@ -2464,6 +2591,7 @@
             <Chinese>EACA 閉合傷口所需的時間</Chinese>
             <Chinesesimp>EACA闭合伤口所需的时间</Chinesesimp>
             <Dutch>Hoe lang het duurt voor EACA om een wond te hechten</Dutch>
+            <Turkish>EACA’nın bir dikişli yarayı kapatması için geçen süre</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SETTING_bandageCycleTime_TXA">
             <English>TXA Cycle Time</English>
@@ -2476,6 +2604,7 @@
             <Chinese>血栓素(TXA)循環時間</Chinese>
             <Chinesesimp>血栓素(TXA)循环时间</Chinesesimp>
             <Dutch>TXA cyclustijd</Dutch>
+            <Turkish>TXA Döngü Süresi</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SETTING_bandageCycleTime_TXA_DESC">
             <English>The time it takes for TXA to close a wound</English>
@@ -2488,6 +2617,7 @@
             <Chinese>血栓素(TXA)閉合傷口所需的時間</Chinese>
             <Chinesesimp>血栓素(TXA)闭合伤口所需的时间</Chinesesimp>
             <Dutch>Hoe lang het duurt voordat TXA een wond dicht</Dutch>
+            <Turkish>TXA’nın bir yarayı kapatması için geçen süre</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SETTING_carbonateChance">
             <English>Maximum Carbonate Success Chance</English>
@@ -2505,11 +2635,13 @@
             <Chinesesimp>成功使用碳酸盐的几率</Chinesesimp>
             <Finnish>Suurin karbonaatin onnistumismahdollisuus</Finnish>
             <Dutch>Maximale succeskans van carbonaat</Dutch>
+            <Turkish>Maksimum Karbonat Başarı Şansı</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SETTING_carbonateChance_DESC">
             <English>Chance for successful carbonate treatment</English>
             <German>Chance für erfolgreiche Carbonat-Behandlung</German>
             <Japanese>炭酸アンモニウムでの治療の成功確率</Japanese>
+            <Turkish>Başarılı karbonat tedavisi şansı</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SETTING_coagulation_Factor_Limit">
             <English>Coagulation Factor Limit</English>
@@ -2522,6 +2654,7 @@
             <Chinese>凝血因子限值</Chinese>
             <Chinesesimp>凝血因子限值</Chinesesimp>
             <Dutch>Stollingsfactor limiet</Dutch>
+            <Turkish>Pıhtılaşma Faktörü Limiti</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SETTING_coagulation_Factor_Limit_DESC">
             <English>The limit for how many coagulation factors can be present inside a units body at once. Meaning if you administer plasma this is the maximum attainable value.</English>
@@ -2534,6 +2667,7 @@
             <Chinese>一個單位體內同時存在多少凝血因子的限制。這意味著，如果你服用血漿，這是可達到的最大值。</Chinese>
             <Chinesesimp>一个单位体内同时存在多少凝血因子的限制。这意味着，如果你服用血浆，这是可达到的最大值。</Chinesesimp>
             <Dutch>Het limiet voor hoeveel stollingsfactoren er in een eenheids lichaam tegelijkertijd aanwezig kan zijn. Wat betekent dat dit de waarde is waar zelfs plasma geen extra factoren meer toevoegd</Dutch>
+            <Turkish>Bir birimin vücudunda aynı anda bulunabilecek pıhtılaşma faktörü sayısının üst sınırı. Yani plazma uygularsanız ulaşılabilecek maksimum değerdir.</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SETTING_ivCheckLimbDamage">
             <English>IV Check limb damage</English>
@@ -2551,6 +2685,7 @@
             <Chinesesimp>IV 检查肢体损伤</Chinesesimp>
             <Finnish>IV tarkista raajan vauriot</Finnish>
             <Dutch>IV checkt voor ledemaatschade</Dutch>
+            <Turkish>IV uzuv hasarını kontrol et</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SETTING_ivCheckLimbDamage_DESC">
             <English>Whether or not you can apply the IV to the too damaged limb. In default, this is disabled.</English>
@@ -2568,6 +2703,7 @@
             <Chinesesimp>是否可以将 IV 应用于受损的肢体。 默认情况下，这是禁用的。</Chinesesimp>
             <Finnish>Voitko laittaa IV vaurioituneeseen raajaan vai et. Tämä on oletuksena pois käytöstä.</Finnish>
             <Dutch>Of je wel of niet een IV kan plaatsen op een te beschadigd ledemaat. standaard staat dit uit.</Dutch>
+            <Turkish>Aşırı hasarlı bir uzva IV uygulanıp uygulanamayacağını belirler. Varsayılan olarak devre dışıdır.</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SETTING_keepScriptRunning_EACA">
             <English>Keep Stiching Until Out Of System</English>
@@ -2581,6 +2717,7 @@
             <Chinese>繼續攪拌，直到系統崩潰</Chinese>
             <Chinesesimp>继续搅拌，直到系统崩溃</Chinesesimp>
             <Dutch>Blijf hechten tot uit systeem</Dutch>
+            <Turkish>Sistemden çıkana kadar dikişe devam et</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SETTING_keepScriptRunning_EACA_DESC">
             <English>If enabled EACA will keep stichinng until it's out of your system\nIf disabled EACA will stop working after stiching the last bandaged wound it can find</English>
@@ -2594,6 +2731,7 @@
             <Chinese>如果啟用，EACA 將繼續縫合，直到它脫離您的系統\n如果禁用，EACA 在縫合它能找到的最後一個繃帶傷口後將停止工作</Chinese>
             <Chinesesimp>如果启用，EACA将继续缝合，直到它脱离您的系统\n如果禁用，EACA在缝合它能找到的最后一个绷带伤口后将停止工作</Chinesesimp>
             <Dutch>Als dit ingeschakeld is, EACA blijft hechten tot het uit je systeem is.\nEACA zal stoppen na de laatste hechtbare wond die hij kan vinden wanneer uitgeschakeld</Dutch>
+            <Turkish>Etkinleştirilirse EACA vücuttan atılana kadar dikiş atmaya devam eder.\nDevre dışıysa, bulabildiği son bandajlı yarayı diktikten sonra çalışmayı durdurur.</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SETTING_keepScriptRunning_TXA">
             <English>Keep Bandaging Until Out Of System</English>
@@ -2606,6 +2744,7 @@
             <Chinese>保持包紮，直到脫離系統</Chinese>
             <Chinesesimp>保持包扎，直到脱离系统</Chinesesimp>
             <Dutch>Blijf verbinden tot uit het systeem</Dutch>
+            <Turkish>Sistemden çıkana kadar bandajlamaya devam et</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SETTING_keepScriptRunning_TXA_DESC">
             <English>If enabled TXA will keep bandaging until it's out of your system\nIf disabled TXA will stop working after bandaging the last wound it can find</English>
@@ -2618,6 +2757,7 @@
             <Chinese>如果啟用，血栓素(TXA)將繼續包紮，直到它離開您的系統\n如果禁用，血栓素(TXA)在包紮最後一個傷口後將停止工作</Chinese>
             <Chinesesimp>如果启用，血栓素(TXA)将继续包扎，直到它离开您的系统\n如果禁用，血栓素(TXA)在包扎最后一个伤口后将停止工作</Chinesesimp>
             <Dutch>Wanneer ingeschakeld: TXA blijft verbinden tot het uit jouw systeem is.\nWanneer uitgeschakeld: TXA Stopt met werken wanneer alle wonden gedicht zijn.</Dutch>
+            <Turkish>Etkinleştirilirse TXA vücuttan atılana kadar bandajlamaya devam eder.\nDevre dışıysa, bulabildiği son yarayı bandajladıktan sonra çalışmayı durdurur.</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SETTING_medLvl_Penthrox">
             <English>Medical level required for Penthrox Inhaler</English>
@@ -2634,6 +2774,7 @@
             <Chinesesimp>Penthrox吸入器所需的医疗水平</Chinesesimp>
             <Finnish>Lääketieteellinen koulutustaso vaatii penthrox-inhalaattorin</Finnish>
             <Dutch>Medisch niveau benodigd voor het gebruik van Penthrox inhalators</Dutch>
+            <Turkish>Penthrox İnhaler için gereken medikal seviye</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SETTING_reorientationChance">
             <English>Maximum Reorientation Success Chance</English>
@@ -2651,11 +2792,13 @@
             <Chinesesimp>成功进行恢复体态的几率</Chinesesimp>
             <Finnish>Suurin mahdollisuus uudelleenorientoitumiseen</Finnish>
             <Dutch>Maximale heroriëntatie succeskans</Dutch>
+            <Turkish>Maksimum Reoryantasyon Başarı Şansı</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SETTING_reorientationChance_DESC">
             <English>Chance for successful reorientation</English>
             <German>Chance für erfolgreiche Neuorientierung</German>
             <Japanese>患者を刺激した際の成功確率</Japanese>
+            <Turkish>Başarılı reoryantasyon şansı</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SETTING_staminaMedication">
             <English>Medication Modifies Stamina</English>
@@ -2672,6 +2815,7 @@
             <Chinesesimp>药物可以改善体力</Chinesesimp>
             <Finnish>Lääkitys muuttaa kestävyyttä</Finnish>
             <Dutch>Medicatie heeft invloed op uithoudingsvermogen</Dutch>
+            <Turkish>İlaç dayanıklılığı etkiler</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SETTING_staminaMedication_DESC">
             <English>Allow certain medications to modify (vanilla/advanced fatigue) stamina as a side effect</English>
@@ -2688,6 +2832,7 @@
             <Chinesesimp>允许某些药物改变（香草/重度疲劳）耐力作为副作用</Chinesesimp>
             <Finnish>Salli tiettyjen lääkkeiden muuttaa kestävyyttä (vanilja/edistynyt väsymys) sivuvaikutuksena</Finnish>
             <Dutch>Bepaald of sommige medicijnen het uithoudingsvermogen (vanilla/geadvanceerde uitputting) beïnvloeden als een bijwerking</Dutch>
+            <Turkish>Bazı ilaçların yan etki olarak (vanilla/gelişmiş yorgunluk) dayanıklılığı değiştirmesine izin verir</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SETTING_treatmentTime_Penthrox">
             <English>Treatment time for Penthrox Inhaler</English>
@@ -2704,6 +2849,7 @@
             <Chinesesimp>Penthrox吸入器的治疗时间</Chinesesimp>
             <Finnish>Penthrox-inhalaattorin hoitoaika</Finnish>
             <Dutch>Behandeltijd van Penthrox inhalators</Dutch>
+            <Turkish>Penthrox İnhaler tedavi süresi</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_Saline_Flush">
             <English>Saline Flush</English>
@@ -2721,6 +2867,7 @@
             <Chinesesimp>用生理盐水冲洗</Chinesesimp>
             <Finnish>suolainen flunssa</Finnish>
             <Dutch>Salinespoeling</Dutch>
+            <Turkish>Salin Yıkama</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SubCategory_Amiodarone">
             <English>Amiodarone Settings</English>
@@ -2738,6 +2885,7 @@
             <Chinesesimp>胺碘酮设置</Chinesesimp>
             <Finnish>Amiodaronin asetukset</Finnish>
             <Dutch>Amiodaron instellingen</Dutch>
+            <Turkish>Amiodaron Ayarları</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SubCategory_ApplyIO">
             <English>IO Settings</English>
@@ -2755,6 +2903,7 @@
             <Chinesesimp>IO设置</Chinesesimp>
             <Finnish>IO-asetukset</Finnish>
             <Dutch>IO instellingen</Dutch>
+            <Turkish>IO Ayarları</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SubCategory_ApplyIV">
             <English>IV Settings</English>
@@ -2772,6 +2921,7 @@
             <Chinesesimp>IV设置</Chinesesimp>
             <Finnish>IV asetukset</Finnish>
             <Dutch>IV instellingen</Dutch>
+            <Turkish>IV Ayarları</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SubCategory_Atropine">
             <English>Atropine Settings</English>
@@ -2789,6 +2939,7 @@
             <Chinesesimp>阿托品设置</Chinesesimp>
             <Finnish>Atropiiniasetukset</Finnish>
             <Dutch>Atropine instellingen</Dutch>
+            <Turkish>Atropin Ayarları</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SubCategory_Basic">
             <English>Basic Settings</English>
@@ -2806,6 +2957,7 @@
             <Chinesesimp>基础设置</Chinesesimp>
             <Finnish>Perus asetukset</Finnish>
             <Dutch>Basis instellingen</Dutch>
+            <Turkish>Temel Ayarlar</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SubCategory_CWMP">
             <English>CWMP Settings</English>
@@ -2815,6 +2967,7 @@
             <German>CWMP Einstellungen</German>
             <Japanese>戦闘傷病治療薬(CWMP)設定</Japanese>
             <Dutch>CWMP Instellingen</Dutch>
+            <Turkish>CWMP Ayarları</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SubCategory_Caffeine">
             <English>Caffeine Settings</English>
@@ -2832,6 +2985,7 @@
             <Chinesesimp>咖啡因设置</Chinesesimp>
             <Finnish>Kofeiiniasetukset</Finnish>
             <Dutch>Caffeïne instellingen</Dutch>
+            <Turkish>Kafein Ayarları</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SubCategory_Carbonate">
             <English>Carbonate Settings</English>
@@ -2849,6 +3003,7 @@
             <Chinesesimp>碳酸盐设置</Chinesesimp>
             <Finnish>Karbonaattiasetukset</Finnish>
             <Dutch>Carbonaat instellingen</Dutch>
+            <Turkish>Karbonat Ayarları</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SubCategory_Coag_Sense">
             <English>Coag-Sense Settings</English>
@@ -2862,6 +3017,7 @@
             <Chinese>Coag-Sense 設定</Chinese>
             <Chinesesimp>Coag-Sense设置</Chinesesimp>
             <Dutch>Coag-Sense instellingen</Dutch>
+            <Turkish>Coag-Sense Ayarları</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SubCategory_Coagulation">
             <English>Coagulation Settings</English>
@@ -2875,6 +3031,7 @@
             <Chinese>凝固設定</Chinese>
             <Chinesesimp>凝固设置</Chinesesimp>
             <Dutch>Coagulatie instellingen</Dutch>
+            <Turkish>Pıhtılaşma Ayarları</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SubCategory_EACA">
             <English>EACA Settings</English>
@@ -2892,6 +3049,7 @@
             <Chinesesimp>EACA设置</Chinesesimp>
             <Finnish>EACA-asetukset</Finnish>
             <Dutch>EACA instellingen</Dutch>
+            <Turkish>EACA Ayarları</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SubCategory_EpinephrineIV">
             <English>IV Epinephrine Settings</English>
@@ -2904,6 +3062,7 @@
             <Chinese>四腎上腺素設定</Chinese>
             <Chinesesimp>四肾上腺素设置</Chinesesimp>
             <Dutch>IV Adrenaline Instellingen</Dutch>
+            <Turkish>IV Epinefrin Ayarları</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SubCategory_Etomidate">
             <English>Etomidate Settings</English>
@@ -2921,6 +3080,7 @@
             <Chinesesimp>依托咪酯设置</Chinesesimp>
             <Finnish>Etomidatin asetukset</Finnish>
             <Dutch>Etomidaat instellingen</Dutch>
+            <Turkish>Etomidat Ayarları</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SubCategory_Fentanyl">
             <English>Fentanyl Settings</English>
@@ -2938,6 +3098,7 @@
             <Chinesesimp>芬太尼设置</Chinesesimp>
             <Finnish>Fentanyyliasetukset</Finnish>
             <Dutch>Fentanyl instellingen</Dutch>
+            <Turkish>Fentanil Ayarları</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SubCategory_Flumazenil">
             <English>Flumazenil Settings</English>
@@ -2955,6 +3116,7 @@
             <Chinesesimp>氟马西尼设置</Chinesesimp>
             <Finnish>Flumazenilin asetukset</Finnish>
             <Dutch>Flumazenil instellingen</Dutch>
+            <Turkish>Flumazenil Ayarları</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SubCategory_Ketamine">
             <English>Ketamine Settings</English>
@@ -2972,6 +3134,7 @@
             <Chinesesimp>氯胺酮设置</Chinesesimp>
             <Finnish>Ketamiinin asetukset</Finnish>
             <Dutch>Ketamine instellingen</Dutch>
+            <Turkish>Ketamin Ayarları</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SubCategory_Lidocaine">
             <English>Lidocaine Settings</English>
@@ -2989,6 +3152,7 @@
             <Chinesesimp>利多卡因设置</Chinesesimp>
             <Finnish>Lidokaiiniasetukset</Finnish>
             <Dutch>Lidocaïne instellingen</Dutch>
+            <Turkish>Lidokain Ayarları</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SubCategory_Lorazepam">
             <English>Lorazepam Settings</English>
@@ -3006,6 +3170,7 @@
             <Chinesesimp>劳拉西泮设置</Chinesesimp>
             <Finnish>Loratsepamin asetukset</Finnish>
             <Dutch>Lorazepam instellingen</Dutch>
+            <Turkish>Lorazepam Ayarları</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SubCategory_Nalbuphine">
             <English>Nalbuphine Settings</English>
@@ -3023,6 +3188,7 @@
             <Chinesesimp>纳布啡设置</Chinesesimp>
             <Finnish>Nalbuphine-asetukset</Finnish>
             <Dutch>Nalbufine instellingen</Dutch>
+            <Turkish>Nalbuphin Ayarları</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SubCategory_Naloxone">
             <English>Naloxone Settings</English>
@@ -3040,6 +3206,7 @@
             <Chinesesimp>纳洛酮设置</Chinesesimp>
             <Finnish>Naloksonin asetukset</Finnish>
             <Dutch>Naloxone instellingen</Dutch>
+            <Turkish>Nalokson Ayarları</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SubCategory_Nitroglycerin">
             <English>Nitroglycerin Settings</English>
@@ -3057,6 +3224,7 @@
             <Chinesesimp>硝酸甘油设置</Chinesesimp>
             <Finnish>Nitroglyseriiniasetukset</Finnish>
             <Dutch>Nitroglycerine instellingen</Dutch>
+            <Turkish>Nitrogliserin Ayarları</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SubCategory_Norepinephrine">
             <English>Norepinephrine Settings</English>
@@ -3074,6 +3242,7 @@
             <Chinesesimp>去甲肾上腺素设置</Chinesesimp>
             <Finnish>Norepinefriinin asetukset</Finnish>
             <Dutch>Noradrenaline instellingen</Dutch>
+            <Turkish>Norepinefrin Ayarları</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SubCategory_Penthrox">
             <English>Penthrox Inhaler Settings</English>
@@ -3090,6 +3259,7 @@
             <Chinesesimp>Penthrox吸入器设置</Chinesesimp>
             <Finnish>Penthrox-inhalaattorin asetukset</Finnish>
             <Dutch>Penthrox inhalator instellingen</Dutch>
+            <Turkish>Penthrox İnhaler Ayarları</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SubCategory_Pervitin">
             <English>Pervitin Settings</English>
@@ -3107,6 +3277,7 @@
             <Chinesesimp>柏飞汀(Pervitin)设置</Chinesesimp>
             <Finnish>Pervitiinin asetukset</Finnish>
             <Dutch>Pervitin instellingen</Dutch>
+            <Turkish>Pervitin Ayarları</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SubCategory_Phenylephrine">
             <English>Phenylephrine Settings</English>
@@ -3124,6 +3295,7 @@
             <Chinesesimp>苯肾上腺素设置</Chinesesimp>
             <Finnish>Fenyyliefriinin asetukset</Finnish>
             <Dutch>Fenylefrine instellingen</Dutch>
+            <Turkish>Fenilefrin Ayarları</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SubCategory_Reorientation">
             <English>Reorientation Settings</English>
@@ -3141,6 +3313,7 @@
             <Chinesesimp>刺激患者设置</Chinesesimp>
             <Finnish>Uudelleensuuntausasetukset</Finnish>
             <Dutch>Heroriëntatie instellingen</Dutch>
+            <Turkish>Reoryantasyon Ayarları</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_SubCategory_TXA">
             <English>TXA Settings</English>
@@ -3158,6 +3331,7 @@
             <Chinesesimp>血栓素设置</Chinesesimp>
             <Finnish>TXA-asetukset</Finnish>
             <Dutch>TXA instellingen</Dutch>
+            <Turkish>TXA Ayarları</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_TXA_Box_Display">
             <English>TXA</English>
@@ -3209,7 +3383,7 @@
             <Japanese>アミオダロンを注入</Japanese>
             <Chinese>注射胺碘酮</Chinese>
             <Chinesesimp>推注胺碘酮</Chinesesimp>
-            <Turkish>Amiodaron'u itin</Turkish>
+            <Turkish>Amiodaron uygula</Turkish>
             <Finnish>Työnnä amiodaria</Finnish>
             <Dutch>Injecteer Amiodaron</Dutch>
         </Key>
@@ -3227,7 +3401,7 @@
             <Japanese>アトロピンを注入</Japanese>
             <Chinese>注射阿托品</Chinese>
             <Chinesesimp>推注阿托品</Chinesesimp>
-            <Turkish>Atropin itin</Turkish>
+            <Turkish>Atropin enjekte et</Turkish>
             <Finnish>Työnnä atropiinia</Finnish>
             <Dutch>Injecteer Atropine</Dutch>
         </Key>
@@ -3247,6 +3421,7 @@
             <Chinesesimp>服用 咖啡因</Chinesesimp>
             <Finnish>Ota kofeiinia</Finnish>
             <Dutch>Neem Caffeïne</Dutch>
+            <Turkish>Kafein al</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_Take_Carbonate">
             <English>Use Carbonate</English>
@@ -3262,7 +3437,7 @@
             <Japanese>炭酸アンモニウムを使う</Japanese>
             <Chinese>使用碳酸銨</Chinese>
             <Chinesesimp>使用碳酸铵</Chinesesimp>
-            <Turkish>Karbonat kullanın</Turkish>
+            <Turkish>Karbonat kullan</Turkish>
             <Finnish>Käytä karbonaattia</Finnish>
             <Dutch>Gebruik carbonaat</Dutch>
         </Key>
@@ -3282,6 +3457,7 @@
             <Chinesesimp>推注EACA</Chinesesimp>
             <Finnish>Paina EACA</Finnish>
             <Dutch>Injecteer EACA</Dutch>
+            <Turkish>EACA uygula</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_Take_Epi">
             <English>Push Epinephrine</English>
@@ -3294,6 +3470,7 @@
             <Chinese>注射腎上腺素</Chinese>
             <Chinesesimp>推肾上腺素</Chinesesimp>
             <Dutch>Injecteer IV Adrenaline</Dutch>
+            <Turkish>Epinefrin uygula</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_Take_Fentanyl">
             <English>Push Fentanyl</English>
@@ -3311,6 +3488,7 @@
             <Chinesesimp>推注芬太尼</Chinesesimp>
             <Finnish>Työnnä fentanyyliä</Finnish>
             <Dutch>Injecteer Fentanyl</Dutch>
+            <Turkish>Fentanil uygula</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_Take_Ketamine">
             <English>Push Ketamine</English>
@@ -3328,6 +3506,7 @@
             <Chinesesimp>推注氯胺酮</Chinesesimp>
             <Finnish>Paina ketamiinia</Finnish>
             <Dutch>Injecteer Ketamine</Dutch>
+            <Turkish>Ketamin uygula</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_Take_Lidocaine">
             <English>Push Lidocaine</English>
@@ -3343,7 +3522,7 @@
             <Japanese>リドカインを注入</Japanese>
             <Chinese>注射利多卡因</Chinese>
             <Chinesesimp>推注利多卡因</Chinesesimp>
-            <Turkish>Push Lidokain</Turkish>
+            <Turkish>Lidokain uygula</Turkish>
             <Finnish>Paina lidokaiinia</Finnish>
             <Dutch>Injecteer Lidocaïne</Dutch>
         </Key>
@@ -3363,6 +3542,7 @@
             <Chinesesimp>推注纳布啡</Chinesesimp>
             <Finnish>Paina nalbufiinia</Finnish>
             <Dutch>Injecteer Nalbufine</Dutch>
+            <Turkish>Nalbuphin uygula</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_Take_Naloxone">
             <English>Use Naloxone</English>
@@ -3378,7 +3558,7 @@
             <Japanese>ナロキソンを投与</Japanese>
             <Chinese>使用納洛酮</Chinese>
             <Chinesesimp>使用纳洛酮</Chinesesimp>
-            <Turkish>Nalokson kullanın</Turkish>
+            <Turkish>Nalokson kullan</Turkish>
             <Finnish>Käytä naloksonia</Finnish>
             <Dutch>Gebruik Naloxone</Dutch>
         </Key>
@@ -3396,7 +3576,7 @@
             <Japanese>ニトログリセリンを注入</Japanese>
             <Chinese>注射硝化甘油</Chinese>
             <Chinesesimp>推注硝化甘油</Chinesesimp>
-            <Turkish>Nitrogliserin itin</Turkish>
+            <Turkish>Nitrogliserin uygula</Turkish>
             <Finnish>Paina nitroglyseriiniä</Finnish>
             <Dutch>Injecteer Nitroglycerine</Dutch>
         </Key>
@@ -3414,7 +3594,7 @@
             <Japanese>ノルアドレナリンを注入</Japanese>
             <Chinese>注射去甲腎上腺素</Chinese>
             <Chinesesimp>推注去甲肾上腺素</Chinesesimp>
-            <Turkish>Norepinefrin itin</Turkish>
+            <Turkish>Norepinefrin uygula</Turkish>
             <Finnish>Työnnä norepinefriiniä</Finnish>
             <Dutch>Injecteer Noradrenaline</Dutch>
         </Key>
@@ -3434,6 +3614,7 @@
             <Chinesesimp>使用 柏飞丁</Chinesesimp>
             <Finnish>Ota pervitiini</Finnish>
             <Dutch>Neem Pervitin</Dutch>
+            <Turkish>Pervitin al</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_Take_Phenyl">
             <English>Push Phenylephrine</English>
@@ -3449,7 +3630,7 @@
             <Japanese>フェニレフリンを注入</Japanese>
             <Chinese>注射去氧腎上腺素</Chinese>
             <Chinesesimp>推注苯肾上腺素</Chinesesimp>
-            <Turkish>Fenilefrin itin</Turkish>
+            <Turkish>Fenilefrin uygula</Turkish>
             <Finnish>Työnnä fenyyliefriiniä</Finnish>
             <Dutch>Injecteer Fenylefrine (IV)</Dutch>
         </Key>
@@ -3467,7 +3648,7 @@
             <Japanese>フェニレフリンを注射</Japanese>
             <Chinese>注射去氧腎上腺素</Chinese>
             <Chinesesimp>推注苯肾上腺素</Chinesesimp>
-            <Turkish>Fenilefrin itin</Turkish>
+            <Turkish>Fenilefrin enjekte et</Turkish>
             <Dutch>Injecteer Fenylefrine</Dutch>
         </Key>
         <Key ID="STR_KAT_Pharma_Take_Reorient">
@@ -3486,6 +3667,7 @@
             <Chinesesimp>刺激患者</Chinesesimp>
             <Finnish>Suuntaa potilas uudelleen</Finnish>
             <Dutch>Heroriënteer patiënt</Dutch>
+            <Turkish>Hastayı reoryante et</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_Take_TXA">
             <English>Push TXA</English>
@@ -3501,7 +3683,7 @@
             <Japanese>トラネキサム酸 (TXA)を注入</Japanese>
             <Chinese>注射 TXA</Chinese>
             <Chinesesimp>推注血栓素</Chinesesimp>
-            <Turkish>TXA'yı itin</Turkish>
+            <Turkish>TXA uygula</Turkish>
             <Finnish>Paina TXA</Finnish>
             <Dutch>Injecteer TXA</Dutch>
         </Key>
@@ -3520,6 +3702,7 @@
             <Chinesesimp>使用“绿哨”吸入式止痛药物</Chinesesimp>
             <Finnish>Käytä penthrox-inhalaattoria</Finnish>
             <Dutch>Gebruik Penthrox inhalator</Dutch>
+            <Turkish>Penthrox İnhaler kullan</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_Using">
             <English>Using</English>
@@ -3564,6 +3747,7 @@
             <German>KAT - ADV Medical: Medikamente</German>
             <Japanese>KAM - 薬学 (Pharmacy)</Japanese>
             <Dutch>KAT - ADV Medical: Farmaceutica</Dutch>
+            <Turkish>KAT – Gelişmiş Tıp: Eczane</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_coagulation_Bandaged">
             <English>Blood clotting temporarily closed a wound on %1</English>
@@ -3577,6 +3761,7 @@
             <Chinese>凝血暫時閉合了 %1 的傷口</Chinese>
             <Chinesesimp>凝血暂时闭合了%1的伤口</Chinesesimp>
             <Dutch>Wondstolling heeft een wond op %1 tijdelijk gedicht</Dutch>
+            <Turkish>Kan pıhtılaşması %1 bölgesindeki bir yarayı geçici olarak kapattı</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_coagulation_Bandaged_TXA">
             <English>Blood clotting permanently closed a wound on %1</English>
@@ -3590,6 +3775,7 @@
             <Chinese>凝血永久閉合了 %1 的傷口</Chinese>
             <Chinesesimp>凝血永久闭合了%1的伤口</Chinesesimp>
             <Dutch>Wondstolling heeft een wond op %1 permanent gedicht</Dutch>
+            <Turkish>Kan pıhtılaşması %1 bölgesindeki bir yarayı kalıcı olarak kapattı</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_dialysis_log">
             <English>%1 performed dialysis</English>
@@ -3607,6 +3793,7 @@
             <Chinesesimp>%1 进行了透析</Chinesesimp>
             <Finnish>%1 suoritettu dialyysi</Finnish>
             <Dutch>%1 heeft een dialyse uitgevoerd</Dutch>
+            <Turkish>%1 diyaliz uyguladı</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_flush_log">
             <English>%1 performed a saline flush</English>
@@ -3623,6 +3810,7 @@
             <Chinesesimp>%1 进行了盐水冲洗</Chinesesimp>
             <Finnish>%1 suoritti suolaliuoksen huuhtelun</Finnish>
             <Dutch>%1 voerde een salinespoeling uit</Dutch>
+            <Turkish>%1 salin yıkama yaptı</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_head">
             <English>Head</English>
@@ -3655,7 +3843,7 @@
             <Japanese>%1 が%2を注射した</Japanese>
             <Chinese>%1 被注射了 %2</Chinese>
             <Chinesesimp>%1 被注射了 %2</Chinesesimp>
-            <Turkish>% 1,% 2 eklendi</Turkish>
+            <Turkish>%1, %2 enjekte etti</Turkish>
             <Finnish>%1 pistetään %2</Finnish>
             <Dutch>%1 injecteerde %2</Dutch>
         </Key>
@@ -3673,7 +3861,7 @@
             <Japanese>%1 が%2を刺入した</Japanese>
             <Chinese>%1 被建立了一個 %2</Chinese>
             <Chinesesimp>%1 被建立了一个 %2</Chinesesimp>
-            <Turkish>% 1,% 2 eklendi</Turkish>
+            <Turkish>%1 bir %2 yerleştirdi</Turkish>
             <Finnish>%1 perusti %2</Finnish>
             <Dutch>%1 heeft een %2 aangelegd</Dutch>
         </Key>
@@ -3727,6 +3915,7 @@
             <Chinesesimp>胺碘酮所需的医疗水平</Chinesesimp>
             <Finnish>Amiodaronille vaadittu lääketieteellinen koulutustaso</Finnish>
             <Dutch>Medisch niveau benodigd voor het gebruik van Amiodaron</Dutch>
+            <Turkish>Amiodaron için gereken medikal seviye</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_medLvl_ApplyIO">
             <English>Allow applying IO</English>
@@ -3744,6 +3933,7 @@
             <Chinesesimp>允许使用IO</Chinesesimp>
             <Finnish>Salli IO:n käyttö</Finnish>
             <Dutch>IO plaatsing niveau</Dutch>
+            <Turkish>IO uygulanmasına izin ver</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_medLvl_ApplyIO_Desc">
             <English>Changes what medical level is required to set IOs</English>
@@ -3761,6 +3951,7 @@
             <Chinesesimp>更改设置 IO 所需的医疗级别</Chinesesimp>
             <Finnish>Muuttaa IO:iden asettamiseen vaadittavaa lääketieteellistä tasoa</Finnish>
             <Dutch>Bepaald welk medisch niveau benodigd is om IO's aan te kunnen leggen</Dutch>
+            <Turkish>IO yerleştirmek için gereken medikal seviyeyi değiştirir</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_medLvl_ApplyIV">
             <English>Allow applying IV</English>
@@ -3778,6 +3969,7 @@
             <Chinesesimp>允许使用IV</Chinesesimp>
             <Finnish>Salli hakeminen IV</Finnish>
             <Dutch>IV plaatsing niveau</Dutch>
+            <Turkish>IV uygulanmasına izin ver</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_medLvl_ApplyIV_Desc">
             <English>Changes what medical level is required to set IVs</English>
@@ -3793,7 +3985,7 @@
             <Japanese>IVの使用に必要な医療スキルのレベルを設定します。</Japanese>
             <Chinese>更改設置 IV 需要的醫療級別</Chinese>
             <Chinesesimp>改变设置 IV 所需的医疗级别</Chinesesimp>
-            <Turkish>IV'leri'ları ayarlamak için gereken tıbbi düzeyi değiştirir</Turkish>
+            <Turkish>IV yerleştirmek için gereken medikal seviyeyi değiştirir</Turkish>
             <Finnish>Muuttaa, mitä lääketieteen koulutustasoa tarvitaan IV:n lisäämiseen</Finnish>
             <Dutch>Bepaald welk medisch niveau benodigd is om IV's aan te kunnen leggen</Dutch>
         </Key>
@@ -3813,6 +4005,7 @@
             <Chinesesimp>阿托品所需的医疗水平</Chinesesimp>
             <Finnish>Atropiinia varten vaadittava lääketieteellinen koulutustaso</Finnish>
             <Dutch>Medisch niveau benodigd voor het gebruik van Atropine</Dutch>
+            <Turkish>Atropin için gereken medikal seviye</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_medLvl_CWMP">
             <English>Allow using CWMP</English>
@@ -3822,6 +4015,7 @@
             <German>Erlaube die Verwendung von CWMP</German>
             <Japanese>戦闘傷病治療薬(CWMP)の許可</Japanese>
             <Dutch>Sta gebruik van CWMP toe</Dutch>
+            <Turkish>CWMP kullanımına izin ver</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_medLvl_Caffeine">
             <English>Allow using Caffeine</English>
@@ -3831,6 +4025,7 @@
             <German>Erlaube die Verwendung von Koffein</German>
             <Japanese>カフェインの許可</Japanese>
             <Dutch>Sta gebruik van caffeine toe</Dutch>
+            <Turkish>Kafein kullanımına izin ver</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_medLvl_Carbonate">
             <English>Allow using Carbonate</English>
@@ -3848,6 +4043,7 @@
             <Chinesesimp>允许使用碳酸盐</Chinesesimp>
             <Finnish>Salli karbonaatin käyttö</Finnish>
             <Dutch>Sta gebruik van carbonaat toe</Dutch>
+            <Turkish>Karbonat kullanımına izin ver</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_medLvl_EACA">
             <English>Medical level required for EACA</English>
@@ -3865,6 +4061,7 @@
             <Chinesesimp>EACA所需的医疗水平</Chinesesimp>
             <Finnish>Lääketieteellinen koulutustaso vaaditaan EACA:lle</Finnish>
             <Dutch>Medisch niveau benodigd voor het gebruik van EACA</Dutch>
+            <Turkish>EACA için gereken medikal seviye</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_medLvl_EpinephrineIV">
             <English>Medical level required for IV Epinephrine</English>
@@ -3877,6 +4074,7 @@
             <Chinese>靜脈注射腎上腺素需要的醫療等級</Chinese>
             <Chinesesimp>静脉注射肾上腺素所需的医疗水平</Chinesesimp>
             <Dutch>Vereist medisch niveau voor gebruik van IV Adrenaline</Dutch>
+            <Turkish>IV Epinefrin için gereken medikal seviye</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_medLvl_Etomidate">
             <English>Medical level required for Etomidate</English>
@@ -3894,6 +4092,7 @@
             <Chinesesimp>依托咪酯所需的医疗水平</Chinesesimp>
             <Finnish>Etomidaatille vaadittava lääketieteellisen hoidon taso</Finnish>
             <Dutch>Medisch niveau benodigd voor het gebruik van Etomidaat</Dutch>
+            <Turkish>Etomidat için gereken medikal seviye</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_medLvl_Fentanyl">
             <English>Medical level required for Fentanyl</English>
@@ -3911,6 +4110,7 @@
             <Chinesesimp>芬太尼所需的医疗水平</Chinesesimp>
             <Finnish>Fentanyylille vaadittu lääketieteellinen koulutustaso</Finnish>
             <Dutch>Medisch niveau benodigd voor het gebruik van Fentanyl</Dutch>
+            <Turkish>Fentanil için gereken medikal seviye</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_medLvl_Flumazenil">
             <English>Medical level required for Flumazenil</English>
@@ -3928,6 +4128,7 @@
             <Chinesesimp>氟马西尼所需的医疗水平</Chinesesimp>
             <Finnish>Flumatseniilin edellyttämä lääketieteellinen koulutustaso</Finnish>
             <Dutch>Medisch niveau benodigd voor het gebruik van Flumazenil</Dutch>
+            <Turkish>Flumazenil için gereken medikal seviye</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_medLvl_Ketamine">
             <English>Medical level required for Ketamine</English>
@@ -3945,6 +4146,7 @@
             <Chinesesimp>氯胺酮所需的医疗水平</Chinesesimp>
             <Finnish>Lääketieteellinen koulutustaso vaaditaan ketamiinille</Finnish>
             <Dutch>Medisch niveau benodigd voor het gebruik van Ketamine</Dutch>
+            <Turkish>Ketamin için gereken medikal seviye</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_medLvl_Lidocaine">
             <English>Medical level required for Lidocaine</English>
@@ -3962,6 +4164,7 @@
             <Chinesesimp>利多卡因所需的医疗水平</Chinesesimp>
             <Finnish>Lääketieteellinen koulutustaso vaaditaan lidokaiinin käyttöön</Finnish>
             <Dutch>Medisch niveau benodigd voor het gebruik van Lidocaïne</Dutch>
+            <Turkish>Lidokain için gereken medikal seviye</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_medLvl_Lorazepam">
             <English>Medical level required for Lorazepam</English>
@@ -3979,6 +4182,7 @@
             <Chinesesimp>劳拉西泮所需的医疗水平</Chinesesimp>
             <Finnish>Lääketieteellinen koulutustaso vaaditaan loratsepaamia varten</Finnish>
             <Dutch>Medisch niveau benodigd voor het gebruik van Lorazepam</Dutch>
+            <Turkish>Lorazepam için gereken medikal seviye</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_medLvl_Nalbuphine">
             <English>Medical level required for Nalbuphine</English>
@@ -3996,6 +4200,7 @@
             <Chinesesimp>纳布啡所需的医疗水平</Chinesesimp>
             <Finnish>Lääketieteellinen koulutustaso vaaditaan nalbufiinille</Finnish>
             <Dutch>Medisch niveau benodigd voor het gebruik van Nalbufine</Dutch>
+            <Turkish>Nalbuphin için gereken medikal seviye</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_medLvl_Naloxone">
             <English>Medical level required for Naloxone</English>
@@ -4013,6 +4218,7 @@
             <Chinesesimp>纳洛酮所需的医疗水平</Chinesesimp>
             <Finnish>Naloksonille vaaditaan lääketieteen koulutustaso</Finnish>
             <Dutch>Medisch niveau benodigd voor gebruik van Naloxone</Dutch>
+            <Turkish>Nalokson için gereken medikal seviye</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_medLvl_Nitroglycerin">
             <English>Medical level required for Nitroglycerin</English>
@@ -4030,6 +4236,7 @@
             <Chinesesimp>硝酸甘油所需的医疗水平</Chinesesimp>
             <Finnish>Nitroglyseriinille vaadittu lääketieteellinen koulutustaso</Finnish>
             <Dutch>Medisch niveau benodigd voor het gebruik van Nitroglycerine</Dutch>
+            <Turkish>Nitrogliserin için gereken medikal seviye</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_medLvl_Norepinephrine">
             <English>Medical level required for Norepinephrine</English>
@@ -4047,6 +4254,7 @@
             <Chinesesimp>去甲肾上腺素所需的医疗水平</Chinesesimp>
             <Finnish>Norepinefriinin käytön edellyttämä lääketieteellinen taso</Finnish>
             <Dutch>Medisch niveau benodigd voor het gebruik van Noradrenaline</Dutch>
+            <Turkish>Norepinefrin için gereken medikal seviye</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_medLvl_Pervitin">
             <English>Medical level required for Pervitin</English>
@@ -4064,6 +4272,7 @@
             <Chinesesimp>柏飞汀(Pervitin)所需的医疗水平</Chinesesimp>
             <Finnish>Pervitiini vaatii lääketieteellisen koulutustason</Finnish>
             <Dutch>Medisch niveau benodigd voor het gebruik van Pervitin</Dutch>
+            <Turkish>Pervitin için gereken medikal seviye</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_medLvl_Phenylephrine">
             <English>Medical level required for Phenylephrine</English>
@@ -4081,6 +4290,7 @@
             <Chinesesimp>苯肾上腺素所需的医疗水平</Chinesesimp>
             <Finnish>Lääketieteellinen taso vaaditaan fenyyliefriinille</Finnish>
             <Dutch>Medisch niveau benodigd voor het gebruik van Fenylefrine</Dutch>
+            <Turkish>Fenilefrin için gereken medikal seviye</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_medLvl_TXA">
             <English>Medical level required for TXA</English>
@@ -4098,6 +4308,7 @@
             <Chinesesimp>血栓素(TXA)所需的医疗水平</Chinesesimp>
             <Finnish>Lääketieteellinen koulutustaso vaaditaan TXA:n käyttöön</Finnish>
             <Dutch>Medisch niveau benodigd voor het gebruik van TXA</Dutch>
+            <Turkish>TXA için gereken medikal seviye</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_pharmaSupplyCrate_displayName">
             <English>[KAM] Medicines crate</English>
@@ -4115,6 +4326,7 @@
             <Chinesesimp>[KAM]药品箱</Chinesesimp>
             <Finnish>[KAM] Lääkelaatikko</Finnish>
             <Dutch>[KAM] Medijnenkrat</Dutch>
+            <Turkish>[KAM] İlaç Sandığı</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_push_log">
             <English>%1 pushed %2</English>
@@ -4130,7 +4342,7 @@
             <Japanese>%1 が%2を注入した</Japanese>
             <Chinese>%1 被注射了 %2</Chinese>
             <Chinesesimp>%1 被注射了 %2</Chinesesimp>
-            <Turkish>% 1,% 2 eklendi</Turkish>
+            <Turkish>%1, %2 uyguladı</Turkish>
             <Finnish>%1 työnnettiin %2</Finnish>
             <Dutch>%1 injecteerde %2</Dutch>
         </Key>
@@ -4184,6 +4396,7 @@
             <Chinesesimp>胺碘酮的治疗时间</Chinesesimp>
             <Finnish>Amiodaronin hoitoaika</Finnish>
             <Dutch>Behandeltijd van Amiodaron</Dutch>
+            <Turkish>Amiodaron tedavi süresi</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_treatmentTime_ApplyIO">
             <English>Time to establish IOs</English>
@@ -4199,7 +4412,7 @@
             <Japanese>IO刺入の所要時間</Japanese>
             <Chinese>建立 IO 注射的時間</Chinese>
             <Chinesesimp>建立 IO 注射的时间</Chinesesimp>
-            <Turkish>IO'ları oluşturma zamanı</Turkish>
+            <Turkish>IO yerleştirme süresi</Turkish>
             <Finnish>Aika luoda IO:t</Finnish>
             <Dutch>Aanbrengtijd voor IO's</Dutch>
         </Key>
@@ -4217,7 +4430,7 @@
             <Japanese>IV刺入の所要時間</Japanese>
             <Chinese>建立 IV 注射的時間</Chinese>
             <Chinesesimp>建立 IV 注射的时间</Chinesesimp>
-            <Turkish>IV'ler oluşturma zamanı</Turkish>
+            <Turkish>IV yerleştirme süresi</Turkish>
             <Finnish>IV lisäämiseen tarvittava aika</Finnish>
             <Dutch>Aanbrengtijd voor IV's</Dutch>
         </Key>
@@ -4237,6 +4450,7 @@
             <Chinesesimp>阿托品的治疗时间</Chinesesimp>
             <Finnish>Atropiinin hoitoaika</Finnish>
             <Dutch>Behandeltijd van Atropine</Dutch>
+            <Turkish>Atropin tedavi süresi</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_treatmentTime_CWMP">
             <English>Treatment time for CWMP</English>
@@ -4246,6 +4460,7 @@
             <German>Anwendungszeit für CWMP</German>
             <Japanese>戦闘傷病治療薬(CWMP)の所要時間</Japanese>
             <Dutch>Behandelingstijd voor gebruik van CWMP</Dutch>
+            <Turkish>CWMP tedavi süresi</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_treatmentTime_Caffeine">
             <English>Treatment time for Caffeine</English>
@@ -4255,6 +4470,7 @@
             <German>Anwendungszeit für Koffein</German>
             <Japanese>カフェインの所要時間</Japanese>
             <Dutch>Behandelingstijd voor gebruik van caffeine</Dutch>
+            <Turkish>Kafein tedavi süresi</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_treatmentTime_Carbonate">
             <English>Treatment time for Carbonate</English>
@@ -4272,6 +4488,7 @@
             <Chinesesimp>碳酸盐的治疗时间</Chinesesimp>
             <Finnish>Karbonaatin käsittelyaika</Finnish>
             <Dutch>Behandeltijd van carbonaat</Dutch>
+            <Turkish>Karbonat tedavi süresi</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_treatmentTime_EACA">
             <English>Treatment time for EACA</English>
@@ -4289,6 +4506,7 @@
             <Chinesesimp>EACA的治疗时间</Chinesesimp>
             <Finnish>Hoitoaika EACA:lle</Finnish>
             <Dutch>Behandeltijd van EACA</Dutch>
+            <Turkish>EACA tedavi süresi</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_treatmentTime_EpinephrineIV">
             <English>Treatment time for IV Epinephrine</English>
@@ -4301,6 +4519,7 @@
             <Chinese>靜脈注射腎上腺素的治療時間</Chinese>
             <Chinesesimp>静脉注射肾上腺素的治疗时间</Chinesesimp>
             <Dutch>Toedieningstijd voor IV Adrenaline</Dutch>
+            <Turkish>IV Epinefrin tedavi süresi</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_treatmentTime_Etomidate">
             <English>Treatment time for Etomidate</English>
@@ -4318,6 +4537,7 @@
             <Chinesesimp>依托咪酯的治疗时间</Chinesesimp>
             <Finnish>Etomidatin hoitoaika</Finnish>
             <Dutch>Behandeltijd van Etomidaat</Dutch>
+            <Turkish>Etomidat tedavi süresi</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_treatmentTime_Fentanyl">
             <English>Treatment time for Fentanyl</English>
@@ -4335,6 +4555,7 @@
             <Chinesesimp>芬太尼的治疗时间</Chinesesimp>
             <Finnish>Fentanyylin hoitoaika</Finnish>
             <Dutch>Behandeltijd van Fentanyl</Dutch>
+            <Turkish>Fentanil tedavi süresi</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_treatmentTime_Flumazenil">
             <English>Treatment time for Flumazenil</English>
@@ -4352,6 +4573,7 @@
             <Chinesesimp>氟马西尼的治疗时间</Chinesesimp>
             <Finnish>Flumatseniilin hoitoaika</Finnish>
             <Dutch>Behandeltijd van Flumazenil</Dutch>
+            <Turkish>Flumazenil tedavi süresi</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_treatmentTime_Ketamine">
             <English>Treatment time for Ketamine</English>
@@ -4369,6 +4591,7 @@
             <Chinesesimp>氯胺酮的治疗时间</Chinesesimp>
             <Finnish>Ketamiinin hoitoaika</Finnish>
             <Dutch>Behandeltijd van Ketamine</Dutch>
+            <Turkish>Ketamin tedavi süresi</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_treatmentTime_Lidocaine">
             <English>Treatment time for Lidocaine</English>
@@ -4386,6 +4609,7 @@
             <Chinesesimp>利多卡因的治疗时间</Chinesesimp>
             <Finnish>Lidokaiinin hoitoaika</Finnish>
             <Dutch>Behandeltijd van Lidocaïne</Dutch>
+            <Turkish>Lidokain tedavi süresi</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_treatmentTime_Lorazepam">
             <English>Treatment time for Lorazepam</English>
@@ -4403,6 +4627,7 @@
             <Chinesesimp>劳拉西泮的治疗时间</Chinesesimp>
             <Finnish>Loratsepaamin hoitoaika</Finnish>
             <Dutch>Behandeltijd van Lorazepam</Dutch>
+            <Turkish>Lorazepam tedavi süresi</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_treatmentTime_Nalbuphine">
             <English>Treatment time for Nalbuphine</English>
@@ -4420,6 +4645,7 @@
             <Chinesesimp>纳布啡的治疗时间</Chinesesimp>
             <Finnish>Nalbufiinin hoitoaika</Finnish>
             <Dutch>Behandeltijd van Nalbufine</Dutch>
+            <Turkish>Nalbuphin tedavi süresi</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_treatmentTime_Naloxone">
             <English>Treatment time for Naloxone</English>
@@ -4437,6 +4663,7 @@
             <Chinesesimp>纳洛酮的治疗时间</Chinesesimp>
             <Finnish>Naloksonin hoitoaika</Finnish>
             <Dutch>Behandeltijd van Naloxone</Dutch>
+            <Turkish>Nalokson tedavi süresi</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_treatmentTime_Nitroglycerin">
             <English>Treatment time for Nitroglycerin</English>
@@ -4454,6 +4681,7 @@
             <Chinesesimp>硝酸甘油的治疗时间</Chinesesimp>
             <Finnish>Nitroglyseriinin hoitoaika</Finnish>
             <Dutch>Behandeltijd van Nitroglycerine</Dutch>
+            <Turkish>Nitrogliserin tedavi süresi</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_treatmentTime_Norepinephrine">
             <English>Treatment time for Norepinephrine</English>
@@ -4471,6 +4699,7 @@
             <Chinesesimp>去甲肾上腺素的治疗时间</Chinesesimp>
             <Finnish>Hoitoaika norepinefriinille</Finnish>
             <Dutch>Behandeltijd van Noradrenaline</Dutch>
+            <Turkish>Norepinefrin tedavi süresi</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_treatmentTime_Pervitin">
             <English>Treatment time for Pervitin</English>
@@ -4488,6 +4717,7 @@
             <Chinesesimp>柏飞汀(Pervitin)的治疗时间</Chinesesimp>
             <Finnish>Pervitiinin hoitoaika</Finnish>
             <Dutch>Behandeltijd van Pervitin</Dutch>
+            <Turkish>Pervitin tedavi süresi</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_treatmentTime_Phenylephrine">
             <English>Treatment time for Phenylephrine</English>
@@ -4505,6 +4735,7 @@
             <Chinesesimp>苯肾上腺素的治疗时间</Chinesesimp>
             <Finnish>Käsittelyaika fenyylille</Finnish>
             <Dutch>Behandeltijd van Fenylefrine</Dutch>
+            <Turkish>Fenilefrin tedavi süresi</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_treatmentTime_Reorientation">
             <English>Treatment time for reorientation</English>
@@ -4522,6 +4753,7 @@
             <Chinesesimp>恢复体态的治疗时间</Chinesesimp>
             <Finnish>Hoitoaika uudelleensuuntautumiseen</Finnish>
             <Dutch>Behandelingstijd voor heroriëntatie</Dutch>
+            <Turkish>Reoryantasyon tedavi süresi</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_treatmentTime_TXA">
             <English>Treatment time for TXA</English>
@@ -4539,16 +4771,19 @@
             <Chinesesimp>血栓素(TXA)的治疗时间</Chinesesimp>
             <Finnish>TXA:n hoitoaika</Finnish>
             <Dutch>Behandeltijd van TXA</Dutch>
+            <Turkish>TXA tedavi süresi</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_treatmenttime_applyio_desc">
             <English>Time required to establish an IO.</English>
             <German>Benötigte Zeit um einen IO-Zugang zu legen.</German>
             <Japanese>IOの刺入に掛かる時間</Japanese>
+            <Turkish>Bir IO yerleştirmek için gereken süre.</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_treatmenttime_applyiv_desc">
             <English>Time required to establish an IV.</English>
             <German>Benötigte Zeit um einen IV-Zugang zu legen.</German>
             <Japanese>IVの刺入に掛かる時間</Japanese>
+            <Turkish>Bir IV yerleştirmek için gereken süre.</Turkish>
         </Key>
         <Key ID="STR_KAT_Pharma_use_log">
             <English>%1 used %2</English>
@@ -4564,7 +4799,7 @@
             <Japanese>%1 が%2を使用した</Japanese>
             <Chinese>%1 被施用了 %2</Chinese>
             <Chinesesimp>%1 被施用了 %2</Chinesesimp>
-            <Turkish>% 1,% 2 eklendi</Turkish>
+            <Turkish>%1, %2 kullandı</Turkish>
             <Finnish>%1 käytetty %2</Finnish>
             <Dutch>%1 gebruikte %2</Dutch>
         </Key>

--- a/addons/stretcher/stringtable.xml
+++ b/addons/stretcher/stringtable.xml
@@ -15,7 +15,7 @@
             <Japanese>担架を取り付ける</Japanese>
             <Chinese>附著擔架</Chinese>
             <Chinesesimp>附着担架</Chinesesimp>
-            <Turkish>Sedyeyi Takın</Turkish>
+            <Turkish>Sedyeyi Tak</Turkish>
             <Finnish>Kiinnitä paarit</Finnish>
             <Dutch>Brancard bevestigen</Dutch>
         </Key>
@@ -31,6 +31,7 @@
             <Chinese>展開擔架</Chinese>
             <Chinesesimp>展开担架</Chinesesimp>
             <Dutch>Ontplooi brancard</Dutch>
+            <Turkish>Sedyeyi Aç</Turkish>
         </Key>
         <Key ID="STR_KAT_Stretcher_DetachHeliStretcher">
             <English>Detach Stretcher</English>
@@ -44,6 +45,7 @@
             <Chinese>釋放擔架</Chinese>
             <Chinesesimp>分离担架</Chinesesimp>
             <Dutch>Maak brancard los</Dutch>
+            <Turkish>Sedyeyi Sök</Turkish>
         </Key>
         <Key ID="STR_KAT_Stretcher_Helistretcher_Desc">
             <English>Allows you to attach a Stretcher to a helicopter (Double click)</English>
@@ -59,7 +61,7 @@
             <Japanese>ヘリコプターに担架を取り付けることができます (ダブルクリック)</Japanese>
             <Chinese>允許您雙擊將擔架連接到直升機上</Chinese>
             <Chinesesimp>允许您双击将担架连接到直升机上</Chinesesimp>
-            <Turkish>Helikoptere sedye takmanızı sağlar(Çift tıklama)</Turkish>
+            <Turkish>Bir sedyeyi helikoptere takmanıza olanak tanır (Çift tıklama)</Turkish>
             <Finnish>Mahdollistaa paareiden kiinnittämisen helikopteriin (klikkaa kahdesti)</Finnish>
             <Dutch>Staat je toe om een brancard aan een heli te bevestigen (dubbel klik)</Dutch>
         </Key>
@@ -77,7 +79,7 @@
             <Japanese>ヘリコプター用担架</Japanese>
             <Chinese>可連接直升機擔架</Chinese>
             <Chinesesimp>可连接直升机担架</Chinesesimp>
-            <Turkish>Helitakılabilir sedye</Turkish>
+            <Turkish>Takılabilir Helistretcher</Turkish>
             <Finnish>Kiinnitettävä paarit helikoptereille</Finnish>
             <Dutch>Bevestigbare helibrancard</Dutch>
         </Key>
@@ -92,6 +94,7 @@
             <Chinese>KAT 直升機擔架</Chinese>
             <Chinesesimp>KAT Helistretcher</Chinesesimp>
             <Dutch>KAT helibrancard</Dutch>
+            <Turkish>KAT Helistretcher</Turkish>
         </Key>
         <Key ID="STR_KAT_Stretcher_LowerHeliStretcher">
             <English>Lower Stretcher</English>
@@ -107,7 +110,7 @@
             <Japanese>担架を下げる</Japanese>
             <Chinese>放下擔架</Chinese>
             <Chinesesimp>放下担架</Chinesesimp>
-            <Turkish>Alt Sedye</Turkish>
+            <Turkish>Sedyeyi İndir</Turkish>
             <Finnish>Laske paarit</Finnish>
             <Dutch>Laat de brancard zakken</Dutch>
         </Key>
@@ -123,6 +126,7 @@
             <Chinese>裝進背包</Chinese>
             <Chinesesimp>装进背包</Chinesesimp>
             <Dutch>Verpak naar een rugzak</Dutch>
+            <Turkish>Sırt çantasına yerleştir</Turkish>
         </Key>
         <Key ID="STR_KAT_Stretcher_PackIntoBag">
             <English>Pack into bag</English>
@@ -136,6 +140,7 @@
             <Chinese>打包到包裡</Chinese>
             <Chinesesimp>装进袋子里</Chinesesimp>
             <Dutch>Verpak naar een tas</Dutch>
+            <Turkish>Çantaya yerleştir</Turkish>
         </Key>
         <Key ID="STR_KAT_Stretcher_PickupStretcher_progressBar">
             <English>Packing Stretcher...</English>
@@ -149,6 +154,7 @@
             <Chinese>正在打包擔架...</Chinese>
             <Chinesesimp>正在打包担架...</Chinesesimp>
             <Dutch>Brancard wordt verpakt</Dutch>
+            <Turkish>Sedye paketleniyor...</Turkish>
         </Key>
         <Key ID="STR_KAT_Stretcher_PlaceStretcher_progressBar">
             <English>Placing Stretcher...</English>
@@ -162,6 +168,7 @@
             <Chinese>正在放置擔架...</Chinese>
             <Chinesesimp>正在放置担架...</Chinesesimp>
             <Dutch>Brancard wordt geplaatst</Dutch>
+            <Turkish>Sedye paketleniyor...</Turkish>
         </Key>
         <Key ID="STR_KAT_Stretcher_RaiseHeliStretcher">
             <English>Raise Stretcher</English>
@@ -177,7 +184,7 @@
             <Japanese>担架を上げる</Japanese>
             <Chinese>抬起擔架</Chinese>
             <Chinesesimp>抬起担架</Chinesesimp>
-            <Turkish>Kaldırma Sedyesi</Turkish>
+            <Turkish>Sedyeyi Kaldır</Turkish>
             <Finnish>Nosta paarit</Finnish>
             <Dutch>Til de brancard op</Dutch>
         </Key>
@@ -193,6 +200,7 @@
             <Chinese>收回擔架</Chinese>
             <Chinesesimp>缩回担架</Chinesesimp>
             <Dutch>Trek brancard terug</Dutch>
+            <Turkish>Sedyeyi Topla</Turkish>
         </Key>
         <Key ID="STR_KAT_Stretcher_StretcherPacked_Display">
             <English>Stretcher (Packed)</English>
@@ -242,6 +250,7 @@
             <Chinese>部屬擔架</Chinese>
             <Chinesesimp>展开担架</Chinesesimp>
             <Dutch>Ontplooi brancard</Dutch>
+            <Turkish>Sedyeyi Aç</Turkish>
         </Key>
     </Package>
 </Project>

--- a/addons/surgery/stringtable.xml
+++ b/addons/surgery/stringtable.xml
@@ -17,6 +17,7 @@
             <Chinesesimp>启用高级骨折</Chinesesimp>
             <Finnish>Mahdollistaa pitkälle edenneet murtumat</Finnish>
             <Dutch>Activeert geadvanceerde breuken</Dutch>
+            <Turkish>Gelişmiş kırıkları etkinleştirir</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_CLAMPED">
             <English>clamped</English>
@@ -34,6 +35,7 @@
             <Chinesesimp>夹紧</Chinesesimp>
             <Finnish>Kiinnitetty</Finnish>
             <Dutch>Vastgeklemd</Dutch>
+            <Turkish>klemplenmiş</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_CLOSED_LOCATION">
             <English>Locations Closed Reduction</English>
@@ -51,6 +53,7 @@
             <Chinesesimp>封闭复位的位置</Chinesesimp>
             <Finnish>Suljettujen paikkojen vähennys</Finnish>
             <Dutch>Locaties waar een gesloten reductie uitgevoerd kan worden</Dutch>
+            <Turkish>Kapalı Redüksiyon Konumları</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_CLOSED_REDUCTION_FAIL">
             <English>Closed reduction fail chance</English>
@@ -68,6 +71,7 @@
             <Chinesesimp>封闭式减少失败几率</Chinesesimp>
             <Finnish>Suljettu vähennys epäonnistuu</Finnish>
             <Dutch>Kans dat een gesloten reductie faalt</Dutch>
+            <Turkish>Kapalı Redüksiyon Başarısızlık Olasılığı</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_CLOSED_REDUCTION_FAIL_DESC">
             <English>Chance that closed reduction will fail. Default value 10%</English>
@@ -85,6 +89,7 @@
             <Chinesesimp>封闭式缩减失败的可能性。默认值10%</Chinesesimp>
             <Finnish>Mahdollisuus, että suljettu vähennys epäonnistuu. Oletusarvo 10 %</Finnish>
             <Dutch>Kans dat een gesloten reductie faalt. Standaard waarde is 10%</Dutch>
+            <Turkish>Kapalı redüksiyonun başarısız olma olasılığı. Varsayılan değer %10</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_CLOSED_REDUCTION_MEDLEVEL">
             <English>Allow Closed Reduction</English>
@@ -102,6 +107,7 @@
             <Chinesesimp>闭合复位所需的医疗水平</Chinesesimp>
             <Finnish>Salli suljettu pienennys</Finnish>
             <Dutch>Benodigde training om een gesloten reductie uit te voeren</Dutch>
+            <Turkish>Kapalı Redüksiyona İzin Ver</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_CLOSED_TIMER">
             <English>Closed Reduction Time</English>
@@ -119,6 +125,7 @@
             <Chinesesimp>执行封闭伤口的时间</Chinesesimp>
             <Finnish>Suljettu vähennysaika</Finnish>
             <Dutch>Benodigde tijd om een gesloten reductie uit te voeren</Dutch>
+            <Turkish>Kapalı Redüksiyon Süresi</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_COMMINUTED_FRACTURE">
             <English>Comminuted Fracture</English>
@@ -136,6 +143,7 @@
             <Chinesesimp>粉碎性骨折</Chinesesimp>
             <Finnish>Hienonnettu murtuma</Finnish>
             <Dutch>Verbrijzeld fractuur</Dutch>
+            <Turkish>Parçalı kırık</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_COMPOUND_FRACTURE">
             <English>Compound Fracture</English>
@@ -153,6 +161,7 @@
             <Chinesesimp>复合性骨折</Chinesesimp>
             <Finnish>Avomurtuma</Finnish>
             <Dutch>Open fractuur</Dutch>
+            <Turkish>Açık kırık</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_COMPOUND_FRACTURE_CHANCE">
             <English>Compound fracture chance</English>
@@ -170,6 +179,7 @@
             <Chinesesimp>复合骨折机率</Chinesesimp>
             <Finnish>Yhdistelmämurtuman mahdollisuus</Finnish>
             <Dutch>Waarschijnlijkheid van een open fractuur</Dutch>
+            <Turkish>Açık kırık olasılığı</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_COMPOUND_FRACTURE_CHANCE_DESC">
             <English>Sets the chance for compound fractures. Also sets the chance for comminuted fractures (60% Compound = 40% Comminuted)</English>
@@ -187,6 +197,7 @@
             <Chinesesimp>设置复合骨折的几率,同时设置粉碎骨折的几率 (60% 复合 = 40% 粉碎)</Chinesesimp>
             <Finnish>Asettaa yhdistelmämurtumien mahdollisuuden. Asettaa myös murtumien mahdollisuuden (60 % yhdiste = 40 % hienonnettu)</Finnish>
             <Dutch>Bepaald de kans voor open botbreuken. Bepaald ook de kans op een verbrijzeld fractuur vast (60% open = 40% verbrijzeld)</Dutch>
+            <Turkish>Açık kırık olasılığını ayarlar. Ayrıca parçalı kırık olasılığını da belirler (%60 Açık = %40 parçalı)</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_Clamp_Action">
             <English>Clamping</English>
@@ -204,6 +215,7 @@
             <Chinesesimp>夹紧中</Chinesesimp>
             <Finnish>Kiinnitys</Finnish>
             <Dutch>Vast klemmen</Dutch>
+            <Turkish>Klempleme</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_Clamp_DescShort">
             <English>Used to clamp comminuted fractures</English>
@@ -221,6 +233,7 @@
             <Chinesesimp>用于夹紧粉碎性骨折</Chinesesimp>
             <Finnish>Käytetään murtumien kiinnittämiseen</Finnish>
             <Dutch>Wordt gebruikt om verbrijzelde fracturen vast te klemmen</Dutch>
+            <Turkish>Parçalı kırıkları klemplemek için kullanılır</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_Clamp_Use">
             <English>Clamp Fracture</English>
@@ -238,6 +251,7 @@
             <Chinesesimp>夹紧骨折</Chinesesimp>
             <Finnish>Puristimen murtuma</Finnish>
             <Dutch>Klem fractuur vast</Dutch>
+            <Turkish>Kırığı Klemple</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_Clamp_displayName">
             <English>Clamp</English>
@@ -255,6 +269,7 @@
             <Chinesesimp>夹钳</Chinesesimp>
             <Finnish>Puristin</Finnish>
             <Dutch>Klem</Dutch>
+            <Turkish>Klemple</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_EXPOSED">
             <English>exposed</English>
@@ -272,6 +287,7 @@
             <Chinesesimp>暴露</Chinesesimp>
             <Finnish>paljastettu</Finnish>
             <Dutch>Vrijgelegd</Dutch>
+            <Turkish>açığa çıkarılmış</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_FRACTURE_CHECK_MEDLEVEL">
             <English>Allow Check Fracture</English>
@@ -289,6 +305,7 @@
             <Chinesesimp>检查骨折所需的医疗水平</Chinesesimp>
             <Finnish>Salli murtuman tarkistaminen</Finnish>
             <Dutch>Benodigde training om een fractuur te controleren</Dutch>
+            <Turkish>Kırık Kontrolüne İzin Ver</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_FRACTURE_CHECK_TIMER">
             <English>Fracture Check Time</English>
@@ -306,6 +323,7 @@
             <Chinesesimp>骨折检查时间</Chinesesimp>
             <Finnish>Murtuman tarkistusaika</Finnish>
             <Dutch>Benodigde tijd om een fractuur te controleren</Dutch>
+            <Turkish>Kırık Kontrol Süresi</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_INCISION_TIMER">
             <English>Perform Incision Time</English>
@@ -323,6 +341,7 @@
             <Chinesesimp>进行切口的时间</Chinesesimp>
             <Finnish>Suorita viiltoaika</Finnish>
             <Dutch>Benodigde tijd om een incisie te maken</Dutch>
+            <Turkish>İnsizyon Yapma Süresi</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_INTERMEDIATE_TIMER">
             <English>Time to perform intermediate actions</English>
@@ -340,6 +359,7 @@
             <Chinesesimp>进行中间操作的时间</Chinesesimp>
             <Finnish>Aika suorittaa välitoimia</Finnish>
             <Dutch>Benodigde tijd om tussenliggende acties uit te voeren</Dutch>
+            <Turkish>Ara işlemleri yapma süresi</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_INTERMEDIATE_TIMER_DESC">
             <English>Sets how long it takes to perform intermediate surgical actions such as exposing and irrigation</English>
@@ -357,6 +377,7 @@
             <Chinesesimp>设置执行手术中间操作（例如暴露和冲洗）所需的时间</Chinesesimp>
             <Finnish>Asettaa, kuinka kauan kirurgisten välitoimenpiteiden, kuten valotuksen ja kastelun, suorittaminen kestää</Finnish>
             <Dutch>Bepaald hoe lang het doet om tussentijdse chirurgische acties uit te voeren, zoals het vrijleggen en irrigeren van een fractuur</Dutch>
+            <Turkish>Açığa çıkarma ve irrigasyon gibi ara cerrahi işlemlerin ne kadar süreceğini belirler</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_IRRIGATED">
             <English>irrigated</English>
@@ -374,6 +395,7 @@
             <Chinesesimp>已冲洗</Chinesesimp>
             <Finnish>Kasteltu</Finnish>
             <Dutch>Geïrrigeerd</Dutch>
+            <Turkish>irige edilmiş</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_Irrigate_Action">
             <English>Irrigating</English>
@@ -391,6 +413,7 @@
             <Chinesesimp>冲洗中</Chinesesimp>
             <Finnish>Kastelu</Finnish>
             <Dutch>Irrigeren</Dutch>
+            <Turkish>irige ediliyor</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_Irrigate_Use">
             <English>Irrigate Wound</English>
@@ -408,6 +431,7 @@
             <Chinesesimp>冲洗伤口</Chinesesimp>
             <Finnish>Huuhtele haava</Finnish>
             <Dutch>Irrigeer wond</Dutch>
+            <Turkish>Yarayı İrige Et</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_NPWT_ACTION_MEDLEVEL">
             <English>Allow NPWT</English>
@@ -422,6 +446,7 @@
             <Chinese>NPWT需要的醫療等級</Chinese>
             <Chinesesimp>NPWT所需的医疗水平</Chinesesimp>
             <Dutch>Benodigde training voor het gebruik van een vacuümverband</Dutch>
+            <Turkish>NPWT’ye İzin Ver</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_NPWT_LOCATION">
             <English>Locations NPWT</English>
@@ -436,6 +461,7 @@
             <Chinese>NPWT的使用位置</Chinese>
             <Chinesesimp>NPWT的使用位置</Chinesesimp>
             <Dutch>Locaties waar een vacuümverband aangelegd kan worden</Dutch>
+            <Turkish>NPWT Konumları</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_OPEN_TIMER">
             <English>Open Reduction Time</English>
@@ -453,6 +479,7 @@
             <Chinesesimp>执行开放伤口的时间</Chinesesimp>
             <Finnish>Avoin vähennysaika</Finnish>
             <Dutch>Benodigde tijd om een open reductie uit te voeren</Dutch>
+            <Turkish>Açık Redüksiyon Süresi</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_PERICARDIALTAP_ACTION_MEDLEVEL">
             <English>Allow Pericardial Tap</English>
@@ -465,6 +492,7 @@
             <Chinese>心包穿刺術需要的醫療等級</Chinese>
             <Chinesesimp>心包穿刺术所需的医疗水平</Chinesesimp>
             <Dutch>Benodigde training voor pericardiale drainage</Dutch>
+            <Turkish>Pericardial Tap’e İzin Ver</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_PERICARDIALTAP_LOCATION">
             <English>Locations for Pericardial Tap</English>
@@ -477,6 +505,7 @@
             <Chinese>心包穿刺術的使用位置</Chinese>
             <Chinesesimp>心包穿刺术的使用位置</Chinesesimp>
             <Dutch>Locaties waar een pericardiale drainage uitgevoerd kan worden</Dutch>
+            <Turkish>Pericardial Tap Konumları</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_PERICARDIALTAP_TIMER">
             <English>Time to perform Pericardial Tap</English>
@@ -489,6 +518,7 @@
             <Chinese>執行心包穿刺術的時間</Chinese>
             <Chinesesimp>执行心包穿刺术的时间</Chinesesimp>
             <Dutch>Benodigde tijd om een pericard drainage uit te voeren</Dutch>
+            <Turkish>Pericardial Tap süresi</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_PERICARDIALTAP_TIMER_DESC">
             <English>Sets how long it takes to perform a Pericardial Tap</English>
@@ -501,6 +531,7 @@
             <Chinese>設置執行心包穿刺術所需的時間</Chinese>
             <Chinesesimp>设置执行心包穿刺术所需的时间</Chinesesimp>
             <Dutch>Bepaald hoe lang het uitvoeren van een pericard drainage duurt</Dutch>
+            <Turkish>Pericardial Tap işleminin ne kadar süreceğini belirler</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_Pericardial_Tap_Action">
             <English>Performing</English>
@@ -515,6 +546,7 @@
             <Chinese>實施中</Chinese>
             <Chinesesimp>操作中</Chinesesimp>
             <Dutch>Wordt uitgevoerd</Dutch>
+            <Turkish>Yapılıyor</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_Pericardial_Tap_Log">
             <English>%1 performed a pericardial tap</English>
@@ -529,6 +561,7 @@
             <Chinese>%1 進行了心包穿刺術</Chinese>
             <Chinesesimp>%1 对患者进行了心包穿刺</Chinesesimp>
             <Dutch>%1 heeft een pericard drainage uitgevoerd</Dutch>
+            <Turkish>%1 bir pericardial tap yaptı</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_Pericardial_Tap_Use">
             <English>Pericardial Tap</English>
@@ -543,6 +576,7 @@
             <Chinese>心包穿刺術</Chinese>
             <Chinesesimp>心包穿刺</Chinesesimp>
             <Dutch>Pericard drainage</Dutch>
+            <Turkish>Pericardial Tap</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_Plate_DescShort">
             <English>Used to complete all complex fracture types</English>
@@ -560,6 +594,7 @@
             <Chinesesimp>用于完成所有复杂骨折类型</Chinesesimp>
             <Finnish>Käytetään viimeistelemään kaikki monimutkaiset fraktit</Finnish>
             <Dutch>Wordt gebruikt om alle complexe fracturen te voltooien</Dutch>
+            <Turkish>Tüm kompleks kırık tiplerini tamamlamak için kullanılır</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_Plate_Display">
             <English>Bone Plate</English>
@@ -577,6 +612,7 @@
             <Chinesesimp>骨板</Chinesesimp>
             <Finnish>Luulevy</Finnish>
             <Dutch>Botplaat</Dutch>
+            <Turkish>Bone Plate</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_REBOA_ACTION_MEDLEVEL">
             <English>Allow REBOA</English>
@@ -589,6 +625,7 @@
             <Chinese>REBOA需要的醫療等級</Chinese>
             <Chinesesimp>REBOA所需的医疗水平</Chinesesimp>
             <Dutch>Benodigde Training om een REBOA toe te dienen</Dutch>
+            <Turkish>REBOA’ya İzin Ver</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_REBOA_LOCATION">
             <English>Locations for REBOA</English>
@@ -601,6 +638,7 @@
             <Chinese>REBOA的使用位置</Chinese>
             <Chinesesimp>REBOA的使用位置</Chinesesimp>
             <Dutch>Locaties waar een REBOA toegediend kan worden</Dutch>
+            <Turkish>REBOA Konumları</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_REBOA_TIMER">
             <English>Time to perform REBOA actions</English>
@@ -613,6 +651,7 @@
             <Chinese>執行REBOA操作的時間</Chinese>
             <Chinesesimp>执行REBOA操作的时间</Chinesesimp>
             <Dutch>Benodigde tijd om REBOA acties uit te voeren</Dutch>
+            <Turkish>REBOA işlemleri süresi</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_REBOA_TIMER_DESC">
             <English>Sets how long it takes to perform REBOA actions (Placing, Advancing, Removing)</English>
@@ -625,6 +664,7 @@
             <Chinese>設置執行REBOA操作（放置、推進、移除）所需的時間</Chinese>
             <Chinesesimp>设置执行REBOA操作（放置、推进、移除）所需的时间</Chinesesimp>
             <Dutch>Bepaald hoe lang het duurt om REBOA acties uit te voeren (Plaatsen, doorvoeren en verwijderen)</Dutch>
+            <Turkish>REBOA işlemlerinin (Placing, Advancing, Removing) ne kadar süreceğini belirler</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_Reboa_Action">
             <English>Placing</English>
@@ -639,6 +679,7 @@
             <Chinese>放置中</Chinese>
             <Chinesesimp>放置</Chinesesimp>
             <Dutch>Wordt geplaatst</Dutch>
+            <Turkish>Yerleştiriliyor</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_Reboa_Deep_Action">
             <English>Advancing</English>
@@ -653,6 +694,7 @@
             <Chinese>推進中</Chinese>
             <Chinesesimp>推进中</Chinesesimp>
             <Dutch>Wordt opgevoerd</Dutch>
+            <Turkish>İlerletiliyor</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_Reboa_Deep_Use">
             <English>Advance REBOA Unit</English>
@@ -667,6 +709,7 @@
             <Chinese>進階REBOA設備</Chinese>
             <Chinesesimp>高级REBOA单元</Chinesesimp>
             <Dutch>Voer REBOA eenheid op</Dutch>
+            <Turkish>REBOA Unit’i İlerlet</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_Reboa_DescShort">
             <English>Used to block the aorta and prevent bleeding below the heart</English>
@@ -681,6 +724,7 @@
             <Chinese>用於阻斷主動脈，防止心臟以下的出血</Chinese>
             <Chinesesimp>用于阻断主动脉，防止心脏以下出血</Chinesesimp>
             <Dutch>Wordt gebruikt om de aorta te blokkeren, en bloedingen onder het hart te stelpen</Dutch>
+            <Turkish>Aortayı bloke ederek kalbin altındaki kanamayı önlemek için kullanılır</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_Reboa_DisplayName">
             <English>REBOA Unit</English>
@@ -695,6 +739,7 @@
             <Chinese>REBOA 設備</Chinese>
             <Chinesesimp>REBOA单元</Chinesesimp>
             <Dutch>ROBOA eenheid</Dutch>
+            <Turkish>REBOA Unit</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_Reboa_Remove_Action">
             <English>Removing</English>
@@ -709,6 +754,7 @@
             <Chinese>移除中</Chinese>
             <Chinesesimp>移除中</Chinesesimp>
             <Dutch>Wordt verwijderd</Dutch>
+            <Turkish>Çıkarılıyor</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_Reboa_Remove_Use">
             <English>Remove REBOA Unit</English>
@@ -723,6 +769,7 @@
             <Chinese>移除 REBOA 設備</Chinese>
             <Chinesesimp>拆除REBOA装置</Chinesesimp>
             <Dutch>Verwijder REBOA eenheid</Dutch>
+            <Turkish>REBOA Unit’i Çıkar</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_Reboa_Status">
             <English>REBOA</English>
@@ -737,6 +784,7 @@
             <Chinese>REBOA</Chinese>
             <Chinesesimp>雷博亚</Chinesesimp>
             <Dutch>REBOA</Dutch>
+            <Turkish>REBOA</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_Reboa_Use">
             <English>Place REBOA Unit</English>
@@ -751,6 +799,7 @@
             <Chinese>放置 REBOA 設備</Chinese>
             <Chinesesimp>放置REBOA单元</Chinesesimp>
             <Dutch>Plaats REBOA eenheid</Dutch>
+            <Turkish>REBOA Unit’i Yerleştir</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_Reset_Surgery">
             <English>Close Incision</English>
@@ -763,6 +812,7 @@
             <Chinese>封閉切口</Chinese>
             <Chinesesimp>闭合切口</Chinesesimp>
             <Dutch>Sluit incisie</Dutch>
+            <Turkish>İnsizyonu Kapat</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_Retractor_Action">
             <English>Exposing</English>
@@ -780,6 +830,7 @@
             <Chinesesimp>暴露</Chinesesimp>
             <Finnish>Paljastaminen</Finnish>
             <Dutch>Vrijleggen</Dutch>
+            <Turkish>Açığa çıkarılıyor</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_Retractor_DescShort">
             <English>Used to expand and expose fractures</English>
@@ -797,6 +848,7 @@
             <Chinesesimp>用于扩大和暴露骨折创面</Chinesesimp>
             <Finnish>Käytetään murtumien laajentamiseen ja paljastamiseen</Finnish>
             <Dutch>Wordt gebruikt om incisies te spreiden en fracturen vrij te leggen</Dutch>
+            <Turkish>Kırıkları genişletmek ve açığa çıkarmak için kullanılır</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_Retractor_Use">
             <English>Expose Fracture</English>
@@ -814,6 +866,7 @@
             <Chinesesimp>暴露骨折</Chinesesimp>
             <Finnish>Paljasta murtuma</Finnish>
             <Dutch>Leg fractuur vrij</Dutch>
+            <Turkish>Kırığı Açığa Çıkar</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_Retractor_displayName">
             <English>Retractor</English>
@@ -831,6 +884,7 @@
             <Chinesesimp>扩张器</Chinesesimp>
             <Finnish>Kelauslaite</Finnish>
             <Dutch>Retractor</Dutch>
+            <Turkish>Retractor</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_SETTING_Anesthesia">
             <English>Surgery Anesthesia</English>
@@ -847,6 +901,7 @@
             <Chinesesimp>手术在麻醉下进行</Chinesesimp>
             <Finnish>Leikkauksen anestesia</Finnish>
             <Dutch>Operatie met anesthesie</Dutch>
+            <Turkish>Cerrahi Anestezi</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_SETTING_Causes_Unconsciousness">
             <English>Surgery Causes Unconsciousness</English>
@@ -863,6 +918,7 @@
             <Chinesesimp>手术导致意识丧失</Chinesesimp>
             <Finnish>Leikkaus aiheuttaa tajuttomuuden</Finnish>
             <Dutch>Operatie veroorzaakt bewustijnsverlies</Dutch>
+            <Turkish>Cerrahi Bilinç Kaybına Neden Olur</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_SETTING_ConsciousnessRequirement">
             <English>Surgery Consciousness Controls</English>
@@ -879,6 +935,7 @@
             <Chinesesimp>手术意识控制</Chinesesimp>
             <Finnish>Kirurginen tajunta</Finnish>
             <Dutch>Operatie bewustzijninstellingen</Dutch>
+            <Turkish>Cerrahi Bilinç Kontrolleri</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_SETTING_ConsciousnessRequirement_DESC">
             <English>Surgery Causes Unconsciousness: Surgery without anesthesia and sedation results in unconsciousness from CA. \nUnconsciousness Required for Surgery: Surgery requires patient to be unconscious. \nNo Unconsciousness from Surgery: Surgery doesn't induce unconsciousness, causes pain. \nSurgery Anesthesia: Patient stays awake during surgery if given Etomidate, if not they will go into CA.</English>
@@ -895,6 +952,7 @@
             <Chinesesimp>手术导致意识丧失：未进行麻醉和镇静的手术会导致因心搏停止而意识丧失。\n手术需要意识丧失：手术需要患者处于无意识状态。\n手术不会导致意识丧失：手术不会引起意识丧失，但会引起疼痛。\n手术麻醉：如果给予依托咪酯，患者在手术期间会保持清醒；如果没有，他们将进入心搏停止状态。</Chinesesimp>
             <Finnish>Leikkaus aiheuttaa tajuttomuuden: leikkaus ilman anestesiaa ja sedaatiota johtaa tajuttomuuteen sydämenpysähdyksestä. \nLeikkaukseen tarvitaan tajuttomuus: leikkaus ei aiheuta tajuttomuutta, aiheuttaa kipua. \nLeikkauksen anestesia: Potilas pysyy hereillä leikkauksen aikana, jos hänelle annetaan etomidaattia, jos ei, hän menettää sydämenpysähdyksen.</Finnish>
             <Dutch>Operatie veroorzaakt bewustzijnsverlies: Operaties zonder anesthesie en sedatie lijdt tot bewustzijnsverlies door hartstilstand. \n Bewusteloosheid benodigd voor operatie: Operaties vereisen dat de patiënt bewusteloos is. \n Geen bewustzijnsverlies door operaties: Operaties lijden niet tot bewustzijnsverlies, maar veroorzaken pijn. \n Operatie met anesthesie: Patiënt blijft wakker tijdens de operatie als etomidaat gegeven is, anders lijdt de operatie tot een hartstilstand.</Dutch>
+            <Turkish>Surgery Causes Unconsciousness: Anestezi ve sedasyon olmadan yapılan cerrahi, CA nedeniyle bilinç kaybına yol açar. \nUnconsciousness Required for Surgery: Cerrahi için hastanın bilinçsiz olması gerekir. \nNo Unconsciousness from Surgery: Cerrahi bilinç kaybı oluşturmaz, ağrıya neden olur. \nSurgery Anesthesia: Etomidate verilirse hasta cerrahi sırasında uyanık kalır; verilmezse CA’ya girer.</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_SETTING_NPWTTime">
             <English>Apply NPWT Dressing Time</English>
@@ -912,6 +970,7 @@
             <Chinesesimp>应用NPWT敷料时间</Chinesesimp>
             <Finnish>Levitä NPWT-sidos tu</Finnish>
             <Dutch>Benodigde tijd om een vacuümverband aan te leggen</Dutch>
+            <Turkish>NPWT Dressing Uygulama Süresi</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_SETTING_No_Unconsciousness">
             <English>No Unconsciousness from Surgery</English>
@@ -928,6 +987,7 @@
             <Chinesesimp>手术期间不会失去意识</Chinesesimp>
             <Finnish>Ei tajuttomuutta leikkauksesta</Finnish>
             <Dutch>Geen Bewustzijnsverlies door operaties</Dutch>
+            <Turkish>Cerrahiden Bilinç Kaybı Yok</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_SETTING_SELF_CHECKFRACTURE">
             <English>Allow self check fracture</English>
@@ -945,6 +1005,7 @@
             <Chinesesimp>允许自行检查骨折</Chinesesimp>
             <Finnish>Salli itsetarkastuksen murtuma</Finnish>
             <Dutch>Sta zelfcontrole van fracturen toe</Dutch>
+            <Turkish>Kendi kendine kırık kontrolüne izin ver</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_SETTING_Unconsciousness_Required">
             <English>Unconsciousness Required for Surgery</English>
@@ -961,6 +1022,7 @@
             <Chinesesimp>手术需要昏迷</Chinesesimp>
             <Finnish>Leikkaukseen tarvitaan tajuttomuus</Finnish>
             <Dutch>Bewusteloosheid</Dutch>
+            <Turkish>Cerrahi için bilinç kaybı gerekli</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_SIMPLE_FRACTURE">
             <English>Simple Fracture</English>
@@ -978,6 +1040,7 @@
             <Chinesesimp>简单骨折</Chinesesimp>
             <Finnish>Yksinkertainen murtuma</Finnish>
             <Dutch>Simpel fractuur</Dutch>
+            <Turkish>Basit kırık</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_SIMPLE_FRACTURE_CHANCE">
             <English>Simple fracture chance</English>
@@ -995,6 +1058,7 @@
             <Chinesesimp>简单骨折机率</Chinesesimp>
             <Finnish>Yksinkertainen murtuman mahdollisuus</Finnish>
             <Dutch>Kans op een simpel fractuur</Dutch>
+            <Turkish>Basit kırık olasılığı</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_SIMPLE_FRACTURE_CHANCE_DESC">
             <English>Sets the chance for simple fractures. Also sets the chance for complex fractures (60% Simple = 40% Complex)</English>
@@ -1012,6 +1076,7 @@
             <Chinesesimp>设置简单骨折的机率,同时设置了复合骨折的机率 (60% 简单 = 40% 复杂)</Chinesesimp>
             <Finnish>Asettaa mahdollisuuden yksinkertaisiin murtumiin. Asettaa myös mahdollisuuden monimutkaisiin murtumiin (60 % yksinkertainen = 40 % monimutkainen)</Finnish>
             <Dutch>Bepaald de kans voor simpele fracturen. Bepaald ook de kans voor geadvanceerde fracturen (60% simpel = 40% geadvanceerd).</Dutch>
+            <Turkish>Basit kırık olasılığını ayarlar. Ayrıca kompleks kırık olasılığını da belirler (%60 Simple = %40 Complex)</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_SURGICAL_ACTION_MEDLEVEL">
             <English>Allow Surgery</English>
@@ -1029,6 +1094,7 @@
             <Chinesesimp>手术所需的医疗水平</Chinesesimp>
             <Finnish>Salli leikkaus</Finnish>
             <Dutch>Benodigde training om chirurgische acties uit te voeren</Dutch>
+            <Turkish>Cerrahiye izin ver</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_SURGICAL_LOCATION">
             <English>Locations Surgery</English>
@@ -1046,6 +1112,7 @@
             <Chinesesimp>切开复位/手术的地点</Chinesesimp>
             <Finnish>Paikkakirurgia</Finnish>
             <Dutch>Locaties waar chirurgische acties uitgevoerd kan worden</Dutch>
+            <Turkish>Cerrahi Konumları</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_Scalpel_DescShort">
             <English>Used for creating incisions</English>
@@ -1063,6 +1130,7 @@
             <Chinesesimp>用于创建切口和伤口清创</Chinesesimp>
             <Finnish>Käytetään viiltojen tekemiseen</Finnish>
             <Dutch>Wordt gebruikt om incisies te maken</Dutch>
+            <Turkish>İnsizyon oluşturmak için kullanılır</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_Scalpel_Use">
             <English>Perform Incision</English>
@@ -1080,6 +1148,7 @@
             <Chinesesimp>创建切口</Chinesesimp>
             <Finnish>Suorita viilto</Finnish>
             <Dutch>Maak incisie</Dutch>
+            <Turkish>İnsizyon Yap</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_Scalpel_displayName">
             <English>Scalpel</English>
@@ -1097,6 +1166,7 @@
             <Chinesesimp>手术刀</Chinesesimp>
             <Finnish>Skalpelli</Finnish>
             <Dutch>Scalpel</Dutch>
+            <Turkish>Scalpel</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_SubCategory_Fractures">
             <English>Fractures Settings</English>
@@ -1114,6 +1184,7 @@
             <Chinesesimp>骨折设置</Chinesesimp>
             <Finnish>Murtumien asetukset</Finnish>
             <Dutch>Instellingen voor fracturen</Dutch>
+            <Turkish>Kırık Ayarları</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_SubCategory_NPWT">
             <English>Dressing Vacuum (NPWT) Settings</English>
@@ -1128,6 +1199,7 @@
             <Chinese>負壓傷口治療（NPWT）設定</Chinese>
             <Chinesesimp>负压伤口治疗（NPWT）设置</Chinesesimp>
             <Dutch>Vacuümverband instellingen</Dutch>
+            <Turkish>Dressing Vacuum (NPWT) Ayarları</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_SubCategory_SurgicalActions">
             <English>Surgical actions Settings</English>
@@ -1145,6 +1217,7 @@
             <Chinesesimp>手术操作设置</Chinesesimp>
             <Finnish>Kirurgisten toimien asetukset</Finnish>
             <Dutch>Instellingen voor chirurgische acties</Dutch>
+            <Turkish>Cerrahi İşlemler Ayarları</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_ULTRASOUND_ACTION_MEDLEVEL">
             <English>Allow Ultrasound</English>
@@ -1157,6 +1230,7 @@
             <Chinese>超音波檢查需要的醫療等級</Chinese>
             <Chinesesimp>超声检查所需的医疗水平</Chinesesimp>
             <Dutch>Benodigde training voor gebruik mobiele echograaf</Dutch>
+            <Turkish>Ultrasound’a İzin Ver</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_ULTRASOUND_LOCATION">
             <English>Locations for Ultrasound</English>
@@ -1169,6 +1243,7 @@
             <Chinese>超音波檢查的使用位置</Chinese>
             <Chinesesimp>超声检查的使用位置</Chinesesimp>
             <Dutch>Locaties waar een mobiele echograaf gebruikt kan worden</Dutch>
+            <Turkish>Ultrasound Konumları</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_ULTRASOUND_TIMER">
             <English>Time to perform Ultrasound actions</English>
@@ -1181,6 +1256,7 @@
             <Chinese>執行 超音波 檢查的時間</Chinese>
             <Chinesesimp>执行超声检查的时间</Chinesesimp>
             <Dutch>Benodigde tijd voor het gebruik van een mobiele echograaf</Dutch>
+            <Turkish>Ultrasound işlemleri süresi</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_ULTRASOUND_TIMER_DESC">
             <English>Sets how long it takes to perform an ultrasound exam</English>
@@ -1193,6 +1269,7 @@
             <Chinese>設置執行 超音波 檢查所需的時間</Chinese>
             <Chinesesimp>设置执行超声检查所需的时间</Chinesesimp>
             <Dutch>Bepaald hoe lang het gebruik van een mobiele echograaf duurt</Dutch>
+            <Turkish>Ultrasound muayenesinin ne kadar süreceğini belirler</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_Ultra_Action">
             <English>Assessing</English>
@@ -1207,6 +1284,7 @@
             <Chinese>評估中</Chinese>
             <Chinesesimp>评估中</Chinesesimp>
             <Dutch>Aan het evalueren</Dutch>
+            <Turkish>Değerlendiriliyor</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_Ultra_Airway">
             <English>Airway Status: %1</English>
@@ -1221,6 +1299,7 @@
             <Chinese>氣道狀態：%1</Chinese>
             <Chinesesimp>气道状态：%1</Chinesesimp>
             <Dutch>Luchtwegstatus: %1</Dutch>
+            <Turkish>Airway Durumu: %1</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_Ultra_Airway_Compromise">
             <English>Compromised</English>
@@ -1231,6 +1310,7 @@
             <German>Kompromittiert</German>
             <Japanese>機能不全</Japanese>
             <Dutch>Gecomprimeerd</Dutch>
+            <Turkish>Bozulmuş</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_Ultra_Airway_NoActivity">
             <English>No Activity</English>
@@ -1241,6 +1321,7 @@
             <German>Keine Aktivität</German>
             <Japanese>活動なし</Japanese>
             <Dutch>Geen activiteit</Dutch>
+            <Turkish>Aktivite Yok</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_Ultra_Airway_Normal">
             <English>Normal</English>
@@ -1255,6 +1336,7 @@
             <Chinese>正常</Chinese>
             <Chinesesimp>正常</Chinesesimp>
             <Dutch>Normaal</Dutch>
+            <Turkish>Normal</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_Ultra_Cardiac">
             <English>Cardiac Status: %1</English>
@@ -1269,6 +1351,7 @@
             <Chinese>心臟狀態：%1</Chinese>
             <Chinesesimp>心脏状态：%1</Chinesesimp>
             <Dutch>Cardiale status: %1</Dutch>
+            <Turkish>Kardiyak Durum: %1</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_Ultra_Cardiac_Shockable">
             <English>Arrest - Shockable</English>
@@ -1283,6 +1366,7 @@
             <Chinese>心臟驟停 - 可電擊</Chinese>
             <Chinesesimp>心脏骤停 - 可电击</Chinesesimp>
             <Dutch>Hartstilstand - Schokbaar</Dutch>
+            <Turkish>Arrest - Şoklanabilir</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_Ultra_Cardiac_Tamponade">
             <English>Tamponade</English>
@@ -1297,6 +1381,7 @@
             <Chinese>心包填塞</Chinese>
             <Chinesesimp>心包填塞</Chinesesimp>
             <Dutch>Harttamponade</Dutch>
+            <Turkish>Tamponad</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_Ultra_Cardiac_Unshockable">
             <English>Arrest - Not Shockable</English>
@@ -1311,6 +1396,7 @@
             <Chinese>心臟驟停 - 不可電擊</Chinese>
             <Chinesesimp>心脏骤停 - 不可电击</Chinesesimp>
             <Dutch>Hartstilstand - Niet schokbaar</Dutch>
+            <Turkish>Arrest - Şoklanamaz</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_Ultra_DescShort">
             <English>Used to assess internal injuries</English>
@@ -1325,6 +1411,7 @@
             <Chinese>用於評估內部損傷</Chinese>
             <Chinesesimp>用于评估内部损伤</Chinesesimp>
             <Dutch>Wordt gebruikt om interne verwondingen te evalueren</Dutch>
+            <Turkish>İç yaralanmaları değerlendirmek için kullanılır</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_Ultra_DisplayName">
             <English>Handheld Ultrasound</English>
@@ -1339,6 +1426,7 @@
             <Chinese>手持式超音波</Chinese>
             <Chinesesimp>手持式超声</Chinesesimp>
             <Dutch>Mobiele echograaf</Dutch>
+            <Turkish>El Tipi Ultrasound</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_Ultra_Thorasic">
             <English>Lung Status: %1</English>
@@ -1353,6 +1441,7 @@
             <Chinese>肺部狀態：%1</Chinese>
             <Chinesesimp>肺部状态：%1</Chinesesimp>
             <Dutch>Longstatus: %1</Dutch>
+            <Turkish>Akciğer Durumu: %1</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_Ultra_Thorasic_Hemo">
             <English>Hemopneumothorax</English>
@@ -1367,6 +1456,7 @@
             <Chinese>血氣胸</Chinese>
             <Chinesesimp>血气胸</Chinesesimp>
             <Dutch>Hemopneumothorax</Dutch>
+            <Turkish>Hemopnömotoraks</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_Ultra_Thorasic_NoActivity">
             <English>No Activity</English>
@@ -1378,6 +1468,7 @@
             <Japanese>活動なし</Japanese>
             <Chinese>無活動</Chinese>
             <Dutch>Geen activiteit</Dutch>
+            <Turkish>Aktivite Yok</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_Ultra_Thorasic_PTX">
             <English>Pneumothorax</English>
@@ -1392,6 +1483,7 @@
             <Chinese>氣胸</Chinese>
             <Chinesesimp>气胸</Chinesesimp>
             <Dutch>Pneumothorax</Dutch>
+            <Turkish>Pnömotoraks</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_Ultra_Thorasic_Tension">
             <English>Tension Pneumothorax</English>
@@ -1406,6 +1498,7 @@
             <Chinese>張力性氣胸</Chinese>
             <Chinesesimp>张力性气胸</Chinesesimp>
             <Dutch>Tensiepneumothorax</Dutch>
+            <Turkish>Gergin Pnömotoraks</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_Ultra_Use">
             <English>Conduct Ultrasound Assessment</English>
@@ -1420,6 +1513,7 @@
             <Chinese>進行超音波評估</Chinese>
             <Chinesesimp>进行超声评估</Chinesesimp>
             <Dutch>Voer echo evaluatie uit</Dutch>
+            <Turkish>Ultrasound Değerlendirmesi Yap</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_Vacuum_Action">
             <English>Applying</English>
@@ -1437,6 +1531,7 @@
             <Chinesesimp>施用中</Chinesesimp>
             <Finnish>Hakeminen</Finnish>
             <Dutch>Wordt aangelegd</Dutch>
+            <Turkish>Uygulanıyor</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_Vacuum_DescShort">
             <English>Used to completely dress and seal wounds</English>
@@ -1454,6 +1549,7 @@
             <Chinesesimp>用于完全包扎和密封伤口</Chinesesimp>
             <Finnish>Käytetään haavojen täydelliseen pukemiseen ja sulkemiseen</Finnish>
             <Dutch>Wordt gebruikt om alle wonden te dichten en verbinden</Dutch>
+            <Turkish>Yaraları tamamen kapatmak ve mühürlemek için kullanılır</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_Vacuum_Use">
             <English>Apply Vacuum Dressing</English>
@@ -1471,6 +1567,7 @@
             <Chinesesimp>施用 NPWT 敷料</Chinesesimp>
             <Finnish>Levitä NPWT-sidosta</Finnish>
             <Dutch>Vacuümverband aanleggen</Dutch>
+            <Turkish>Vacuum Dressing Uygula</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_Vacuum_displayName">
             <English>Dressing Vacuum (NPWT)</English>
@@ -1488,6 +1585,7 @@
             <Chinesesimp>NPWT 敷料</Chinesesimp>
             <Finnish>Pukeutumistyhjiö</Finnish>
             <Dutch>Vacuümverband (NPWT)</Dutch>
+            <Turkish>Dressing Vacuum (NPWT)</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_cba_name">
             <English>KAT - ADV Medical: Surgery</English>
@@ -1497,6 +1595,7 @@
             <German>KAT - ADV Medical: Chirurgie</German>
             <Japanese>KAM - 外科 (Surgery)</Japanese>
             <Dutch>KAT - ADV Medical: Chirurgie</Dutch>
+            <Turkish>KAT – Gelişmiş Tıp: Cerrahi</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_fracture_check">
             <English>Check Fracture</English>
@@ -1514,6 +1613,7 @@
             <Chinesesimp>检查骨折</Chinesesimp>
             <Finnish>Tarkista murtuma</Finnish>
             <Dutch>Check fractuur</Dutch>
+            <Turkish>Kırığı Kontrol Et</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_fracture_checking">
             <English>Checking</English>
@@ -1531,6 +1631,7 @@
             <Chinesesimp>检查中</Chinesesimp>
             <Finnish>Tarkistetaan</Finnish>
             <Dutch>Checking</Dutch>
+            <Turkish>Kontrol Ediliyor</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_fracture_closed">
             <English>Perform Closed Reduction</English>
@@ -1548,6 +1649,7 @@
             <Chinesesimp>封闭复位</Chinesesimp>
             <Finnish>Suorita suljettu pienennys</Finnish>
             <Dutch>Voer gesloten reductie uit</Dutch>
+            <Turkish>Kapalı Redüksiyon Uygula</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_fracture_fail">
             <English>Surgical Action Failed</English>
@@ -1565,6 +1667,7 @@
             <Chinesesimp>手术失败</Chinesesimp>
             <Finnish>Kirurginen toimenpide: epäonnistunut</Finnish>
             <Dutch>Chirurgische actie is gefaald</Dutch>
+            <Turkish>Cerrahi İşlem Başarısız</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_fracture_log">
             <English>%1 present on %2</English>
@@ -1582,6 +1685,7 @@
             <Chinesesimp>%1 存在于 %2</Chinesesimp>
             <Finnish>%1 läsnä %2</Finnish>
             <Dutch>%1 aanwezig op %2</Dutch>
+            <Turkish>%1, %2 üzerinde mevcut</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_fracture_open">
             <English>Perform Open Reduction</English>
@@ -1599,6 +1703,7 @@
             <Chinesesimp>开放复位</Chinesesimp>
             <Finnish>Suorita avoin pienennys</Finnish>
             <Dutch>Voer open reductie uit</Dutch>
+            <Turkish>Açık Redüksiyon Uygula</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_incision_log">
             <English>%1 made an incision on the %2</English>
@@ -1616,6 +1721,7 @@
             <Chinesesimp>%1 在 %2 上做了一个切口</Chinesesimp>
             <Finnish>%1 teki viillon %2</Finnish>
             <Dutch>%1 heeft een incisie gemaakt op %2</Dutch>
+            <Turkish>%1, %2 üzerinde bir insizyon yaptı</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_perform">
             <English>Performing</English>
@@ -1633,6 +1739,7 @@
             <Chinesesimp>透析中</Chinesesimp>
             <Finnish>Suorietaan</Finnish>
             <Dutch>Wordt uitgevoerd</Dutch>
+            <Turkish>Yapılıyor</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_surgeryToolbox">
             <English>[KAM] Surgery Box</English>
@@ -1650,6 +1757,7 @@
             <Chinesesimp>[KAM]手术箱</Chinesesimp>
             <Finnish>[KAM] Leikkauslaatikko</Finnish>
             <Dutch>[KAM] Chirurgiedoos</Dutch>
+            <Turkish>[KAM] Surgery Box</Turkish>
         </Key>
         <Key ID="STR_KAT_Surgery_surgery_log">
             <English>%1 %2 the fracture on the %3</English>
@@ -1667,6 +1775,7 @@
             <Chinesesimp>在 %3 上有一处 %1 %2</Chinesesimp>
             <Finnish>%1 %2 murtuma %3</Finnish>
             <Dutch>%1 %2 de breuk op %3</Dutch>
+            <Turkish>%1, %3 üzerindeki kırığı %2</Turkish>
         </Key>
     </Package>
 </Project>

--- a/addons/vitals/stringtable.xml
+++ b/addons/vitals/stringtable.xml
@@ -150,7 +150,7 @@
             <German>KAT - ADV Medical: Vitalwerte</German>
             <Japanese>KAM - バイタル</Japanese>
             <Dutch>KAT - ADV Medical: Vitals</Dutch>
-            <Turkish>KAT – Gelişmiş Tıp: Vital Bulgular</Turkish>
+            <Turkish>KAT – Gelişmiş Tıp: Hayati Bulgular</Turkish>
         </Key>
     </Package>
 </Project>

--- a/addons/vitals/stringtable.xml
+++ b/addons/vitals/stringtable.xml
@@ -12,6 +12,7 @@
             <Chinese>啟用基本生命體徵套件</Chinese>
             <Chinesesimp>启用基本生命体征套件</Chinesesimp>
             <Dutch>Sta eenvoudige vitalen waarden kits toe</Dutch>
+            <Turkish>Temel Vital Setini etkinleştir</Turkish>
         </Key>
         <Key ID="STR_KAT_Vitals_BASIC_DIAGNOSTIC_TIME">
             <English>Basic Vitals Kit Time</English>
@@ -24,6 +25,7 @@
             <Chinese>基本生命體徵套件時間</Chinese>
             <Chinesesimp>基本生命体征套件时间</Chinesesimp>
             <Dutch>Behandelingstijd voor het gebruik van eenvoudige vitale waarden kits</Dutch>
+            <Turkish>Temel Vital Seti süresi</Turkish>
         </Key>
         <Key ID="STR_KAT_Vitals_BasicDiagnostic_Output">
             <English>HR: %1, BP: %2/%3, RR: %4</English>
@@ -36,6 +38,7 @@
             <Chinese>心率：％1，血壓：％2／％3，呼吸頻率：％4</Chinese>
             <Chinesesimp>心率：％1，血压：％2／％3，呼吸频率：％4</Chinesesimp>
             <Dutch>HF: %1, BD: %2/%3, AF: %4</Dutch>
+            <Turkish>Nabız: %1, Tansiyon: %2/%3, Solunum: %4</Turkish>
         </Key>
         <Key ID="STR_KAT_Vitals_FLUID_SHIFT">
             <English>Enable Patient Fluid Shift</English>
@@ -48,6 +51,7 @@
             <Chinese>啟用患者體液轉移</Chinese>
             <Chinesesimp>启用患者体液转移</Chinesesimp>
             <Dutch>Sta vloeistoffenverschuivingen in patiënten toe</Dutch>
+            <Turkish>Hasta sıvı kaymasını etkinleştir</Turkish>
         </Key>
         <Key ID="STR_KAT_Vitals_SIMPLEMED_ENABLE">
             <English>Activate AI Simple Medical</English>
@@ -60,6 +64,7 @@
             <Chinese>啟用AI簡易醫療</Chinese>
             <Chinesesimp>启用AI简易医疗</Chinesesimp>
             <Dutch>Activeer AI/KI versimpeld medisch</Dutch>
+            <Turkish>Yapay zekâ basit medikal sistemini etkinleştir</Turkish>
         </Key>
         <Key ID="STR_KAT_Vitals_SIMPLEMED_ENABLE_DESC">
             <English>Apply simplified vital calculations to the AI unit. Which can be useful for saving FPS.</English>
@@ -72,6 +77,7 @@
             <Chinese>將簡化的生命體徵計算應用於AI單位，這可以幫助節省FPS。</Chinese>
             <Chinesesimp>将简化的生命体征计算应用于AI单位，这可以帮助节省FPS。</Chinesesimp>
             <Dutch>Versimpelt de vitale-waardensimulatie voor KI-eenheden. Dit kan helpen bij het besparen op FPS</Dutch>
+            <Turkish>FPS tasarrufu sağlamak için yapay zekâ birimlerine basitleştirilmiş vital hesaplamaları uygular.</Turkish>
         </Key>
         <Key ID="STR_KAT_Vitals_basicDiagnostic_Log">
             <English>%1 - %2</English>
@@ -82,6 +88,7 @@
             <German>%1 - %2</German>
             <Japanese>%1 - %2</Japanese>
             <Dutch>%1 - %2</Dutch>
+            <Turkish>%1 – %2</Turkish>
         </Key>
         <Key ID="STR_KAT_Vitals_basicDiagnostic_description">
             <English>Vitals Kit which returns HR, BP, and RR</English>
@@ -94,6 +101,7 @@
             <Chinese>可測量心率（HR）、血壓（BP）和呼吸頻率（RR）等生命體徵的診斷套件</Chinese>
             <Chinesesimp>可测量心率（HR）、血压（BP）和呼吸频率（RR）等生命体征的诊断套件</Chinesesimp>
             <Dutch>Vitale waarden kit dat bloeddruk en hart- en ademfrequentie meet</Dutch>
+            <Turkish>Nabız, tansiyon ve solunum değerlerini veren vital seti</Turkish>
         </Key>
         <Key ID="STR_KAT_Vitals_basicDiagnostic_display">
             <English>Basic Vitals Kit</English>
@@ -106,6 +114,7 @@
             <Chinese>基本生命體徵套件</Chinese>
             <Chinesesimp>基本生命体征套件</Chinesesimp>
             <Dutch>Eenvoudige vitalen waarden kit</Dutch>
+            <Turkish>Temel Vital Seti</Turkish>
         </Key>
         <Key ID="STR_KAT_Vitals_basicDiagnostic_progress">
             <English>Assessing Patient...</English>
@@ -118,6 +127,7 @@
             <Chinese>正在評估患者...</Chinese>
             <Chinesesimp>正在评估患者...</Chinesesimp>
             <Dutch>Patiënt wordt onderzocht...</Dutch>
+            <Turkish>Hasta değerlendiriliyor...</Turkish>
         </Key>
         <Key ID="STR_KAT_Vitals_basicDiagnostic_use">
             <English>Use Basic Vitals Kit</English>
@@ -130,6 +140,7 @@
             <Chinese>使用基本生命體徵套件</Chinese>
             <Chinesesimp>使用基本生命体征套件</Chinesesimp>
             <Dutch>Vitale waarden kit gebruiken</Dutch>
+            <Turkish>Temel Vital Setini kullan</Turkish>
         </Key>
         <Key ID="STR_KAT_Vitals_cba_name">
             <English>KAT - ADV Medical: Vitals</English>
@@ -139,6 +150,7 @@
             <German>KAT - ADV Medical: Vitalwerte</German>
             <Japanese>KAM - バイタル</Japanese>
             <Dutch>KAT - ADV Medical: Vitals</Dutch>
+            <Turkish>KAT – Gelişmiş Tıp: Vital Bulgular</Turkish>
         </Key>
     </Package>
 </Project>

--- a/addons/watch/stringtable.xml
+++ b/addons/watch/stringtable.xml
@@ -12,6 +12,7 @@
             <Chinese>計時器增加 15 秒</Chinese>
             <Chinesesimp>添加15秒观看计时器</Chinesesimp>
             <Dutch>Voeg 15 seconden toe aan de timer</Dutch>
+            <Turkish>Saat Zamanlayıcısına 15 Saniye Ekle</Turkish>
         </Key>
         <Key ID="STR_KAT_Watch_CavminDescription">
             <English>Watch with Vital Monitoring Capabilities. Garry Owen!</English>
@@ -24,6 +25,7 @@
             <Chinese>具有生命體徵監測功能的腕錶。Garry Owen!</Chinese>
             <Chinesesimp>使用重要监控功能观看。加里·欧文！</Chinesesimp>
             <Dutch>Horloge met vitale waarden monitoringscapaciteit. Garry Owen!</Dutch>
+            <Turkish>Hayati Bulguları İzleme Özellikli Saat. Garry Owen!</Turkish>
         </Key>
         <Key ID="STR_KAT_Watch_CavminDisplayName">
             <English>Katmin Cavalry Limited</English>
@@ -36,6 +38,7 @@
             <Chinese>Katmin Cavalry Limited</Chinese>
             <Chinesesimp>Katmin 骑兵限量</Chinesesimp>
             <Dutch>Katmin Cavalry Limited</Dutch>
+            <Turkish>Katmin Cavalry Limited</Turkish>
         </Key>
         <Key ID="STR_KAT_Watch_KatminDescription">
             <English>Watch with Vital Monitoring Capabilities</English>
@@ -48,6 +51,7 @@
             <Chinese>具有生命體徵監測功能的腕錶</Chinese>
             <Chinesesimp>具有重要监控功能的手表</Chinesesimp>
             <Dutch>Horloge met ingebouwde vitale waarden monitor</Dutch>
+            <Turkish>Hayati Bulguları İzleme Özellikli Saat</Turkish>
         </Key>
         <Key ID="STR_KAT_Watch_KatminDisplayName">
             <English>Katmin K500</English>
@@ -60,6 +64,7 @@
             <Chinese>Katmin K500</Chinese>
             <Chinesesimp>Katmin K500</Chinesesimp>
             <Dutch>Katmin K500</Dutch>
+            <Turkish>Katmin K500</Turkish>
         </Key>
         <Key ID="STR_KAT_Watch_RangerDescription">
             <English>Watch with Vital Monitoring Capabilities. Sua Sponte.</English>
@@ -72,6 +77,7 @@
             <Chinese>具有生命監測功能的腕錶。Sua Sponte。</Chinese>
             <Chinesesimp>使用重要监控功能观看。Sua Sponte。</Chinesesimp>
             <Dutch>Horloge met vitale waarden monitoringscapaciteit. Sua Sponte.</Dutch>
+            <Turkish>Hayati Bulguları İzleme Özellikli Saat. Sua Sponte.</Turkish>
         </Key>
         <Key ID="STR_KAT_Watch_RangerDisplayName">
             <English>Katmin K12 Model R</English>
@@ -84,6 +90,7 @@
             <Chinese>Katmin K12 R 型</Chinese>
             <Chinesesimp>Katmin K12 R型</Chinesesimp>
             <Dutch>Katmin K12 Model R</Dutch>
+            <Turkish>Katmin K12 Model R</Turkish>
         </Key>
         <Key ID="STR_KAT_Watch_SETTING_AltitudeForm">
             <English>Select altitude form</English>
@@ -96,6 +103,7 @@
             <Chinese>選擇高度單位</Chinese>
             <Chinesesimp>选择高度单位</Chinesesimp>
             <Dutch>Selecteer hoogte vorm</Dutch>
+            <Turkish>İrtifa Birimini Seç</Turkish>
         </Key>
         <Key ID="STR_KAT_Watch_SETTING_AltitudeForm_Desc">
             <English>Selects which altitude unit is used for the KATMIN watch display</English>
@@ -108,6 +116,7 @@
             <Chinese>選擇在KATMIN手錶顯示器上使用的高度單位</Chinese>
             <Chinesesimp>选择用于KATMIN手表显示的高度单位</Chinesesimp>
             <Dutch>Selecteerd welk hoogte eenheid gebruikt wordt voor de KATMIN horloge</Dutch>
+            <Turkish>KATMIN saat ekranında kullanılacak irtifa birimini seçer</Turkish>
         </Key>
         <Key ID="STR_KAT_Watch_SETTING_AltitudeForm_feet">
             <English>Feet</English>
@@ -120,6 +129,7 @@
             <Chinese>英尺</Chinese>
             <Chinesesimp>英尺</Chinesesimp>
             <Dutch>Voet</Dutch>
+            <Turkish>Feet</Turkish>
         </Key>
         <Key ID="STR_KAT_Watch_SETTING_AltitudeForm_meters">
             <English>Meters</English>
@@ -132,6 +142,7 @@
             <Chinese>公尺</Chinese>
             <Chinesesimp>米</Chinesesimp>
             <Dutch>Meters</Dutch>
+            <Turkish>Metre</Turkish>
         </Key>
         <Key ID="STR_KAT_Watch_SETTING_PressureForm">
             <English>Select pressure form</English>
@@ -144,6 +155,7 @@
             <Chinese>選擇壓力單位</Chinese>
             <Chinesesimp>选择压力单位</Chinesesimp>
             <Dutch>Selecteer drukvorm</Dutch>
+            <Turkish>Basınç Birimini Seç</Turkish>
         </Key>
         <Key ID="STR_KAT_Watch_SETTING_PressureForm_Desc">
             <English>Selects which pressure unit is used for the KATMIN watch display</English>
@@ -156,6 +168,7 @@
             <Chinese>選擇在KATMIN手錶顯示的壓力單位</Chinese>
             <Chinesesimp>选择用于KATMIN手表显示的压力单位</Chinesesimp>
             <Dutch>Selecteerd welke drukeenheden gebruikt worden voor de KATMIN horloge</Dutch>
+            <Turkish>KATMIN saat ekranında kullanılacak basınç birimini seçer</Turkish>
         </Key>
         <Key ID="STR_KAT_Watch_SETTING_PressureForm_hPa">
             <English>hPa</English>
@@ -168,6 +181,7 @@
             <Chinese>百帕</Chinese>
             <Chinesesimp>hPa</Chinesesimp>
             <Dutch>hPa</Dutch>
+            <Turkish>hPa</Turkish>
         </Key>
         <Key ID="STR_KAT_Watch_SETTING_PressureForm_mmHg">
             <English>mmHg</English>
@@ -180,6 +194,7 @@
             <Chinese>mmHg</Chinese>
             <Chinesesimp>mmHg</Chinesesimp>
             <Dutch>mmHg</Dutch>
+            <Turkish>mmHg</Turkish>
         </Key>
         <Key ID="STR_KAT_Watch_SETTING_TemperatureForm">
             <English>Select temperature form</English>
@@ -192,6 +207,7 @@
             <Chinese>選擇溫度單位</Chinese>
             <Chinesesimp>选择温度单位</Chinesesimp>
             <Dutch>Selecteer temperatuur vorm</Dutch>
+            <Turkish>Sıcaklık Birimini Seç</Turkish>
         </Key>
         <Key ID="STR_KAT_Watch_SETTING_TemperatureForm_Celsius">
             <English>Celsius</English>
@@ -204,6 +220,7 @@
             <Chinese>攝氏</Chinese>
             <Chinesesimp>摄氏度</Chinesesimp>
             <Dutch>Celsius</Dutch>
+            <Turkish>Celsius</Turkish>
         </Key>
         <Key ID="STR_KAT_Watch_SETTING_TemperatureForm_Desc">
             <English>Selects which temperature unit is used for the KATMIN watch display</English>
@@ -216,6 +233,7 @@
             <Chinese>選擇在KATMIN手錶顯示器上使用的溫度單位</Chinese>
             <Chinesesimp>选择KATMIN手表显示使用的温度单位</Chinesesimp>
             <Dutch>Selecteert welke temperatuur eenheid gebruikt wordt voor de KATMIN horloge</Dutch>
+            <Turkish>KATMIN saat ekranında kullanılacak sıcaklık birimini seçer</Turkish>
         </Key>
         <Key ID="STR_KAT_Watch_SETTING_TemperatureForm_Fahrenheit">
             <English>Fahrenheit</English>
@@ -228,6 +246,7 @@
             <Chinese>華氏</Chinese>
             <Chinesesimp>华氏度</Chinesesimp>
             <Dutch>Fahrenheit</Dutch>
+            <Turkish>Fahrenheit</Turkish>
         </Key>
         <Key ID="STR_KAT_Watch_SETTING_WatchInaccuracy">
             <English>Watch Vitals Inaccuracy</English>
@@ -237,6 +256,7 @@
             <German>Ungenauigkeit der Uhren-Vitalwerte</German>
             <Japanese>腕時計バイタルの不正確性</Japanese>
             <Dutch>Inaccuraatheid van vitale waarden gemeten via horloge</Dutch>
+            <Turkish>Saat Hayati Bulgular Hata Payı</Turkish>
         </Key>
         <Key ID="STR_KAT_Watch_SETTING__WatchInaccuracy_Desc">
             <English>Enables watch inaccuracy when reading patient vitals</English>
@@ -246,6 +266,7 @@
             <German>Aktiviert Ungenauigkeit der Vitalwerte der Uhren</German>
             <Japanese>腕時計が患者のバイタルを不正確に読み取るようになります。</Japanese>
             <Dutch>Staat inaccuraatheid bij metingen van vitale waarden door horloges toe</Dutch>
+            <Turkish>Saatin hasta hayati bulgularını okurken hata payı oluşturmasını etkinleştirir</Turkish>
         </Key>
         <Key ID="STR_KAT_Watch_STSDescription">
             <English>Watch with Vital Monitoring Capabilities. So Others May Live.</English>
@@ -258,6 +279,7 @@
             <Chinese>具有生命體徵監測功能的腕錶。以便其他人能夠活下去。</Chinese>
             <Chinesesimp>使用重要监控功能观看。所以其他人可以活下去。</Chinesesimp>
             <Dutch>Horloge met vitale waarden monitoringscapaciteit. Zodat anderen kunnen leven.</Dutch>
+            <Turkish>Hayati Bulguları İzleme Özellikli Saat. Başkaları Yaşasın Diye!</Turkish>
         </Key>
         <Key ID="STR_KAT_Watch_STSDisplayName">
             <English>Katmin Jump Standard</English>
@@ -269,6 +291,7 @@
             <Japanese>Katmin Jump Standard</Japanese>
             <Chinesesimp>Katmin 跳跃标准</Chinesesimp>
             <Dutch>Katmin Jump Standard</Dutch>
+            <Turkish>Katmin Jump Standard</Turkish>
         </Key>
         <Key ID="STR_KAT_Watch_ShowKATWatch_Setting">
             <English>Show KATMIN Watch</English>
@@ -281,6 +304,7 @@
             <Chinese>顯示 KATMIN 腕錶</Chinese>
             <Chinesesimp>显示KATMIN手表</Chinesesimp>
             <Dutch>Toon KATMIN horloge</Dutch>
+            <Turkish>KATMIN Saatini Göster</Turkish>
         </Key>
         <Key ID="STR_KAT_Watch_StartStopTimer_Setting">
             <English>Start and Stop Watch Timer</English>
@@ -293,6 +317,7 @@
             <Chinese>啟動、停止計時器</Chinese>
             <Chinesesimp>启动和停止手表定时器</Chinesesimp>
             <Dutch>Timer starten/stoppen</Dutch>
+            <Turkish>Saat Zamanlayıcısını Başlat / Durdur</Turkish>
         </Key>
         <Key ID="STR_KAT_Watch_SubtractTimer_Setting">
             <English>Subtract 15 Seconds from Watch Timer</English>
@@ -305,6 +330,7 @@
             <Chinese>計時器減去 15 秒</Chinese>
             <Chinesesimp>从手表计时器中减去15秒</Chinesesimp>
             <Dutch>15 seconden van timer afhalen</Dutch>
+            <Turkish>Saat Zamanlayıcısından 15 Saniye Çıkar</Turkish>
         </Key>
         <Key ID="STR_KAT_Watch_TimeModifier_Settings">
             <English>Time Modifier (K500/Model R)</English>
@@ -316,6 +342,7 @@
             <Japanese>盤面/指針の表示切り替え (K500/Model R)</Japanese>
             <Chinese>時間調整器 (K500/Model R)</Chinese>
             <Dutch>Tijdmodificator (K500/Model R)</Dutch>
+            <Turkish>Zaman Değiştirici (K500/Model R)</Turkish>
         </Key>
         <Key ID="STR_KAT_Watch_cba_name">
             <English>KAT - ADV Medical: Watch</English>
@@ -325,6 +352,7 @@
             <German>KAT - ADV Medical: Uhren</German>
             <Japanese>KAM - 腕時計 (Watch)</Japanese>
             <Dutch>KAT - ADV Medical: Horloges</Dutch>
+            <Turkish>KAT – Gelişmiş Tıp: Saat</Turkish>
         </Key>
         <Key ID="STR_KAT_Watch_descentFT">
             <English>%1ft/s</English>
@@ -337,6 +365,7 @@
             <Chinese>%1 ft/s</Chinese>
             <Chinesesimp>%1 ft/s</Chinesesimp>
             <Dutch>%1ft/s</Dutch>
+            <Turkish>%1 ft/sn</Turkish>
         </Key>
         <Key ID="STR_KAT_Watch_descentM">
             <English>%1m/s</English>
@@ -349,6 +378,7 @@
             <Chinese>%1 m/s</Chinese>
             <Chinesesimp>%1 m/s</Chinesesimp>
             <Dutch>%1m/s</Dutch>
+            <Turkish>%1 m/sn</Turkish>
         </Key>
     </Package>
 </Project>

--- a/addons/zeus/stringtable.xml
+++ b/addons/zeus/stringtable.xml
@@ -34,6 +34,7 @@
             <Chinesesimp>无脉冲电活动(PEA)</Chinesesimp>
             <Finnish>Pulssiton sähköinen toiminta:</Finnish>
             <Dutch>Polsloze electrische activiteit (PEA)</Dutch>
+            <Turkish>Nabızsız Elektriksel Aktivite (PEA)</Turkish>
         </Key>
         <Key ID="STR_KAT_Zeus_CardiacState_Module_State">
             <English>State:</English>
@@ -49,7 +50,7 @@
             <Japanese>状態:</Japanese>
             <Chinese>狀態：</Chinese>
             <Chinesesimp>状态：</Chinesesimp>
-            <Turkish>Belirtmek:</Turkish>
+            <Turkish>Durum:</Turkish>
             <Finnish>Olotila:</Finnish>
             <Dutch>staat:</Dutch>
         </Key>
@@ -68,6 +69,7 @@
             <Chinesesimp>心室颤动(VF)</Chinesesimp>
             <Finnish>Kammiovärinä:</Finnish>
             <Dutch>Ventriculaire fibrillatie</Dutch>
+            <Turkish>Ventriküler Fibrilasyon</Turkish>
         </Key>
         <Key ID="STR_KAT_Zeus_CardiacState_Module_VT">
             <English>Ventricular Tachycardia</English>
@@ -84,6 +86,7 @@
             <Chinesesimp>室性心动过速(VT)</Chinesesimp>
             <Finnish>Ventrikulaarinen takykardia:</Finnish>
             <Dutch>Ventriculaire tachycardie</Dutch>
+            <Turkish>Ventriküler Taşikardi</Turkish>
         </Key>
         <Key ID="STR_KAT_Zeus_CardiacState_Module_displayname">
             <English>Change Cardiac State</English>
@@ -100,6 +103,7 @@
             <Chinesesimp>改变心脏状态</Chinesesimp>
             <Finnish>Muuta sydämen tilaa</Finnish>
             <Dutch>Verander cardiale staat</Dutch>
+            <Turkish>Kardiyak Durumu Değiştir</Turkish>
         </Key>
         <Key ID="STR_KAT_Zeus_ModuleManageAirway_Hemopneumothorax">
             <English>Hemopneumothorax:</English>
@@ -133,7 +137,7 @@
             <Japanese>気道閉塞:</Japanese>
             <Chinese>氣道阻塞：</Chinese>
             <Chinesesimp>气道闭塞:</Chinesesimp>
-            <Turkish>ACE-Eczacılık etkinleştirildi mi?</Turkish>
+            <Turkish>Hava yolu tıkanıklığı:</Turkish>
             <Finnish>Hengitysteiden tukos:</Finnish>
             <Dutch>Luchtwegobstructie:</Dutch>
         </Key>
@@ -151,7 +155,7 @@
             <Japanese>気道異物:</Japanese>
             <Chinese>气道闭塞:</Chinese>
             <Chinesesimp>气道阻塞：</Chinesesimp>
-            <Turkish>Hava yolu tıkanıklığı:</Turkish>
+            <Turkish>Hava yolu kapanıklığı:</Turkish>
             <Finnish>Hengitysteiden tukos:</Finnish>
             <Dutch>Luchtwegverstopping:</Dutch>
         </Key>
@@ -186,6 +190,7 @@
             <Chinese>氣胸惡化：</Chinese>
             <Chinesesimp>气胸恶化:</Chinesesimp>
             <Dutch>Verslechterende pneumothorax:</Dutch>
+            <Turkish>Pnömotoraks Kötüleşmesi:</Turkish>
         </Key>
         <Key ID="STR_KAT_Zeus_ModuleManageAirway_SpO2Value">
             <English>PaO2 value:</English>
@@ -274,6 +279,7 @@
             <Chinesesimp>单位必须是AI</Chinesesimp>
             <Finnish>Yksikön on oltava AI</Finnish>
             <Dutch>Eenheid moet een KI / AI zijn</Dutch>
+            <Turkish>Birim bir AI olmalıdır</Turkish>
         </Key>
         <Key ID="STR_KAT_Zeus_bloodType_Module_displayname">
             <English>Change blood group / volume</English>
@@ -289,7 +295,7 @@
             <Japanese>血液型/血液量を変更</Japanese>
             <Chinese>更改血型/血液量</Chinese>
             <Chinesesimp>改变血型/血液量:</Chinesesimp>
-            <Turkish>Kan grubunu / hacmini değiştir</Turkish>
+            <Turkish>Kan Grubunu / Hacmini Değiştir</Turkish>
             <Finnish>Muuta verityyppiä/tilavuutta</Finnish>
             <Dutch>Verander bloedgroep / -volume</Dutch>
         </Key>
@@ -307,7 +313,7 @@
             <Japanese>気道の管理</Japanese>
             <Chinese>氣道管理</Chinese>
             <Chinesesimp>气道管理</Chinesesimp>
-            <Turkish>Hava Yollarını Yönet</Turkish>
+            <Turkish>Hava Yolunu Yönet</Turkish>
             <Finnish>Hallitse hengitysteitä</Finnish>
             <Dutch>Manage luchtweg</Dutch>
         </Key>
@@ -325,7 +331,7 @@
             <Japanese>%1%3 (以前は %2%3)</Japanese>
             <Chinese>%1%3 (曾是 %2%3)</Chinese>
             <Chinesesimp>%1%3 (以前是 %2%3)</Chinesesimp>
-            <Turkish>%1%3 (oldu %2%3)</Turkish>
+            <Turkish>%1%3 (önceden %2%3)</Turkish>
             <Finnish>%1%2(oli %2%3)</Finnish>
             <Dutch>%1%3 (was %2%3)</Dutch>
         </Key>
@@ -344,6 +350,7 @@
             <Chinesesimp>AI单位即时死亡 %1</Chinesesimp>
             <Finnish>Välitön AI-kuolema %1 yksikölle</Finnish>
             <Dutch>Onmiddelijke dood voor KI / AI %1 voor eenheid</Dutch>
+            <Turkish>Birim için Anında AI Ölümü: %1</Turkish>
         </Key>
         <Key ID="STR_KAT_Zeus_toggleAIDeath_Module_displayname">
             <English>Toggle Instant AI Death</English>
@@ -360,6 +367,7 @@
             <Chinesesimp>切换AI即时死亡</Chinesesimp>
             <Finnish>Valitse välitön AI-kuolema</Finnish>
             <Dutch>Schakel onmiddelijke KI / AI dood om</Dutch>
+            <Turkish>Anında AI Ölümünü Aç/Kapat</Turkish>
         </Key>
     </Package>
 </Project>

--- a/addons/zeus/stringtable.xml
+++ b/addons/zeus/stringtable.xml
@@ -224,7 +224,7 @@
             <Japanese>緊張性気胸:</Japanese>
             <Chinese>張力性氣胸：</Chinese>
             <Chinesesimp>张力性气胸：</Chinesesimp>
-            <Turkish>Tansiyon pnömotoraks:</Turkish>
+            <Turkish>Gergin pnömotoraks:</Turkish>
             <Finnish>Lamannut keuhko jännityksen alaisena:</Finnish>
             <Dutch>Spanningspneumothorax:</Dutch>
         </Key>


### PR DESCRIPTION
**When merged this pull request will:**
- Add complete Turkish translations for KAT ADV Medical modules
- Translate all missing and outdated Turkish strings
- Improve consistency and medical terminology across all translated strings
- Keep original logic and functionality unchanged

### IMPORTANT

- [x] Development Guidelines are read, understood and applied.
- [x] Title of this PR uses the standard template `Component - Add {changes}`.
