### PR TITLE
Pharma - Change advanced treatments to use Medication function instead of duplicating it

### DIFF
--- a/addons/pharma/functions/fnc_treatmentAdvanced_CWMP.sqf
+++ b/addons/pharma/functions/fnc_treatmentAdvanced_CWMP.sqf
@@ -22,8 +22,5 @@
 
 params ["_medic", "_patient", "_bodyPart", "_classname", "", "_usedItem"];
 
-[_patient, _classname] call ACEFUNC(medical_treatment,addToTriageCard);
-[_patient, "activity", ACELSTRING(medical_treatment,Activity_usedItem), [[_medic] call ACEFUNC(common,getName), _classname]] call ACEFUNC(medical_treatment,addToLog);
-
-[QGVAR(medicationLocal), [_patient, _bodyPart, _classname], _patient] call CBA_fnc_targetEvent;
+_this call FUNC(medication);
 [_patient] call EFUNC(circulation,wrongBloodTreatment);

--- a/addons/pharma/functions/fnc_treatmentAdvanced_Caffeine.sqf
+++ b/addons/pharma/functions/fnc_treatmentAdvanced_Caffeine.sqf
@@ -22,8 +22,5 @@
 
 params ["_medic", "_patient", "_bodyPart", "_classname", "", "_usedItem"];
 
-[_patient, _classname] call ACEFUNC(medical_treatment,addToTriageCard);
-[_patient, "activity", ACELSTRING(medical_treatment,Activity_usedItem), [[_medic] call ACEFUNC(common,getName), _classname]] call ACEFUNC(medical_treatment,addToLog);
-
-[QGVAR(medicationLocal), [_patient, _bodyPart, _classname], _patient] call CBA_fnc_targetEvent;
+_this call FUNC(medication);
 [QGVAR(caffeineLocal), _patient, _patient] call CBA_fnc_targetEvent;

--- a/addons/pharma/functions/fnc_treatmentAdvanced_Carbonate.sqf
+++ b/addons/pharma/functions/fnc_treatmentAdvanced_Carbonate.sqf
@@ -22,8 +22,5 @@
 
 params ["_medic", "_patient", "_bodyPart", "_classname", "", "_usedItem"];
 
-[_patient, _classname] call ACEFUNC(medical_treatment,addToTriageCard);
-[_patient, "activity", ACELSTRING(medical_treatment,Activity_usedItem), [[_medic] call ACEFUNC(common,getName), _classname]] call ACEFUNC(medical_treatment,addToLog);
-
-[QGVAR(medicationLocal), [_patient, _bodyPart, _classname], _patient] call CBA_fnc_targetEvent;
+_this call FUNC(medication);
 [QGVAR(carbonateLocal), [_medic, _patient], _patient] call CBA_fnc_targetEvent;

--- a/addons/pharma/functions/fnc_treatmentAdvanced_Naloxone.sqf
+++ b/addons/pharma/functions/fnc_treatmentAdvanced_Naloxone.sqf
@@ -22,8 +22,5 @@
 
 params ["_medic", "_patient", "_bodyPart", "_classname", "", "_usedItem"];
 
-[_patient, _usedItem] call ACEFUNC(medical_treatment,addToTriageCard);
-[_patient, "activity", ACELSTRING(medical_treatment,Activity_usedItem), [[_medic] call ACEFUNC(common,getName), getText (configFile >> "CfgWeapons" >> _usedItem >> "displayName")]] call ACEFUNC(medical_treatment,addToLog);
-
-[QGVAR(medicationLocal), [_patient, _bodyPart, _classname], _patient] call CBA_fnc_targetEvent;
+_this call FUNC(medication);
 [QGVAR(naloxoneLocal), _patient, _patient] call CBA_fnc_targetEvent;

--- a/addons/pharma/functions/fnc_treatmentAdvanced_Penthrox.sqf
+++ b/addons/pharma/functions/fnc_treatmentAdvanced_Penthrox.sqf
@@ -22,7 +22,4 @@
 
 params ["_medic", "_patient", "_bodyPart", "_classname", "", "_usedItem"];
 
-[_patient, _classname] call ACEFUNC(medical_treatment,addToTriageCard);
-[_patient, "activity", ACELSTRING(medical_treatment,Activity_usedItem), [[_medic] call ACEFUNC(common,getName), LLSTRING(Penthrox_Display)]] call ACEFUNC(medical_treatment,addToLog);
-
-[QGVAR(medicationLocal), [_patient, _bodyPart, _classname], _patient] call CBA_fnc_targetEvent;
+_this call FUNC(medication);

--- a/addons/pharma/functions/fnc_treatmentAdvanced_Pervitin.sqf
+++ b/addons/pharma/functions/fnc_treatmentAdvanced_Pervitin.sqf
@@ -22,8 +22,5 @@
 
 params ["_medic", "_patient", "_bodyPart", "_classname", "", "_usedItem"];
 
-[_patient, _classname] call ACEFUNC(medical_treatment,addToTriageCard);
-[_patient, "activity", ACELSTRING(medical_treatment,Activity_usedItem), [[_medic] call ACEFUNC(common,getName), _classname]] call ACEFUNC(medical_treatment,addToLog);
-
-[QGVAR(medicationLocal), [_patient, _bodyPart, _classname], _patient] call CBA_fnc_targetEvent;
+_this call FUNC(medication);
 [QGVAR(pervitinLocal), _patient, _patient] call CBA_fnc_targetEvent;


### PR DESCRIPTION
**When merged this pull request will:**
- Change several advanced treatment functions to use the Medication function, instead of duplicating its code
- Aside from reducing code duplication, this also makes these treatments use the item's displayname for log entries again, instead of using the treatment action's classname. This is better because the displayname is meant to be shown in UI text and the treatment action classname is not (e.g. may contain addon prefixes, cannot contain spaces).
- Note: the Penthrox advanced treatment is basically redundant, because its code is literally just the Medication function, but I didn't outright remove it because that's a bigger change and it may be used for something later.

### IMPORTANT

- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
