### PR TITLE
Chemical - Fix reported 2.0 bugs

### DIFF
--- a/addons/chemical/functions/fnc_applyMustardDamage.sqf
+++ b/addons/chemical/functions/fnc_applyMustardDamage.sqf
@@ -24,8 +24,8 @@
 params ["_unit"];
 if (!alive _unit) exitWith {};
 
-// Lung damage: chemical pneumonitis from inhaled mustard. High chance value
-// pushes toward tension hemopneumothorax (the lethal variant).
+// Lung damage: chemical pneumonitis from inhaled mustard. Forces a
+// hemopneumothorax (bleeding variant)
 _unit setVariable [QEGVAR(breathing,pneumothorax), 1, true];
 _unit setVariable [QEGVAR(breathing,deepPenetratingInjury), true, true];
 _unit setVariable [QEGVAR(breathing,activeChestSeal), false, true];
@@ -34,7 +34,10 @@ _unit setVariable [QEGVAR(breathing,activeChestSeal), false, true];
 [_unit] call EFUNC(breathing,handlePneumothoraxDeterioration);
 
 if (EGVAR(breathing,advPtxEnable)) then {
-    [_unit, 30, true] call EFUNC(breathing,inflictAdvancedPneumothorax);
+    [_unit, 0.7] call ACEFUNC(medical_status,adjustPainLevel);
+    _unit setVariable [QEGVAR(breathing,hemopneumothorax), true, true];
+    _unit setVariable [QEGVAR(breathing,pneumothorax), 4, true];
+    [_unit] call EFUNC(circulation,updateInternalBleeding);
 };
 
 // Pain spike — pushes past unconscious threshold quickly.

--- a/addons/chemical/functions/fnc_effect_mustard.sqf
+++ b/addons/chemical/functions/fnc_effect_mustard.sqf
@@ -36,7 +36,9 @@ private _eyeMax = missionNamespace getVariable [QGVAR(mustard_eyeOnsetMax), 600]
 private _burnMin = missionNamespace getVariable [QGVAR(mustard_burnOnsetMin), 600];
 private _burnMax = missionNamespace getVariable [QGVAR(mustard_burnOnsetMax), 1200];
 
-_unit setVariable [QGVAR(mustardDeadline_eye),  CBA_missionTime + _eyeMin  + random (_eyeMax  - _eyeMin),  true];
+if (missionNamespace getVariable [QEGVAR(ophthalmology,enable), false]) then {
+    _unit setVariable [QGVAR(mustardDeadline_eye),  CBA_missionTime + _eyeMin  + random (_eyeMax  - _eyeMin),  true];
+};
 _unit setVariable [QGVAR(mustardDeadline_burn), CBA_missionTime + _burnMin + random (_burnMax - _burnMin), true];
 
 [_unit] call FUNC(addToExposureWatcher);

--- a/addons/chemical/functions/fnc_effect_mustard.sqf
+++ b/addons/chemical/functions/fnc_effect_mustard.sqf
@@ -36,7 +36,7 @@ private _eyeMax = missionNamespace getVariable [QGVAR(mustard_eyeOnsetMax), 600]
 private _burnMin = missionNamespace getVariable [QGVAR(mustard_burnOnsetMin), 600];
 private _burnMax = missionNamespace getVariable [QGVAR(mustard_burnOnsetMax), 1200];
 
-if (missionNamespace getVariable [QEGVAR(ophthalmology,enable), false]) then {
+if (EGVAR(ophthalmology,enable)) then {
     _unit setVariable [QGVAR(mustardDeadline_eye),  CBA_missionTime + _eyeMin  + random (_eyeMax  - _eyeMin),  true];
 };
 _unit setVariable [QGVAR(mustardDeadline_burn), CBA_missionTime + _burnMin + random (_burnMax - _burnMin), true];

--- a/addons/surgery/ACE_Medical_Treatment.hpp
+++ b/addons/surgery/ACE_Medical_Treatment.hpp
@@ -111,6 +111,11 @@ class ACE_Medical_Treatment {
             };
             class PunctureWoundMedium: PunctureWound {};
             class PunctureWoundLarge: PunctureWound {};
+
+            class KAT_ChemicalBurn: Abrasion {};
+            class KAT_ChemicalBurnMinor: AbrasionMinor {};
+            class KAT_ChemicalBurnMedium: Abrasion {};
+            class KAT_ChemicalBurnLarge: Abrasion {};
         };
 
         class BloodClotMedium: FieldDressing {
@@ -174,6 +179,11 @@ class ACE_Medical_Treatment {
                 effectiveness = 1;
             };
             class PunctureWoundLarge: PunctureWound {};
+
+            class KAT_ChemicalBurn: Abrasion {};
+            class KAT_ChemicalBurnMinor: Abrasion {};
+            class KAT_ChemicalBurnMedium: AbrasionMedium {};
+            class KAT_ChemicalBurnLarge: Abrasion {};
         };
 
         class BloodClotLarge: FieldDressing {
@@ -237,6 +247,11 @@ class ACE_Medical_Treatment {
             class PunctureWoundLarge: AbrasionLarge {
                 effectiveness = 1;
             };
+
+            class KAT_ChemicalBurn: Abrasion {};
+            class KAT_ChemicalBurnMinor: Abrasion {};
+            class KAT_ChemicalBurnMedium: Abrasion {};
+            class KAT_ChemicalBurnLarge: AbrasionLarge {};
         };
 
         class BloodClotMinorTXA: BloodClotMinor {


### PR DESCRIPTION
**When merged this pull request will:**
- Remove Mustard gas eye injuries if they are disabled in addon options
- Fix 'No config for wound type' warning spam in RPT
- Changed mustard gas tension pneumo to hemo pneumo

### IMPORTANT

- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
