### PR TITLE
Chemical - Fix various 3.2.0 critical bugs

### DIFF
--- a/addons/chemical/XEH_postInit.sqf
+++ b/addons/chemical/XEH_postInit.sqf
@@ -151,6 +151,10 @@ if (!isServer) exitWith {};
 GVAR(gasSources) = createHashMap;
 GVAR(exposureWatcherUnits) = createHashMap;
 
+// Units the gas manager touched on its previous tick, so it can clear areaIntensity
+// on the ones that have since left every cloud
+GVAR(exposedUnits) = [];
+
 // Server-side: register a unit with the exposure watcher PFH (idempotent).
 // Triggered by FUNC(addToExposureWatcher) on the unit's owner.
 [QGVAR(serverAddExposureWatcher), {

--- a/addons/chemical/functions/fnc_effect_cs.sqf
+++ b/addons/chemical/functions/fnc_effect_cs.sqf
@@ -2,7 +2,7 @@
 /*
  * Author: DiGii
  * CS / tear gas effect. Lifted from the original fnc_poison.sqf:40-45 branch.
- * Sets the CSGas timer and rolls for the random weapon-drop.
+ * Sets the CSGas deadline and rolls for the random weapon-drop.
  *
  * Runs local to the unit's owner via QGVAR(poison) target event.
  *
@@ -19,7 +19,7 @@
 
 params ["_unit", "_infectedObject", "_gasData"];
 
-_unit setVariable [QGVAR(CSGas), 30, true];
+_unit setVariable [QGVAR(CSGas), CBA_missionTime + GVAR(csDuration), true];
 
 if (random 1 <= GVAR(tearGasDropChance)) then {
     [QACEGVAR(hitreactions,dropWeapon), _unit, _unit] call CBA_fnc_targetEvent;

--- a/addons/chemical/functions/fnc_fullHealLocal.sqf
+++ b/addons/chemical/functions/fnc_fullHealLocal.sqf
@@ -22,6 +22,7 @@ _patient setVariable [QGVAR(gasmask_durability), 10, true];
 _patient setVariable [QGVAR(CSGas), 0, true];
 _patient setVariable [QGVAR(airPoisoning), false, true];
 _patient setVariable [QGVAR(infectionTime), missionNamespace getVariable [QGVAR(chlorine_onsetTime), 60], true];
+_patient setVariable [QGVAR(chlorineLastTick), -1e9, true];
 _patient setVariable [QGVAR(infectionArray), [], true];
 _patient setVariable [QGVAR(CoughCooldown), false, true];
 

--- a/addons/chemical/functions/fnc_gasManagerPFH.sqf
+++ b/addons/chemical/functions/fnc_gasManagerPFH.sqf
@@ -16,6 +16,8 @@
  * Public: No
  */
 
+private _exposedNow = [];
+
 {
     _y params ["_gasLogic", "_radius", "_gasLevel", "_condition", "_conditionArgs", "_isSealable"];
     TRACE_2("gasManagerPFH loop",_x,_y);
@@ -55,8 +57,18 @@
         private _intensity = 1 - (_distance / _radius);
 
         _x setVariable [QGVAR(areaIntensity), _intensity, true];
+        _exposedNow pushBackUnique _x;
 
         [QGVAR(poison), [_x, _gasLevel, _infectedObject], _x] call CBA_fnc_targetEvent;
 
     } forEach nearestObjects [_gasLogic, ["CAManBase"], _radius];
 } forEach GVAR(gasSources);
+
+// Units that were in a cloud last tick but are in none now read as clean air again
+{
+    if !(_x in _exposedNow) then {
+        _x setVariable [QGVAR(areaIntensity), 0, true];
+    };
+} forEach GVAR(exposedUnits);
+
+GVAR(exposedUnits) = _exposedNow;

--- a/addons/chemical/functions/fnc_handleFired.sqf
+++ b/addons/chemical/functions/fnc_handleFired.sqf
@@ -37,19 +37,28 @@ if (_gasLevel == 5) then {
     _lifetime = missionNamespace getVariable [QGVAR(vx_cloudLifetime), _lifetime];
 };
 
+// Track the round until it detonates, then register the cloud once at the impact point.
 [{
     params ["_args", "_handler"];
-    _args params ["_projectile", "_gasInfo"];
-    _gasInfo params ["_lifetime", "_radius", "_gasLeveL"];
+    _args params ["_projectile", "_gasInfo", "_impactPos", "_key"];
 
-    if (isNull _projectile || {!alive _projectile}) exitWith {
-        [_handler] call CBA_fnc_removePerFrameHandler;
+    if (!isNull _projectile && {alive _projectile}) exitWith {
+        _args set [2, getPosASL _projectile];
     };
 
-    [QGVAR(addGasSource), [_projectile, _radius, _gasLevel, _projectile, {
+    [_handler] call CBA_fnc_removePerFrameHandler;
+
+    _gasInfo params ["_lifetime", "_radius", "_gasLevel"];
+
+    [QGVAR(addGasSource), [_impactPos, _radius, _gasLevel, _key, {
         params ["_endTime"];
 
         CBA_missionTime < _endTime // return
     }, [CBA_missionTime + _lifetime]]] call CBA_fnc_serverEvent;
 
-}, 0, [_projectile, [_lifetime, _radius, _gasLevel]]] call CBA_fnc_addPerFrameHandler;
+}, 0, [
+    _projectile,
+    [_lifetime, _radius, _gasLevel],
+    getPosASL _projectile,
+    format ["%1_%2_%3", QGVAR(gasRound), _projectile, CBA_missionTime] // built while the round still exists, so every round gets its own cloud instead of evicting the previous one
+]] call CBA_fnc_addPerFrameHandler;

--- a/addons/chemical/functions/fnc_scheduleAirPoisoningOnset.sqf
+++ b/addons/chemical/functions/fnc_scheduleAirPoisoningOnset.sqf
@@ -33,6 +33,15 @@ _unit setVariable [QGVAR(infectionArray), _currentInfectionArray, true];
 private _maxOnset = missionNamespace getVariable [QGVAR(chlorine_onsetTime), 30];
 private _currentInfection = _unit getVariable [QGVAR(infectionTime), _maxOnset];
 
+private _now = CBA_missionTime;
+private _timeOutOfCloud = (_now - (_unit getVariable [QGVAR(chlorineLastTick), -1e9])) - GAS_MANAGER_PFH_DELAY;
+
+if (_timeOutOfCloud > 0) then {
+    _currentInfection = (_currentInfection + _timeOutOfCloud) min _maxOnset;
+};
+
+_unit setVariable [QGVAR(chlorineLastTick), _now, true];
+
 private _timeLeft = (_currentInfection - 1) max 0;
 
 if (_currentInfection != _timeLeft) then {

--- a/addons/chemical/initSettings.inc.sqf
+++ b/addons/chemical/initSettings.inc.sqf
@@ -88,6 +88,15 @@
 
 // =============== CS Gas (Level 0) ===============
 [
+    QGVAR(csDuration),
+    "TIME",
+    [LLSTRING(SETTING_csDuration), LLSTRING(SETTING_csDuration_DESC)],
+    [CBA_SETTINGS_CAT, LSTRING(SubCategory_CS)],
+    [0, 3600, 30],
+    true
+] call CBA_fnc_addSetting;
+
+[
     QGVAR(tearGasDropChance),
     "SLIDER",
     [LLSTRING(SETTING_dropWeaponChance), LLSTRING(SETTING_dropWeaponChance_DESC)],

--- a/addons/chemical/stringtable.xml
+++ b/addons/chemical/stringtable.xml
@@ -706,6 +706,14 @@
             <Dutch>Bepaald hoelang je in gas kan staan zonder dat je geïnfecteerd raakt.</Dutch>
             <Turkish>Gaz maskesi takılıyken enfekte olmadan gaz içinde ne kadar süre dayanabileceğinizi belirler.</Turkish>
         </Key>
+        <Key ID="STR_KAT_Chemical_SETTING_csDuration">
+            <English>CS Gas Duration</English>
+            <German>CS-Gas Dauer</German>
+        </Key>
+        <Key ID="STR_KAT_Chemical_SETTING_csDuration_DESC">
+            <English>How long the tear gas irritation lasts after leaving the cloud</English>
+            <German>Wie lange die Reizung durch Tränengas nach dem Verlassen der Wolke anhält</German>
+        </Key>
         <Key ID="STR_KAT_Chemical_SETTING_dropWeaponChance">
             <English>Drop Weapon Chance</English>
             <Czech>Šance na upuštění zbraně</Czech>

--- a/addons/main/script_macros.hpp
+++ b/addons/main/script_macros.hpp
@@ -350,7 +350,7 @@
 #define GET_PP(unit) (unit getVariable [VAR_PP, 0])
 
 #define IS_AIRPOISONED(unit) (unit getVariable [QEGVAR(chemical,airPoisoning), false])
-#define IN_TEARGAS(unit) (unit getVariable [QEGVAR(chemical,CSGas), 0])
+#define IN_TEARGAS(unit) (((unit getVariable [QEGVAR(chemical,CSGas), 0]) - CBA_missionTime) max 0)
 
 //Ophthalmology
 #define GET_DUST_INJURY(unit) ((unit getVariable [QEGVAR(ophthalmology,dustInjuryLight), 0]) + (unit getVariable [QEGVAR(ophthalmology,dustInjuryHeavy), 0]))

--- a/docs/de/Chemical/03_gases.md
+++ b/docs/de/Chemical/03_gases.md
@@ -17,7 +17,7 @@ The non-lethal one. CS is a riot-control irritant — it won't injure anyone med
 
 - **Cloud:** white / pale, lasts about 60 seconds.
 - **Effect:** there's a configurable chance of dropping your weapon while inside the cloud (off by default — set *Drop Weapon Chance* above 0 to enable it).
-- **Treatment:** none needed. Step out and it passes.
+- **Treatment:** none needed. Step out and it passes after about 30 seconds (*CS Gas Duration*).
 - **Delivery of note:** the `KAT_M7A3` hand grenade is a dedicated CS gas grenade.
 
 ### Chlorine (Level 1)

--- a/docs/de/Chemical/06_zeus_and_MissionMakers.md
+++ b/docs/de/Chemical/06_zeus_and_MissionMakers.md
@@ -77,6 +77,7 @@ All of the below live under **CBA Settings → KAT - ADV Medical: Chemical**. De
 
 | Setting | Default | Range | What it does |
 |---------|---------|-------|--------------|
+| CS Gas Duration | 30 s | 0–3600 s | How long the irritation lasts after leaving the cloud |
 | Drop Weapon Chance | 0 | 0–1 | Chance per check to drop your weapon while in tear gas |
 
 ### Chlorine (Level 1)

--- a/docs/en/Chemical/03_gases.md
+++ b/docs/en/Chemical/03_gases.md
@@ -17,7 +17,7 @@ The non-lethal one. CS is a riot-control irritant — it won't injure anyone med
 
 - **Cloud:** white / pale, lasts about 60 seconds.
 - **Effect:** there's a configurable chance of dropping your weapon while inside the cloud (off by default — set *Drop Weapon Chance* above 0 to enable it).
-- **Treatment:** none needed. Step out and it passes.
+- **Treatment:** none needed. Step out and it passes after about 30 seconds (*CS Gas Duration*).
 - **Delivery of note:** the `KAT_M7A3` hand grenade is a dedicated CS gas grenade.
 
 ### Chlorine (Level 1)

--- a/docs/en/Chemical/06_zeus_and_MissionMakers.md
+++ b/docs/en/Chemical/06_zeus_and_MissionMakers.md
@@ -77,6 +77,7 @@ All of the below live under **CBA Settings → KAT - ADV Medical: Chemical**. De
 
 | Setting | Default | Range | What it does |
 |---------|---------|-------|--------------|
+| CS Gas Duration | 30 s | 0–3600 s | How long the irritation lasts after leaving the cloud |
 | Drop Weapon Chance | 0 | 0–1 | Chance per check to drop your weapon while in tear gas |
 
 ### Chlorine (Level 1)

--- a/docs/jp/Chemical/03_gases.md
+++ b/docs/jp/Chemical/03_gases.md
@@ -17,7 +17,7 @@ The non-lethal one. CS is a riot-control irritant — it won't injure anyone med
 
 - **Cloud:** white / pale, lasts about 60 seconds.
 - **Effect:** there's a configurable chance of dropping your weapon while inside the cloud (off by default — set *Drop Weapon Chance* above 0 to enable it).
-- **Treatment:** none needed. Step out and it passes.
+- **Treatment:** none needed. Step out and it passes after about 30 seconds (*CS Gas Duration*).
 - **Delivery of note:** the `KAT_M7A3` hand grenade is a dedicated CS gas grenade.
 
 ### Chlorine (Level 1)

--- a/docs/jp/Chemical/06_zeus_and_MissionMakers.md
+++ b/docs/jp/Chemical/06_zeus_and_MissionMakers.md
@@ -77,6 +77,7 @@ All of the below live under **CBA Settings → KAT - ADV Medical: Chemical**. De
 
 | Setting | Default | Range | What it does |
 |---------|---------|-------|--------------|
+| CS Gas Duration | 30 s | 0–3600 s | How long the irritation lasts after leaving the cloud |
 | Drop Weapon Chance | 0 | 0–1 | Chance per check to drop your weapon while in tear gas |
 
 ### Chlorine (Level 1)


### PR DESCRIPTION
**When merged this pull request will:**
- Add CBA setting for CS Gas affected duration
- Fix CS / tear gas never wore off.
- Fix every gas mortar / artillery round rebuilt its entire gas cloud once per
  frame while in flight
- Fix `kat_chemical_areaIntensity` was never reset when a unit left a gas cloud
- Fix the chlorine onset countdown


### IMPORTANT

- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
