### PR TITLE
Breathing - Add SpO2 rise during CPR + SpO2 CPR Rise Multiplier setting

### DIFF
--- a/addons/breathing/initSettings.inc.sqf
+++ b/addons/breathing/initSettings.inc.sqf
@@ -159,6 +159,16 @@
     true
 ] call CBA_fnc_addSetting;
 
+// Multiplier for how fast SpO2 rises during CPR without BVM
+[
+    QGVAR(SpO2_CPR_RiseMultiplier),
+    "SLIDER",
+    [LLSTRING(SETTING_SpO2_CPR_RiseMultiplier), LLSTRING(SETTING_SpO2_CPR_RiseMultiplier_DESC)],
+    [CBA_SETTINGS_CAT, ELSTRING(GUI,SubCategory_Basic)],
+    [0, 10, 1, 1],
+    true
+] call CBA_fnc_addSetting;
+
 // breathing SpO2 perfusion multiplier
 [
     QGVAR(SpO2_PerfusionMultiplier),

--- a/addons/breathing/initSettings.inc.sqf
+++ b/addons/breathing/initSettings.inc.sqf
@@ -149,6 +149,16 @@
     true
 ] call CBA_fnc_addSetting;
 
+// Allow SpO2 to rise during CPR without BVM
+[
+    QGVAR(SpO2_CPR_Rise),
+    "CHECKBOX",
+    [LLSTRING(SETTING_SpO2_CPR_Rise), LLSTRING(SETTING_SpO2_CPR_Rise_DESC)],
+    [CBA_SETTINGS_CAT, ELSTRING(GUI,SubCategory_Basic)],
+    [false],
+    true
+] call CBA_fnc_addSetting;
+
 // breathing SpO2 perfusion multiplier
 [
     QGVAR(SpO2_PerfusionMultiplier),

--- a/addons/breathing/stringtable.xml
+++ b/addons/breathing/stringtable.xml
@@ -1756,6 +1756,12 @@
         <Key ID="STR_KAT_Breathing_SETTING_SpO2_CPR_Rise_DESC">
             <English>When enabled, CPR alone allows SpO2 to rise without a BVM in the advanced vitals system</English>
         </Key>
+        <Key ID="STR_KAT_Breathing_SETTING_SpO2_CPR_RiseMultiplier">
+            <English>SpO2 rise during CPR multiplier</English>
+        </Key>
+        <Key ID="STR_KAT_Breathing_SETTING_SpO2_CPR_RiseMultiplier_DESC">
+            <English>Scales how far actual ventilation is pushed above demand during CPR without a BVM. Higher values raise SpO2 faster; 0 leaves ventilation balanced for the slowest recovery. Requires SpO2 rises during CPR to be enabled</English>
+        </Key>
         <Key ID="STR_KAT_Breathing_SETTING_SpO2_cardiacActive">
             <English>Activate cardiac arrest SpO2 value</English>
             <Czech>Aktivace hodnoty SpO2 pro srdeční zástavu</Czech>

--- a/addons/breathing/stringtable.xml
+++ b/addons/breathing/stringtable.xml
@@ -1750,6 +1750,12 @@
             <Japanese>心停止によってSpO2が低下するかどうかを制御します。</Japanese>
             <Turkish>Kardiyak arrest sırasında SpO2’nin düşüp düşmeyeceğini kontrol eder</Turkish>
         </Key>
+        <Key ID="STR_KAT_Breathing_SETTING_SpO2_CPR_Rise">
+            <English>SpO2 rises during CPR</English>
+        </Key>
+        <Key ID="STR_KAT_Breathing_SETTING_SpO2_CPR_Rise_DESC">
+            <English>When enabled, CPR alone allows SpO2 to rise without a BVM in the advanced vitals system</English>
+        </Key>
         <Key ID="STR_KAT_Breathing_SETTING_SpO2_cardiacActive">
             <English>Activate cardiac arrest SpO2 value</English>
             <Czech>Aktivace hodnoty SpO2 pro srdeční zástavu</Czech>

--- a/addons/vitals/functions/fnc_handleOxygenFunction.sqf
+++ b/addons/vitals/functions/fnc_handleOxygenFunction.sqf
@@ -41,8 +41,9 @@ private _demandVentilation = 0;
 private _actualVentilation = 0;
 private _previousCyclePaco2 = (_bloodGas select 0);
 private _previousCyclePao2 = (_bloodGas select 1);
+private _cprActive = alive (_unit getVariable [QACEGVAR(medical,CPR_provider), objNull]);
 
-if (IN_CRDC_ARRST(_unit)) then { 
+if ((IN_CRDC_ARRST(_unit)) && {!(_cprActive && EGVAR(breathing,SpO2_CPR_Rise))}) then {
     // When in arrest, there should be no effecive breaths but still a minimum O2 demand. Zero O2 demand would mean a dead patient. Actual ventilation is 1 to prevent issues in the gas tension functions
     _demandVentilation = MINIMUM_VENTILATION;
     _respiratoryDepression = 1;

--- a/addons/vitals/functions/fnc_handleOxygenFunction.sqf
+++ b/addons/vitals/functions/fnc_handleOxygenFunction.sqf
@@ -42,29 +42,44 @@ private _actualVentilation = 0;
 private _previousCyclePaco2 = (_bloodGas select 0);
 private _previousCyclePao2 = (_bloodGas select 1);
 private _cprActive = alive (_unit getVariable [QACEGVAR(medical,CPR_provider), objNull]);
+// When the setting is enabled, CPR without a BVM lets SpO2 recover through chest compressions alone
+private _cprAssistSpO2 = _cprActive && {EGVAR(breathing,SpO2_CPR_Rise)} && {!(_unit getVariable [QEGVAR(breathing,BVMInUse), false])};
 
-if ((IN_CRDC_ARRST(_unit)) && {!(_cprActive && EGVAR(breathing,SpO2_CPR_Rise))}) then {
-    // When in arrest, there should be no effecive breaths but still a minimum O2 demand. Zero O2 demand would mean a dead patient. Actual ventilation is 1 to prevent issues in the gas tension functions
-    _demandVentilation = MINIMUM_VENTILATION;
-    _respiratoryDepression = 1;
-    _respiratoryRate = [0, 20] select (_unit getVariable [QEGVAR(breathing,BVMInUse), false]);
-    _respiratoryDepth = [0, 10] select (_unit getVariable [QEGVAR(breathing,BVMInUse), false]);
-    _actualVentilation = 1;
-} else {
-    // Ventilatory Demand comes from Heart Rate with increase demand from PaCO2 levels 
-    _demandVentilation = ((((_actualHeartRate * HEART_RATE_CO2_MULTIPLIER) / _anerobicPressure) + ((_previousCyclePaco2 - DEFAULT_PACO2) * 200)) max MINIMUM_VENTILATION);
+switch (true) do {
+    case ((IN_CRDC_ARRST(_unit)) && _cprAssistSpO2): {
+        // Dedicated CPR controller: rate and depth are held at zero so chest compressions do not produce
+        // a respiratory rate, which would falsely read as return of spontaneous breathing (ROSC). Demand and
+        // actual ventilation are balanced so oxygenation recovers without RR swinging on PaCO2.
+        _demandVentilation = MINIMUM_VENTILATION;
+        _respiratoryDepression = 1;
+        _respiratoryRate = 0;
+        _respiratoryDepth = 0;
+        _actualVentilation = MINIMUM_VENTILATION;
+    };
+    case (IN_CRDC_ARRST(_unit)): {
+        // When in arrest, there should be no effecive breaths but still a minimum O2 demand. Zero O2 demand would mean a dead patient. Actual ventilation is 1 to prevent issues in the gas tension functions
+        _demandVentilation = MINIMUM_VENTILATION;
+        _respiratoryDepression = 1;
+        _respiratoryRate = [0, 20] select (_unit getVariable [QEGVAR(breathing,BVMInUse), false]);
+        _respiratoryDepth = [0, 10] select (_unit getVariable [QEGVAR(breathing,BVMInUse), false]);
+        _actualVentilation = 1;
+    };
+    default {
+        // Ventilatory Demand comes from Heart Rate with increase demand from PaCO2 levels
+        _demandVentilation = ((((_actualHeartRate * HEART_RATE_CO2_MULTIPLIER) / _anerobicPressure) + ((_previousCyclePaco2 - DEFAULT_PACO2) * 200)) max MINIMUM_VENTILATION);
 
-    // Tidal Volume is modified by respiratory depth which can be supressed by opioids and pneumothroax
-    _respiratoryDepth = [((DEFAULT_RESPIRATORY_DEPTH) - (_opioidDepression / 1.5)), 10] select (_unit getVariable [QEGVAR(breathing,BVMInUse), false]);
-    private _tidalVolume = GET_KAT_SURFACE_AREA(_unit) * (_respiratoryDepth / 10);
-    
-    // Respiratory Rate Calculation
-    _respiratoryRate = [((_demandVentilation / _tidalVolume)) min MAXIMUM_RR, 20] select (_unit getVariable [QEGVAR(breathing,BVMInUse), false]);
+        // Tidal Volume is modified by respiratory depth which can be supressed by opioids and pneumothroax
+        _respiratoryDepth = [((DEFAULT_RESPIRATORY_DEPTH) - (_opioidDepression / 1.5)), 10] select (_unit getVariable [QEGVAR(breathing,BVMInUse), false]);
+        private _tidalVolume = GET_KAT_SURFACE_AREA(_unit) * (_respiratoryDepth / 10);
 
-    // If respiratory rate is low due to PaCO2, it starts increasing faster to compensate
-    if (_previousCyclePaco2 > 50) then { _respiratoryRate = (_respiratoryRate + ((_previousCyclePaco2 - 50) * 0.2)) min MAXIMUM_RR};
+        // Respiratory Rate Calculation
+        _respiratoryRate = [((_demandVentilation / _tidalVolume)) min MAXIMUM_RR, 20] select (_unit getVariable [QEGVAR(breathing,BVMInUse), false]);
 
-    _actualVentilation = _tidalVolume * _respiratoryRate;
+        // If respiratory rate is low due to PaCO2, it starts increasing faster to compensate
+        if (_previousCyclePaco2 > 50) then { _respiratoryRate = (_respiratoryRate + ((_previousCyclePaco2 - 50) * 0.2)) min MAXIMUM_RR};
+
+        _actualVentilation = _tidalVolume * _respiratoryRate;
+    };
 };
 
 private _paco2 = 40;
@@ -108,7 +123,7 @@ private _fio2 = switch (true) do {
     case ((_unit getVariable [QEGVAR(airway,occluded), false]) || (_unit getVariable [QEGVAR(airway,obstruction), false])): { 
         [0, DEFAULT_FIO2] select ((_unit getVariable [QEGVAR(airway,recovery), false]) || (_unit getVariable [QEGVAR(airway,overstretch), false])) 
     };
-    case ((_respiratoryRate == 0) && (EGVAR(breathing,SpO2_perfusion))): { 0 };
+    case ((_respiratoryRate == 0) && (EGVAR(breathing,SpO2_perfusion)) && !_cprAssistSpO2): { 0 };
     case ((_unit getVariable [QEGVAR(chemical,airPoisoning), false]) || (_unit getVariable [QEGVAR(breathing,tensionpneumothorax), false]) || (_unit getVariable [QEGVAR(breathing,hemopneumothorax), false])): { 0 };
     case (_unit getVariable [QEGVAR(breathing,oxygenMaskActive), false]): { 0.95 };
     case (_unit getVariable [QEGVAR(breathing,oxygenTankConnected), false]): { 1 };

--- a/addons/vitals/functions/fnc_handleOxygenFunction.sqf
+++ b/addons/vitals/functions/fnc_handleOxygenFunction.sqf
@@ -33,6 +33,7 @@ params ["_unit", "_actualHeartRate", "_anerobicPressure", "_bloodGas", "_tempera
 #define PAO2_MAX_CHANGE 0.1
 #define DEFAULT_FIO2 0.21
 #define MINIMUM_DEPTH 0.2
+#define CPR_VENTILATION_BOOST 200
 
 private _respiratoryRate = 0;
 private _respiratoryDepression = 0;
@@ -48,13 +49,14 @@ private _cprAssistSpO2 = _cprActive && {EGVAR(breathing,SpO2_CPR_Rise)} && {!(_u
 switch (true) do {
     case ((IN_CRDC_ARRST(_unit)) && _cprAssistSpO2): {
         // Dedicated CPR controller: rate and depth are held at zero so chest compressions do not produce
-        // a respiratory rate, which would falsely read as return of spontaneous breathing (ROSC). Demand and
-        // actual ventilation are balanced so oxygenation recovers without RR swinging on PaCO2.
+        // a respiratory rate, which would falsely read as return of spontaneous breathing (ROSC). Actual
+        // ventilation is pushed above demand so oxygenation recovers without RR swinging on PaCO2. The boost
+        // is scaled by a setting so the recovery speed can be tuned.
         _demandVentilation = MINIMUM_VENTILATION;
         _respiratoryDepression = 1;
         _respiratoryRate = 0;
         _respiratoryDepth = 0;
-        _actualVentilation = MINIMUM_VENTILATION;
+        _actualVentilation = MINIMUM_VENTILATION + (CPR_VENTILATION_BOOST * EGVAR(breathing,SpO2_CPR_RiseMultiplier));
     };
     case (IN_CRDC_ARRST(_unit)): {
         // When in arrest, there should be no effecive breaths but still a minimum O2 demand. Zero O2 demand would mean a dead patient. Actual ventilation is 1 to prevent issues in the gas tension functions


### PR DESCRIPTION
## When merged this pull request will:
- Add a new `kat_breathing_SpO2_CPR_Rise` CBA setting (CHECKBOX, default `false`) + SpO2_CPR_RiseMultiplier slider where original default value is preserved and now can be configured.
- When enabled and CPR is actively being performed on a patient in cardiac arrest, the advanced vitals oxygen function skips the arrest branch, allowing SpO2 to rise from chest-compression-driven circulation without requiring a BVM.
- Default behavior is unchanged: with the setting off, cardiac arrest SpO2 handling works exactly as before.